### PR TITLE
[Experimental] Add support for Docusaurus vendor extensions

### DIFF
--- a/demo/docs/petstore/sidebar.js
+++ b/demo/docs/petstore/sidebar.js
@@ -1,150 +1,161 @@
-module.exports = [
-  { type: "doc", id: "petstore/swagger-petstore-yaml" },
-  {
-    type: "category",
-    label: "Pets",
-    link: { type: "doc", id: "petstore/pet" },
-    items: [
-      {
-        type: "doc",
-        id: "petstore/add-a-new-pet-to-the-store",
-        label: "Add a new pet to the store",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/update-an-existing-pet",
-        label: "Update an existing pet",
-        className: "api-method put",
-      },
-      {
-        type: "doc",
-        id: "petstore/find-pet-by-id",
-        label: "Find pet by ID",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/updates-a-pet-in-the-store-with-form-data",
-        label: "Updates a pet in the store with form data",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/deletes-a-pet",
-        label: "Deletes a pet",
-        className: "api-method delete",
-      },
-      {
-        type: "doc",
-        id: "petstore/uploads-an-image",
-        label: "uploads an image",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/finds-pets-by-status",
-        label: "Finds Pets by status",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/finds-pets-by-tags",
-        label: "Finds Pets by tags",
-        className: "menu__list-item--deprecated api-method get",
-      },
-    ],
+module.exports = {
+  type: "category",
+  label: "Petstore API",
+  link: {
+    type: "generated-index",
+    title: "Petstore API",
+    description:
+      "This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on irc.freenode.net, #swagger. For this sample, you can use the api key special-key to test the authorization filters.\n",
+    slug: "/category/petstore-api",
   },
-  {
-    type: "category",
-    label: "Petstore Orders",
-    link: { type: "doc", id: "petstore/store" },
-    items: [
-      {
-        type: "doc",
-        id: "petstore/returns-pet-inventories-by-status",
-        label: "Returns pet inventories by status",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/place-an-order-for-a-pet",
-        label: "Place an order for a pet",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/find-purchase-order-by-id",
-        label: "Find purchase order by ID",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/delete-purchase-order-by-id",
-        label: "Delete purchase order by ID",
-        className: "api-method delete",
-      },
-      {
-        type: "doc",
-        id: "petstore/subscribe-to-the-store-events",
-        label: "Subscribe to the Store events",
-        className: "api-method post",
-      },
-    ],
-  },
-  {
-    type: "category",
-    label: "Users",
-    link: { type: "doc", id: "petstore/user" },
-    items: [
-      {
-        type: "doc",
-        id: "petstore/create-user",
-        label: "Create user",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/get-user-by-user-name",
-        label: "Get user by user name",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/updated-user",
-        label: "Updated user",
-        className: "api-method put",
-      },
-      {
-        type: "doc",
-        id: "petstore/delete-user",
-        label: "Delete user",
-        className: "api-method delete",
-      },
-      {
-        type: "doc",
-        id: "petstore/creates-list-of-users-with-given-input-array",
-        label: "Creates list of users with given input array",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/creates-list-of-users-with-given-input-list",
-        label: "Creates list of users with given input list",
-        className: "api-method post",
-      },
-      {
-        type: "doc",
-        id: "petstore/logs-user-into-the-system",
-        label: "Logs user into the system",
-        className: "api-method get",
-      },
-      {
-        type: "doc",
-        id: "petstore/logs-out-current-logged-in-user-session",
-        label: "Logs out current logged in user session",
-        className: "api-method get",
-      },
-    ],
-  },
-];
+  items: [
+    { type: "doc", id: "petstore/swagger-petstore-yaml" },
+    {
+      type: "category",
+      label: "Pets",
+      link: { type: "doc", id: "petstore/pet" },
+      items: [
+        {
+          type: "doc",
+          id: "petstore/add-a-new-pet-to-the-store",
+          label: "Add a new pet to the store",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/update-an-existing-pet",
+          label: "Update an existing pet",
+          className: "api-method put",
+        },
+        {
+          type: "doc",
+          id: "petstore/find-pet-by-id",
+          label: "Find pet by ID",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/updates-a-pet-in-the-store-with-form-data",
+          label: "Updates a pet in the store with form data",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/deletes-a-pet",
+          label: "Deletes a pet",
+          className: "api-method delete",
+        },
+        {
+          type: "doc",
+          id: "petstore/uploads-an-image",
+          label: "uploads an image",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/finds-pets-by-status",
+          label: "Finds Pets by status",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/finds-pets-by-tags",
+          label: "Finds Pets by tags",
+          className: "menu__list-item--deprecated api-method get",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Petstore Orders",
+      link: { type: "doc", id: "petstore/store" },
+      items: [
+        {
+          type: "doc",
+          id: "petstore/returns-pet-inventories-by-status",
+          label: "Returns pet inventories by status",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/place-an-order-for-a-pet",
+          label: "Place an order for a pet",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/find-purchase-order-by-id",
+          label: "Find purchase order by ID",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/delete-purchase-order-by-id",
+          label: "Delete purchase order by ID",
+          className: "api-method delete",
+        },
+        {
+          type: "doc",
+          id: "petstore/subscribe-to-the-store-events",
+          label: "Subscribe to the Store events",
+          className: "api-method post",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "Users",
+      link: { type: "doc", id: "petstore/user" },
+      items: [
+        {
+          type: "doc",
+          id: "petstore/create-user",
+          label: "Create user",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/get-user-by-user-name",
+          label: "Get user by user name",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/updated-user",
+          label: "Updated user",
+          className: "api-method put",
+        },
+        {
+          type: "doc",
+          id: "petstore/delete-user",
+          label: "Delete user",
+          className: "api-method delete",
+        },
+        {
+          type: "doc",
+          id: "petstore/creates-list-of-users-with-given-input-array",
+          label: "Creates list of users with given input array",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/creates-list-of-users-with-given-input-list",
+          label: "Creates list of users with given input list",
+          className: "api-method post",
+        },
+        {
+          type: "doc",
+          id: "petstore/logs-user-into-the-system",
+          label: "Logs user into the system",
+          className: "api-method get",
+        },
+        {
+          type: "doc",
+          id: "petstore/logs-out-current-logged-in-user-session",
+          label: "Logs out current logged in user session",
+          className: "api-method get",
+        },
+      ],
+    },
+  ],
+};

--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -1,4 +1,8 @@
 openapi: 3.0.0
+x-docusaurus-extensions:
+  root-category-label: Petstore API
+  root-category-description: |
+    This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on irc.freenode.net, #swagger. For this sample, you can use the api key special-key to test the authorization filters.
 servers:
   - url: https://petstore.swagger.io/v2
     description: Default server

--- a/demo/sidebars.js
+++ b/demo/sidebars.js
@@ -35,18 +35,7 @@ const sidebars = {
     },
   ],
   petstore: [
-    {
-      type: "category",
-      label: "Petstore",
-      link: {
-        type: "generated-index",
-        title: "Petstore API",
-        description:
-          "This is a sample server Petstore server. You can find out more about Swagger at http://swagger.io or on irc.freenode.net, #swagger. For this sample, you can use the api key special-key to test the authorization filters.",
-        slug: "/category/petstore-api",
-      },
-      items: require("./docs/petstore/sidebar.js"),
-    },
+    require("./docs/petstore/sidebar.js"),
     {
       type: "category",
       label: "Cloud Object Storage",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -104,6 +104,12 @@ export default function pluginOpenAPIDocs(
         }
       }
 
+      const extensionsItem = loadedApi.filter(
+        (item) => item.type === "extensions"
+      ) as ExtensionsMetadata[];
+      const extensions = extensionsItem[0]?.extensions;
+
+      let extendedSidebar; // Undefined extended sidebar
       // TODO: figure out better way to set default
       if (Object.keys(sidebarOptions ?? {}).length > 0) {
         const sidebarSlice = generateSidebarSlice(
@@ -111,15 +117,63 @@ export default function pluginOpenAPIDocs(
           options,
           loadedApi,
           tags,
-          docPath
+          docPath,
+          extensions
         );
+        if (extensions && sidebarSlice) {
+          const label = extensions["root-category-label"];
+          const description = extensions["root-category-description"];
+          extendedSidebar = {
+            type: "category",
+            label: label,
+            link: {
+              type: "generated-index",
+              title: label,
+              ...(description && {
+                description: description,
+              }),
+              slug: "/category/" + kebabCase(label),
+            },
+            items: sidebarSlice,
+          };
+        }
 
-        let extendedSidebar;
-        const extensionsItem = loadedApi.filter(
-          (item) => item.type === "extensions"
-        ) as ExtensionsMetadata[];
-        const extensions = extensionsItem[0]?.extensions;
-        if (extensions) {
+        const sidebarSliceTemplate = template
+          ? fs.readFileSync(template).toString()
+          : `module.exports = {{{slice}}};`;
+
+        const view = render(sidebarSliceTemplate, {
+          slice: extendedSidebar
+            ? JSON.stringify(extendedSidebar)
+            : JSON.stringify(sidebarSlice),
+        });
+
+        if (!fs.existsSync(`${outputDir}/sidebar.js`)) {
+          try {
+            fs.writeFileSync(`${outputDir}/sidebar.js`, view, "utf8");
+            console.log(
+              chalk.green(`Successfully created "${outputDir}/sidebar.js"`)
+            );
+          } catch (err) {
+            console.error(
+              chalk.red(`Failed to write "${outputDir}/sidebar.js"`),
+              chalk.yellow(err)
+            );
+          }
+        }
+      }
+
+      // Handle extensions with no sidebarOptions
+      if (extensions["root-category-label"]) {
+        const sidebarSlice = generateSidebarSlice(
+          sidebarOptions!,
+          options,
+          loadedApi,
+          tags,
+          docPath,
+          extensions
+        );
+        if (extensions && sidebarSlice) {
           const label = extensions["root-category-label"];
           const description = extensions["root-category-description"];
           extendedSidebar = {

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -16,7 +16,6 @@ import { render } from "mustache";
 
 import { createApiPageMD, createInfoPageMD, createTagPageMD } from "./markdown";
 import { readOpenapiFiles, processOpenapiFiles } from "./openapi";
-import { Extensions } from "./openapi/types";
 import { OptionsSchema } from "./options";
 import generateSidebarSlice from "./sidebars";
 import type {

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -110,70 +110,17 @@ export default function pluginOpenAPIDocs(
       const extensions = extensionsItem[0]?.extensions;
 
       let extendedSidebar; // Undefined extended sidebar
-      // TODO: figure out better way to set default
-      if (Object.keys(sidebarOptions ?? {}).length > 0) {
-        const sidebarSlice = generateSidebarSlice(
-          sidebarOptions!,
-          options,
-          loadedApi,
-          tags,
-          docPath,
-          extensions
-        );
-        if (extensions && sidebarSlice) {
-          const label = extensions["root-category-label"];
-          const description = extensions["root-category-description"];
-          extendedSidebar = {
-            type: "category",
-            label: label,
-            link: {
-              type: "generated-index",
-              title: label,
-              ...(description && {
-                description: description,
-              }),
-              slug: "/category/" + kebabCase(label),
-            },
-            items: sidebarSlice,
-          };
-        }
+      const sidebarSlice = generateSidebarSlice(
+        sidebarOptions!,
+        options,
+        loadedApi,
+        tags,
+        docPath,
+        extensions // groupBySpec if present
+      ); // Can return undefined
 
-        const sidebarSliceTemplate = template
-          ? fs.readFileSync(template).toString()
-          : `module.exports = {{{slice}}};`;
-
-        const view = render(sidebarSliceTemplate, {
-          slice: extendedSidebar
-            ? JSON.stringify(extendedSidebar)
-            : JSON.stringify(sidebarSlice),
-        });
-
-        if (!fs.existsSync(`${outputDir}/sidebar.js`)) {
-          try {
-            fs.writeFileSync(`${outputDir}/sidebar.js`, view, "utf8");
-            console.log(
-              chalk.green(`Successfully created "${outputDir}/sidebar.js"`)
-            );
-          } catch (err) {
-            console.error(
-              chalk.red(`Failed to write "${outputDir}/sidebar.js"`),
-              chalk.yellow(err)
-            );
-          }
-        }
-      }
-
-      // Handle extensions with no sidebarOptions
-      if (extensions["root-category-label"]) {
-        const sidebarSlice = generateSidebarSlice(
-          sidebarOptions!,
-          options,
-          loadedApi,
-          tags,
-          docPath,
-          extensions
-        );
-        if (extensions && sidebarSlice) {
+      if (sidebarSlice) {
+        if (extensions && extensions["root-category-label"] && sidebarSlice) {
           const label = extensions["root-category-label"];
           const description = extensions["root-category-description"];
           extendedSidebar = {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchemaDetails.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchemaDetails.ts
@@ -52,7 +52,11 @@ interface RowProps {
 
 function createRow({ name, schema, required }: RowProps) {
   const schemaName = getSchemaName(schema, true);
-  if (schemaName && (schemaName === "object" || schemaName === "object[]")) {
+  if (
+    schemaName &&
+    (typeof schema === "object" ||
+      ((typeof schema as any) === "array" && typeof schema[0] === "object"))
+  ) {
     return create("SchemaItem", {
       collapsible: true,
       className: "schemaItem",
@@ -100,7 +104,6 @@ function createRow({ name, schema, required }: RowProps) {
       ],
     });
   }
-
   return create("SchemaItem", {
     collapsible: false,
     name,

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -21,6 +21,7 @@ import {
   ApiMetadata,
   APIOptions,
   ApiPageMetadata,
+  ExtensionsMetadata,
   InfoPageMetadata,
   SidebarOptions,
   TagPageMetadata,
@@ -142,6 +143,14 @@ function createItems(
     items.push(infoPage);
   }
 
+  if (openapiData["x-docusaurus-extensions"]) {
+    const extensions: ExtensionsMetadata = {
+      type: "extensions",
+      extensions: openapiData["x-docusaurus-extensions"],
+    };
+    items.push(extensions);
+  }
+
   for (let [path, pathObject] of Object.entries(openapiData.paths)) {
     const { $ref, description, parameters, servers, summary, ...rest } =
       pathObject;
@@ -228,7 +237,11 @@ function bindCollectionToApiItems(
       .replace(/:([a-z0-9-_]+)/gi, "{$1}"); // replace "/:variableName" with "/{variableName}"
 
     const apiItem = items.find((item) => {
-      if (item.type === "info" || item.type === "tag") {
+      if (
+        item.type === "info" ||
+        item.type === "tag" ||
+        item.type === "extensions"
+      ) {
         return false;
       }
       return item.api.path === path && item.api.method === method;

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -11,6 +11,11 @@ interface Map<T> {
   [key: string]: T;
 }
 
+export interface Extensions {
+  "root-category-label"?: string;
+  "root-category-description"?: string;
+}
+
 export interface OpenApiObject {
   openapi: string;
   info: InfoObject;
@@ -20,6 +25,7 @@ export interface OpenApiObject {
   security?: SecurityRequirementObject[];
   tags?: TagObject[];
   externalDocs?: ExternalDocumentationObject;
+  "x-docusaurus-extensions"?: Extensions;
 }
 
 export interface OpenApiObjectWithRef {

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -255,9 +255,17 @@ export default function generateSidebarSlice(
       tags,
       docPath
     );
+    return sidebarSlice;
   }
-  if (extensions["root-category-label"]) {
+  if (
+    !sidebarOptions?.groupPathsBy &&
+    extensions &&
+    extensions["root-category-label"]
+  ) {
+    console.log("Burgers!");
     sidebarSlice = groupBySpec(api as ApiPageMetadata[], options, docPath);
+    return sidebarSlice;
   }
-  return sidebarSlice;
+
+  return;
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -8,6 +8,7 @@
 import type Request from "@paloaltonetworks/postman-collection";
 
 import {
+  Extensions,
   InfoObject,
   OperationObject,
   SecuritySchemeObject,
@@ -61,7 +62,11 @@ export interface LoadedContent {
   // loadedDocs: DocPageMetadata[]; TODO: cleanup
 }
 
-export type ApiMetadata = ApiPageMetadata | InfoPageMetadata | TagPageMetadata;
+export type ApiMetadata =
+  | ApiPageMetadata
+  | InfoPageMetadata
+  | TagPageMetadata
+  | ExtensionsMetadata;
 
 export interface ApiMetadataBase {
   sidebar?: string;
@@ -112,6 +117,12 @@ export interface InfoPageMetadata extends ApiMetadataBase {
 export interface TagPageMetadata extends ApiMetadataBase {
   type: "tag";
   tag: TagObject;
+  markdown?: string;
+}
+
+export interface ExtensionsMetadata {
+  type: "extensions";
+  extensions: Extensions;
   markdown?: string;
 }
 


### PR DESCRIPTION
## Description

This PR introduces support for OpenAPI vendor extensions for Docusaurus. The first use case addresses #142 and introduces support for `root-category-label` and `root-category-description`.

## Motivation and Context

Vendor extensions can be used to describe extra functionality that is not covered by the standard OpenAPI Specification. The idea would be to leverage them as a means to customizing Docusaurus features related to generating docs, sidebars and potentially other features.

> Again, the first use-case addressed allows for defining a top-level Docusaurus sidebar category for grouping paths/operations. The idea is that these extensions can be used by themselves or with `sidebarOptions`. The end result will still be a sidebar slice compatible with a Docusaurus sidebar object.

## How Has This Been Tested?

See the Petstore API  under "API Zoo" in the deploy preview.

## Additional Changes

* Fixed an issue that resulted in some schemas not being handled when the key didn't match the strings "object" or "object[]": https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/main/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchemaDetails.ts#L55