### PR TITLE
[Enhancement] Add support for URL specPath

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -18,6 +18,10 @@ import { readOpenapiFiles, processOpenapiFiles } from "./openapi";
 import generateSidebarSlice from "./sidebars";
 import type { PluginOptions, LoadedContent, APIOptions } from "./types";
 
+export function isURL(str: string): boolean {
+  return /^(https?:)\/\//m.test(str);
+}
+
 export default function pluginOpenAPI(
   context: LoadContext,
   options: PluginOptions
@@ -28,7 +32,9 @@ export default function pluginOpenAPI(
   async function generateApiDocs(options: APIOptions) {
     let { specPath, outputDir, template, sidebarOptions } = options;
 
-    const contentPath = path.resolve(siteDir, specPath);
+    const contentPath = isURL(specPath)
+      ? specPath
+      : path.resolve(siteDir, specPath);
 
     try {
       const openapiFiles = await readOpenapiFiles(contentPath, {});


### PR DESCRIPTION
## Description

Now that we're using ReDoc to load and parse we can also support loading specs from URL.

## Motivation and Context

Cause why not?

## How Has This Been Tested?

I tested using https://petstore.swagger.io/v2/swagger.json as `specPath` and then switching back to `petstore.yaml`. Seems to work ok and also up-converted the URL spec from 2.0 to 3.0.

## Screenshots (if appropriate)

```bash
$ docusaurus gen-api-docs petstore
[ReDoc Compatibility mode]: Converting OpenAPI 2.0 to OpenAPI 3.0
Successfully created "docs/petstore/sidebar.js"
Successfully created "docs/petstore/pet.tag.mdx"
Successfully created "docs/petstore/store.tag.mdx"
Successfully created "docs/petstore/user.tag.mdx"
Successfully created "docs/petstore/swagger-petstore.info.mdx"
Successfully created "docs/petstore/uploads-an-image.api.mdx"
Successfully created "docs/petstore/add-a-new-pet-to-the-store.api.mdx"
Successfully created "docs/petstore/update-an-existing-pet.api.mdx"
Successfully created "docs/petstore/finds-pets-by-status.api.mdx"
Successfully created "docs/petstore/finds-pets-by-tags.api.mdx"
...
```

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
