### PR TITLE
[Enhancement] Increase dereference timeout

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndBundleSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndBundleSpec.ts
@@ -21,6 +21,11 @@ async function resolveJsonRefs(specUrlOrObject: object | string) {
   try {
     let schema = await $RefParser.dereference(specUrlOrObject, {
       continueOnError: true,
+      resolve: {
+        http: {
+          timeout: 15000, // 15 sec timeout
+        },
+      },
       dereference: {
         circular: "ignore",
       },


### PR DESCRIPTION
## Description

Increases dereference timeout from 5 to 15 seconds to allow more time to fetch remote `$ref` pointers, i.e. using http/https.