### PR TITLE
[Bug] Use basePath in place of slug to avoid duplicate routes

### DIFF
--- a/demo/docs/cos/sidebar.js
+++ b/demo/docs/cos/sidebar.js
@@ -5,7 +5,7 @@ module.exports = [
     link: {
       type: "generated-index",
       title: "Authentication",
-      slug: "/category/authentication",
+      slug: "/category/cos/authentication",
     },
     items: [
       {
@@ -22,7 +22,7 @@ module.exports = [
     link: {
       type: "generated-index",
       title: "Bucket operations",
-      slug: "/category/bucket-operations",
+      slug: "/category/cos/bucket-operations",
     },
     items: [
       {

--- a/demo/docs/petstore/login-user.api.mdx
+++ b/demo/docs/petstore/login-user.api.mdx
@@ -20,7 +20,15 @@ import TabItem from "@theme/TabItem";
 
 successful operation
 
-</div><div><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></div></TabItem><TabItem label={"400"} value={"400"}><div>
+</div><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+
+calls per hour allowed by the user
+
+</div></div></li><li class={"schemaItem"}><summary style={{}}><strong>X-Expires-After</strong><span style={{"opacity":"0.6"}}> string</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+
+date in UTC when token expires
+
+</div></div></li></ul></details><div><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></div></TabItem><TabItem label={"400"} value={"400"}><div>
 
 Invalid username/password supplied
 

--- a/demo/docs/petstore_versioned/login-user.api.mdx
+++ b/demo/docs/petstore_versioned/login-user.api.mdx
@@ -20,7 +20,15 @@ import TabItem from "@theme/TabItem";
 
 successful operation
 
-</div><div><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></div></TabItem><TabItem label={"400"} value={"400"}><div>
+</div><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+
+calls per hour allowed by the user
+
+</div></div></li><li class={"schemaItem"}><summary style={{}}><strong>X-Expires-After</strong><span style={{"opacity":"0.6"}}> string</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+
+date in UTC when token expires
+
+</div></div></li></ul></details><div><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></div></TabItem><TabItem label={"400"} value={"400"}><div>
 
 Invalid username/password supplied
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -102,7 +102,6 @@ function createItems(
           unversionedId: tagId,
           title: description ?? "",
           description: description ?? "",
-          slug: "/" + tagId,
           frontMatter: {},
           tag: {
             ...tag,
@@ -120,7 +119,6 @@ function createItems(
       unversionedId: infoId,
       title: openapiData.info.title,
       description: openapiData.info.description,
-      slug: "/" + infoId,
       frontMatter: {},
       securitySchemes: openapiData.components?.securitySchemes,
       info: {
@@ -184,7 +182,6 @@ function createItems(
         unversionedId: baseId,
         title: title,
         description: description ?? "",
-        slug: "/" + baseId,
         frontMatter: {},
         api: {
           ...defaults,

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import path from "path";
+
 import {
   ProcessedSidebar,
   SidebarItemCategory,
@@ -14,7 +16,6 @@ import {
 import clsx from "clsx";
 import { kebabCase } from "lodash";
 import uniq from "lodash/uniq";
-import path from "path";
 
 import { TagObject } from "../openapi/types";
 import type {

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -14,6 +14,7 @@ import {
 import clsx from "clsx";
 import { kebabCase } from "lodash";
 import uniq from "lodash/uniq";
+import path from "path";
 
 import { TagObject } from "../openapi/types";
 import type {
@@ -139,8 +140,8 @@ function groupByTags(
           type: "generated-index" as "generated-index",
           title: tag,
           slug: label
-            ? "/category/" + kebabCase(label) + "/" + kebabCase(tag)
-            : "/category/" + kebabCase(tag),
+            ? path.join("/category", basePath, kebabCase(label), kebabCase(tag))
+            : path.join("/category", basePath, kebabCase(tag)),
         } as SidebarItemCategoryLinkConfig;
       }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -76,7 +76,7 @@ export interface ApiMetadataBase {
   description: string;
   source: string; // @site aliased source => "@site/docs/folder/subFolder/subSubFolder/myDoc.md"
   sourceDirName: string; // relative to the versioned docs folder (can be ".") => "folder/subFolder/subSubFolder"
-  slug: string;
+  slug?: string;
   permalink: string;
   sidebarPosition?: number;
   frontMatter: Record<string, unknown>;


### PR DESCRIPTION
## Description

Remove unnecessary slugs and introduce basePath to necessary slugs

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We were using the same basePath for all slugs, meaning that shared id's could result in multiple specs being mapped to the same category-index when they were in separate outputDir's. 

We were also adding slugs to pages that didn't need them e.g. info pages. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Confirmed links were working correctly in sidebar.js files. Mostly used in generated-index pages which are based on the slug fed, so shouldn't be an issue. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
