### PR TITLE
[Bug] Missing info fields rendered undefined

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -6,10 +6,10 @@
  * ========================================================================== */
 
 import { ContactObject } from "../openapi/types";
-import { create } from "./utils";
+import { create, guard } from "./utils";
 
 export function createContactInfo(contact: ContactObject) {
-  if (!contact) return "";
+  if (!contact || !Object.keys(contact).length) return "";
   const { name, url, email } = contact;
 
   return create("div", {
@@ -27,22 +27,26 @@ export function createContactInfo(contact: ContactObject) {
       }),
       create("span", {
         children: [
-          `${name}: `,
-          create("a", {
-            href: `mailto:${email}`,
-            children: `${email}`,
-          }),
+          guard(name, () => `${name}: `),
+          guard(email, () =>
+            create("a", {
+              href: `mailto:${email}`,
+              children: `${email}`,
+            })
+          ),
         ],
       }),
-      create("span", {
-        children: [
-          "URL: ",
-          create("a", {
-            href: `${url}`,
-            children: `${url}`,
-          }),
-        ],
-      }),
+      guard(url, () =>
+        create("span", {
+          children: [
+            "URL: ",
+            create("a", {
+              href: `${url}`,
+              children: `${url}`,
+            }),
+          ],
+        })
+      ),
     ],
   });
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createLicense.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createLicense.ts
@@ -6,10 +6,10 @@
  * ========================================================================== */
 
 import { LicenseObject } from "../openapi/types";
-import { create } from "./utils";
+import { create, guard } from "./utils";
 
 export function createLicense(license: LicenseObject) {
-  if (!license) return "";
+  if (!license || !Object.keys(license).length) return "";
   const { name, url } = license;
 
   return create("div", {
@@ -23,10 +23,12 @@ export function createLicense(license: LicenseObject) {
         },
         children: "License",
       }),
-      create("a", {
-        href: url,
-        children: name,
-      }),
+      guard(url, () =>
+        create("a", {
+          href: url,
+          children: name ?? url,
+        })
+      ),
     ],
   });
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createTermsOfService.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createTermsOfService.ts
@@ -8,7 +8,7 @@
 import { create } from "./utils";
 
 export function createTermsOfService(termsOfService: string | undefined) {
-  if (!createTermsOfService) return "";
+  if (!termsOfService) return "";
 
   return create("div", {
     style: {


### PR DESCRIPTION
## Description

Related to #96 

Added extra conditions to safeguard against `undefined` within newly added `info` properties. The expected behavior is that any `info` field that is `undefined` should not be written to `*.info.mdx` files.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- Tested on CSPM API (missing `info` fields were not being rendered as expected)
- Tested on Petstore API (supported `info` fields render accordingly)
 
## Screenshots (if appropriate)

## Issue
<img width="928" alt="Screen Shot 2022-05-20 at 5 22 01 PM" src="https://user-images.githubusercontent.com/48506502/169626801-8eb211ab-8d8d-483c-aeb6-39f53acbf19f.png">

## Evidence 

### CSPM API 
![image](https://user-images.githubusercontent.com/48506502/169626836-7330712a-4b25-4442-a4c3-06b3a3d14e94.png)

### Petstore API
![Screen Shot 2022-05-20 at 5 28 33 PM](https://user-images.githubusercontent.com/48506502/169627080-6b05098e-cd56-481a-b5d3-b40118129822.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
