### PR TITLE
[Bug] Refactor categoryLinkSource option and usage

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -155,7 +155,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         if (item.type === "info") {
           if (!fs.existsSync(`${outputDir}/${item.id}.info.mdx`)) {
             try {
-              sidebarOptions?.useInfoAsCategoryLink
+              sidebarOptions?.categoryLinkSource === "info" // Only use utils template if set to "info"
                 ? fs.writeFileSync(
                     `${outputDir}/${item.id}.info.mdx`,
                     utils,

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -90,7 +90,6 @@ export interface ApiNavLink {
 
 export interface SidebarOptions {
   groupPathsBy?: string;
-  useInfoAsCategoryLink?: boolean; // TODO: confirm name of option
   categoryLinkSource?: string;
   customProps?: { [key: string]: unknown };
   sidebarCollapsible?: boolean;


### PR DESCRIPTION
## Description

Cleaned up the logic/behavior and usage of `categoryLinkSource` option when grouping paths by tag. 

New expected behavior is as follows:

## Scenario 1

`categoryLinkSource`: undefined
Multi or single spec? single
Expected result:  Category link configs should be `generated-index` with no description. The "Introduction" doc should be the first item in the sidebar and NOT contain `DocCardList` in the footer.

## Scenario 2

`categoryLinkSource`: "tag"
Multi or single spec? single
Expected result:  Category link configs should be `generated-index` with description(s) set to tag description(s). The "Introduction" doc should be the first item in the sidebar and NOT contain `DocCardList` in the footer.

## Scenario 3

`categoryLinkSource`: "info"
Multi or single spec? multi (micro-specs)
Expected result:  Category link configs should link to respective info/intro docs with `DocCardList` in the footer. No root level "Introduction" doc should appear in the sidebar.

## Anti-pattern 1

`categoryLinkSource`: "info"
Multi or single spec? single
Expected result:  Category link configs will link to the same info/intro doc. No root-level "Introduction" will be included in the sidebar. This is considered an anti-pattern and will be documented as such.

> Note that `categoryLinkSource: "info"` should be reserved for micro-spec use case

## Test Plan/Checklist

- [x] Scenario 1 - Tested with Petstore API

https://user-images.githubusercontent.com/48506502/169863942-2676a1aa-c26a-44ee-89b0-b560d4d14c90.mov


- [x] Scenario 2 - Tested with Petstore API

https://user-images.githubusercontent.com/48506502/169864391-3c8a5fa3-8673-4784-af8e-662c1dea6105.mov

- [x] Scenario 3 - Tested with CSPM API

![image](https://user-images.githubusercontent.com/48506502/169864601-b1d67b24-0b66-48c4-8acd-82342f9c12a7.png)

> Note that the `undefined` fields have been resolved and is currently a pending merge #98 

- [x] Anti-pattern 1 - Tested with Petstore API
![image](https://user-images.githubusercontent.com/48506502/169863285-e22cd85a-07f9-47e9-88d5-7aaa348ab868.png)
