### PR TITLE
[Bug] Re-introduce json-schema-ref-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Here is an example of properly configuring your `docusaurus.config.js` file for 
       'docusaurus-plugin-openapi-docs',
       {
         id: "apiDocs",
-        docPluginId: "classic",
+        docsPluginId: "classic",
         config: {
           petstore: { // Note: petstore key is treated as the <id> and can be used to specify an API doc instance when using CLI commands
             specPath: "examples/petstore.yaml", // Path to designated spec file
@@ -118,10 +118,10 @@ Here is an example of properly configuring your `docusaurus.config.js` file for 
 
 The `docusaurus-plugin-openapi-docs` plugin can be configured with the following options:
 
-| Name          | Type     | Default | Description                                                                                                                                          |
-| ------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | `string` | `null`  | A unique document id.                                                                                                                                |
-| `docPluginId` | `string` | `null`  | The ID associated with the `plugin-content-docs` or `preset` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| Name           | Type     | Default | Description                                                                                                                                          |
+| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `string` | `null`  | A unique document id.                                                                                                                                |
+| `docsPluginId` | `string` | `null`  | The ID associated with the `plugin-content-docs` or `preset` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
 
 ### config
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -98,7 +98,7 @@ Here is an example of properly configuring your `docusaurus.config.js` file for 
       'docusaurus-plugin-openapi-docs',
       {
         id: "apiDocs",
-        docPluginId: "classic",
+        docsPluginId: "classic",
         config: {
           petstore: { // Note: petstore key is treated as the <id> and can be used to specify an API doc instance when using CLI commands
             specPath: "examples/petstore.yaml", // Path to designated spec file

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -143,7 +143,7 @@ const config = {
       "docusaurus-plugin-openapi-docs",
       {
         id: "openapi",
-        docPluginId: "classic",
+        docsPluginId: "classic",
         config: {
           petstore_versioned: {
             specPath: "examples/petstore.yaml",

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -81,7 +81,7 @@ Here is an example of properly configuring your `docusaurus.config.js` file for 
       'docusaurus-plugin-openapi-docs',
       {
         id: "apiDocs",
-        docPluginId: "classic",
+        docsPluginId: "classic",
         config: {
           petstore: { // Note: petstore key is treated as the <id> and can be used to specify an API doc instance when using CLI commands
             specPath: "examples/petstore.yaml", // Path to designated spec file
@@ -108,10 +108,10 @@ Here is an example of properly configuring your `docusaurus.config.js` file for 
 
 The `docusaurus-plugin-openapi-docs` plugin can be configured with the following options:
 
-| Name          | Type     | Default | Description                                                                                                                                          |
-| ------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`          | `string` | `null`  | A unique document id.                                                                                                                                |
-| `docPluginId` | `string` | `null`  | The ID associated with the `plugin-content-docs` or `preset` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| Name           | Type     | Default | Description                                                                                                                                          |
+| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `string` | `null`  | A unique document id.                                                                                                                                |
+| `docsPluginId` | `string` | `null`  | The ID associated with the `plugin-content-docs` or `preset` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
 
 ### config
 

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -36,6 +36,7 @@
     "utility-types": "^3.10.0"
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@docusaurus/mdx-loader": "2.0.0-beta.21",
     "@docusaurus/plugin-content-docs": "2.0.0-beta.21",
     "@docusaurus/utils": "2.0.0-beta.21",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -62,14 +62,14 @@ export default function pluginOpenAPIDocs(
   context: LoadContext,
   options: PluginOptions
 ): Plugin<LoadedContent> {
-  const { config, docPluginId } = options;
+  const { config, docsPluginId } = options;
   const { siteDir, siteConfig } = context;
 
   // Get routeBasePath and path from plugin-content-docs or preset
   const presets: any = siteConfig.presets;
   const plugins: any = siteConfig.plugins;
   const presetsPlugins = presets.concat(plugins);
-  const docData: any = getDocsData(presetsPlugins, docPluginId);
+  const docData: any = getDocsData(presetsPlugins, docsPluginId);
   const docRouteBasePath = docData ? docData.routeBasePath : undefined;
   const docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
 
@@ -81,7 +81,7 @@ export default function pluginOpenAPIDocs(
       : path.resolve(siteDir, specPath);
 
     try {
-      const openapiFiles = await readOpenapiFiles(contentPath, {});
+      const openapiFiles = await readOpenapiFiles(contentPath, options);
       const [loadedApi, tags] = await processOpenapiFiles(
         openapiFiles,
         sidebarOptions!

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -16,7 +16,7 @@ describe("openapi", () => {
     it("readOpenapiFiles", async () => {
       const results = await readOpenapiFiles(
         path.join(__dirname, "__fixtures__/examples"),
-        {}
+        { specPath: "./", outputDir: "./" }
       );
       const categoryMeta = results.find((x) =>
         x.source.endsWith("_category_.json")

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -19,6 +19,7 @@ import { kebabCase } from "lodash";
 import { isURL } from "../index";
 import {
   ApiMetadata,
+  APIOptions,
   ApiPageMetadata,
   InfoPageMetadata,
   SidebarOptions,
@@ -247,8 +248,9 @@ interface OpenApiFiles {
 
 export async function readOpenapiFiles(
   openapiPath: string,
-  _options: {}
+  options: APIOptions
 ): Promise<OpenApiFiles[]> {
+  const { parseJsonRefs } = options;
   if (!isURL(openapiPath)) {
     const stat = await fs.lstat(openapiPath);
     if (stat.isDirectory()) {
@@ -270,7 +272,8 @@ export async function readOpenapiFiles(
           // TODO: make a function for this
           const fullPath = path.join(openapiPath, source);
           const data = (await loadAndBundleSpec(
-            fullPath
+            fullPath,
+            parseJsonRefs
           )) as OpenApiObjectWithRef;
           return {
             source: fullPath, // This will be aliased in process.
@@ -281,7 +284,10 @@ export async function readOpenapiFiles(
       );
     }
   }
-  const data = (await loadAndBundleSpec(openapiPath)) as OpenApiObjectWithRef;
+  const data = (await loadAndBundleSpec(
+    openapiPath,
+    parseJsonRefs
+  )) as OpenApiObjectWithRef;
   return [
     {
       source: openapiPath, // This will be aliased in process.

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -250,7 +250,10 @@ export async function readOpenapiFiles(
   openapiPath: string,
   options: APIOptions
 ): Promise<OpenApiFiles[]> {
-  const { parseJsonRefs } = options;
+  // TODO: determine if this should be an API option
+  // Forces the json-schema-ref-parser
+  const parseJsonRefs = true;
+
   if (!isURL(openapiPath)) {
     const stat = await fs.lstat(openapiPath);
     if (stat.isDirectory()) {

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -25,7 +25,6 @@ export const OptionsSchema = Joi.object({
         specPath: Joi.string().required(),
         outputDir: Joi.string().required(),
         template: Joi.string(),
-        parseJsonRefs: Joi.boolean(),
         sidebarOptions: sidebarOptions,
         version: Joi.string().when("versions", {
           is: Joi.exist(),
@@ -44,7 +43,6 @@ export const OptionsSchema = Joi.object({
           Joi.object({
             specPath: Joi.string().required(),
             outputDir: Joi.string().required(),
-            parseJsonRefs: Joi.boolean(),
             label: Joi.string().required(),
             baseUrl: Joi.string().required(),
           })

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -17,7 +17,7 @@ const sidebarOptions = Joi.object({
 
 export const OptionsSchema = Joi.object({
   id: Joi.string().required(),
-  docPluginId: Joi.string().required(),
+  docsPluginId: Joi.string().required(),
   config: Joi.object()
     .pattern(
       /^/,
@@ -25,6 +25,7 @@ export const OptionsSchema = Joi.object({
         specPath: Joi.string().required(),
         outputDir: Joi.string().required(),
         template: Joi.string(),
+        parseJsonRefs: Joi.boolean(),
         sidebarOptions: sidebarOptions,
         version: Joi.string().when("versions", {
           is: Joi.exist(),
@@ -43,6 +44,7 @@ export const OptionsSchema = Joi.object({
           Joi.object({
             specPath: Joi.string().required(),
             outputDir: Joi.string().required(),
+            parseJsonRefs: Joi.boolean(),
             label: Joi.string().required(),
             baseUrl: Joi.string().required(),
           })

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -38,7 +38,7 @@ function groupByTags(
   tags: TagObject[],
   docPath: string
 ): ProcessedSidebar {
-  const { outputDir } = options;
+  const { outputDir, label } = options;
   const {
     sidebarCollapsed,
     sidebarCollapsible,
@@ -135,7 +135,9 @@ function groupByTags(
         linkConfig = {
           type: "generated-index" as "generated-index",
           title: tag,
-          slug: "/category/" + kebabCase(tag),
+          slug: label
+            ? "/category/" + kebabCase(label) + "/" + kebabCase(tag)
+            : "/category/" + kebabCase(tag),
         } as SidebarItemCategoryLinkConfig;
       }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -22,7 +22,7 @@ export type {
 } from "@docusaurus/plugin-content-docs-types";
 export interface PluginOptions {
   id?: string;
-  docPluginId: string;
+  docsPluginId: string;
   config: {
     [key: string]: APIOptions;
   };
@@ -32,6 +32,7 @@ export interface APIOptions {
   specPath: string;
   outputDir: string;
   template?: string;
+  parseJsonRefs?: boolean;
   sidebarOptions?: SidebarOptions;
   version?: string;
   label?: string;

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -32,7 +32,6 @@ export interface APIOptions {
   specPath: string;
   outputDir: string;
   template?: string;
-  parseJsonRefs?: boolean;
   sidebarOptions?: SidebarOptions;
   version?: string;
   label?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,16 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@apidevtools/json-schema-ref-parser@^9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#d720f9256e3609621280584f2b47ae165359268b"
+  integrity sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
 "@babel/cli@^7.16.0":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.17.10.tgz#5ea0bf6298bb78f3b59c7c06954f9bd1c79d5943"
@@ -2631,6 +2641,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -4052,7 +4067,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==


### PR DESCRIPTION
## Description

> Note: This PR also renames `docPluginId` to `docsPluginId` to be consistent with Docusaurus

> Note: This PR also introduces a fix for ensuring unique category link slugs when using `groupPathsBy` tag on versioned docs.

Re-inroduces the `json-schema-ref-parser` utility to help handle `$ref` usage that falls outside of the OpenAPI specification. For example, `$ref`s that are used inside descriptions, such as with the CWPP specification.

The following variable was added to `openapi.ts`:

```javascript
  // TODO: determine if this should be an API option
  // Forces the json-schema-ref-parser
  const parseJsonRefs = true;
```

Basically, the behavior is for it to be forced "on" for now. We can make this an API or Plugin option in the future if it makes sense.

Also implemented some basic error handling, for cases in which remote `$ref` cannot be resolved, e.g. 404, 403, timeout, etc. The error will include what went wrong and which `$ref` was involved. Failed JSON schema resolution should still fall back to the original parser.

## Motivation and Context

OpenAPI specs with non-compliant `$ref` pointers render with missing attributes. For example, local or remote `$ref` in description field would fail to be rendered properly.

## How Has This Been Tested?

Tested using the CWPP API spec.