### PR TITLE
[Bug]: TypeError: Cannot read properties of undefined (reading 'schema')

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchemaDetails.ts
@@ -242,7 +242,12 @@ interface Props {
 }
 
 export function createSchemaDetails({ title, body, ...rest }: Props) {
-  if (body === undefined || body.content === undefined) {
+  if (
+    body === undefined ||
+    body.content === undefined ||
+    Object.keys(body).length === 0 ||
+    Object.keys(body.content).length === 0
+  ) {
     return undefined;
   }
 
@@ -250,7 +255,6 @@ export function createSchemaDetails({ title, body, ...rest }: Props) {
   // NOTE: We just pick a random content-type.
   // How common is it to have multiple?
   const randomFirstKey = Object.keys(body.content)[0];
-
   const firstBody = body.content[randomFirstKey].schema;
 
   if (firstBody === undefined) {


### PR DESCRIPTION
## Description

This PR addresses the following issue when generating OpenAPI Docs via the CLI: 

`TypeError: Cannot read properties of undefined (reading 'schema')`

In some cases, OAS files containing `content: {}` within their `responses` property were not being handled properly. To safeguard against this issue, an additional check was added within `createSchemaDetails` to check against `body` and `body.content` emptiness.

## Motivation and Context

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/48506502/168396773-9a8a5fba-1086-4e0a-b9b5-efdce14f1fe3.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
