### PR TITLE
[Bug] Add missing openapi code colors

### DIFF
--- a/demo/src/css/custom.css
+++ b/demo/src/css/custom.css
@@ -18,16 +18,6 @@
   --ifm-color-success: #3cad6e;
   --ifm-color-warning: #ffcb06;
   --ifm-color-danger: #fa582d;
-  --ifm-code-font-size: 95%;
-  --openapi-input-background: rgba(110, 118, 129, 0.4) !important;
-  /* --openapi-monaco-border-color: #21262d !important;
-  --openapi-monaco-background-color-dark: #0d1117 !important; */
-  --openapi-code-green: var(--ifm-color-success) !important;
-  --openapi-code-blue: var(--ifm-color-primary) !important;
-  --openapi-code-red: var(--ifm-color-danger) !important;
-  --openapi-code-orange: var(--ifm-color-warning) !important;
-  /* Helps avoid #aaa bug in monaco-editor */
-  /* --openapi-code-dim-light: var(--ifm-color-secondary-lightest) !important; */
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -118,13 +108,6 @@ html[data-theme="dark"] .header-github-link:before {
   content: "patch";
   border-color: var(--openapi-code-orange);
   color: var(--openapi-code-orange);
-}
-
-.alert--success {
-  --ifm-alert-background-color: var(--ifm-color-success-contrast-background);
-  --ifm-alert-background-color-highlight: rgba(0, 164, 0, 0.15);
-  --ifm-alert-foreground-color: var(--ifm-color-success-contrast-foreground);
-  --ifm-alert-border-color: var(--ifm-color-success-dark);
 }
 
 .prism-code {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/styles.module.css
@@ -1,5 +1,9 @@
 :root {
   --openapi-required: var(--ifm-color-danger);
+  --openapi-code-blue: var(--ifm-color-info);
+  --openapi-code-red: var(--ifm-color-danger);
+  --openapi-code-orange: var(--ifm-color-warning);
+  --openapi-code-green: var(--ifm-color-success);
 }
 
 .apiItemContainer article > *:first-child,


### PR DESCRIPTION
## Description

Adds missing `--openapi-code-<color>` styles used for syntax highlighting in code samples.

## Motivation and Context

Improves readability of code samples and removes need to specify them in `custom.css`. 

## How Has This Been Tested?

Tested in workspace.

## Screenshots (if appropriate)

See build preview.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
