### PR TITLE
[FR] Add support for Response Headers

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -7,11 +7,64 @@
 
 import { ApiItem } from "../types";
 import { createDescription } from "./createDescription";
+import { createDetails } from "./createDetails";
+import { createDetailsSummary } from "./createDetailsSummary";
 import { createSchemaDetails } from "./createSchemaDetails";
 import { create } from "./utils";
+import { guard } from "./utils";
 
 interface Props {
   responses: ApiItem["responses"];
+}
+
+function createResponseHeaders(responseHeaders: any) {
+  return guard(responseHeaders, () =>
+    create("ul", {
+      style: { marginLeft: "1rem" },
+      children: [
+        Object.entries(responseHeaders).map(([headerName, headerObj]) => {
+          const {
+            description,
+            schema: { type },
+            example,
+          }: any = headerObj;
+
+          return create("li", {
+            class: "schemaItem",
+            children: [
+              createDetailsSummary({
+                children: [
+                  create("strong", { children: headerName }),
+                  guard(type, () => [
+                    create("span", {
+                      style: { opacity: "0.6" },
+                      children: ` ${type}`,
+                    }),
+                  ]),
+                ],
+              }),
+              create("div", {
+                children: [
+                  guard(description, (description) =>
+                    create("div", {
+                      style: {
+                        marginTop: ".5rem",
+                        marginBottom: ".5rem",
+                      },
+                      children: [
+                        guard(example, () => `Example: ${example}`),
+                        createDescription(description),
+                      ],
+                    })
+                  ),
+                ],
+              }),
+            ],
+          });
+        }),
+      ],
+    })
+  );
 }
 
 export function createStatusCodes({ responses }: Props) {
@@ -28,6 +81,7 @@ export function createStatusCodes({ responses }: Props) {
     children: [
       create("ApiTabs", {
         children: codes.map((code) => {
+          const responseHeaders: any = responses[code].headers;
           return create("TabItem", {
             label: code,
             value: code,
@@ -35,6 +89,20 @@ export function createStatusCodes({ responses }: Props) {
               create("div", {
                 children: createDescription(responses[code].description),
               }),
+              responseHeaders &&
+                createDetails({
+                  "data-collaposed": false,
+                  open: true,
+                  style: { textAlign: "left" },
+                  children: [
+                    createDetailsSummary({
+                      children: [
+                        create("strong", { children: "Response Headers" }),
+                      ],
+                    }),
+                    createResponseHeaders(responseHeaders),
+                  ],
+                }),
               create("div", {
                 children: createSchemaDetails({
                   title: "Schema",


### PR DESCRIPTION
## Description

This PR introduces support for rendering Response Headers, should they exist within an OAS file. The following `header` object properties are supported: 

- `description`
- `schema.type`
- `example` (if provided)

## Motivation and Context
Related to #170 

## How Has This Been Tested?

Tested with `ATP` and `TP` API 

## Screenshots (if appropriate)

![Screen Shot 2022-07-25 at 3 23 16 PM](https://user-images.githubusercontent.com/48506502/180886743-2fb78c8f-7b27-4b68-8805-6af5da1a2e82.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
