### PR TITLE
[FR] Support for response status code examples 

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -82,6 +82,12 @@ export function createStatusCodes({ responses }: Props) {
       create("ApiTabs", {
         children: codes.map((code) => {
           const responseHeaders: any = responses[code].headers;
+          const responseContent: any = responses[code].content;
+          const responseContentKey: any =
+            responseContent && Object.keys(responseContent)[0];
+          const responseExamples: any =
+            responseContentKey && responseContent[responseContentKey].examples;
+
           return create("TabItem", {
             label: code,
             value: code,
@@ -111,6 +117,10 @@ export function createStatusCodes({ responses }: Props) {
                   },
                 }),
               }),
+              responseExamples &&
+                create("ResponseSamples", {
+                  responseExamples: responseExamples,
+                }),
             ],
           });
         }),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -119,7 +119,8 @@ export function createStatusCodes({ responses }: Props) {
               }),
               responseExamples &&
                 create("ResponseSamples", {
-                  responseExamples: responseExamples,
+                  responseContentKey,
+                  responseExamples,
                 }),
             ],
           });

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -67,6 +67,26 @@ function createResponseHeaders(responseHeaders: any) {
   );
 }
 
+function createResponseExamples(responseExamples: any) {
+  return Object.entries(responseExamples).map(
+    ([exampleName, exampleValue]: any) => {
+      const camelToSpaceName = exampleName.replace(/([A-Z])/g, " $1");
+      let finalFormattedName =
+        camelToSpaceName.charAt(0).toUpperCase() + camelToSpaceName.slice(1);
+
+      return create("TabItem", {
+        label: `${finalFormattedName}`,
+        value: `${finalFormattedName}`,
+        children: [
+          create("ResponseSamples", {
+            responseExample: JSON.stringify(exampleValue.value, null, 2),
+          }),
+        ],
+      });
+    }
+  );
+}
+
 export function createStatusCodes({ responses }: Props) {
   if (responses === undefined) {
     return undefined;
@@ -95,7 +115,44 @@ export function createStatusCodes({ responses }: Props) {
               create("div", {
                 children: createDescription(responses[code].description),
               }),
-              responseHeaders &&
+              guard(responseExamples, () =>
+                create("SchemaTabs", {
+                  children: [
+                    create("TabTtem", {
+                      label: "Schema",
+                      value: "Schema",
+                      children: [
+                        responseHeaders &&
+                          createDetails({
+                            "data-collaposed": false,
+                            open: true,
+                            style: { textAlign: "left" },
+                            children: [
+                              createDetailsSummary({
+                                children: [
+                                  create("strong", {
+                                    children: "Response Headers",
+                                  }),
+                                ],
+                              }),
+                              createResponseHeaders(responseHeaders),
+                            ],
+                          }),
+                        create("div", {
+                          children: createSchemaDetails({
+                            title: "Schema",
+                            body: {
+                              content: responses[code].content,
+                            },
+                          }),
+                        }),
+                      ],
+                    }),
+                    createResponseExamples(responseExamples),
+                  ],
+                })
+              ),
+              guard(responseHeaders, () =>
                 createDetails({
                   "data-collaposed": false,
                   open: true,
@@ -108,20 +165,18 @@ export function createStatusCodes({ responses }: Props) {
                     }),
                     createResponseHeaders(responseHeaders),
                   ],
-                }),
-              create("div", {
-                children: createSchemaDetails({
-                  title: "Schema",
-                  body: {
-                    content: responses[code].content,
-                  },
-                }),
-              }),
-              responseExamples &&
-                create("ResponseSamples", {
-                  responseContentKey,
-                  responseExamples,
-                }),
+                })
+              ),
+              guard(!responseExamples, () =>
+                create("div", {
+                  children: createSchemaDetails({
+                    title: "Schema",
+                    body: {
+                      content: responses[code].content,
+                    },
+                  }),
+                })
+              ),
             ],
           });
         }),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -37,9 +37,10 @@ export function createApiPageMD({
   },
 }: ApiPageMetadata) {
   return render([
-    `import ParamsItem from "@theme/ParamsItem";\n`,
-    `import SchemaItem from "@theme/SchemaItem"\n`,
     `import ApiTabs from "@theme/ApiTabs";\n`,
+    `import ParamsItem from "@theme/ParamsItem";\n`,
+    `import ResponseSamples from "@theme/ResponseSamples";\n`,
+    `import SchemaItem from "@theme/SchemaItem"\n`,
     `import SchemaTabs from "@theme/SchemaTabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
     `## ${escape(title)}\n\n`,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
@@ -39,13 +39,18 @@ function ResponseSamples({ responseExamples }) {
         2
       );
 
-      return <CodeBlock>{responseSampleContent}</CodeBlock>;
+      return (
+        <CodeBlock className={styles.responseSamplesCodeBlock}>
+          {responseSampleContent}
+        </CodeBlock>
+      );
     }
   };
 
   return (
     <div className={styles.responseSamplesContainer}>
       <strong className={styles.responseSamplesHeader}>Response Samples</strong>
+      <hr />
       {renderResponseSamples()}
     </div>
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
@@ -10,10 +10,14 @@ import React from "react";
 import CodeBlock from "@theme/CodeBlock";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
+import clsx from "clsx";
 
 import styles from "./styles.module.css";
 
-function ResponseSamples({ responseExamples }) {
+function ResponseSamples({
+  responseExamples,
+  responseContentKey: contentType,
+}) {
   const hasMultipleExamples = Object.keys(responseExamples).length > 1;
 
   const renderResponseSamples = () => {
@@ -23,7 +27,13 @@ function ResponseSamples({ responseExamples }) {
           {Object.entries(responseExamples).map(
             ([exampleKey, exampleValue]) => (
               <TabItem label={exampleKey} value={exampleKey}>
-                <CodeBlock>
+                <pre
+                  className={clsx(styles.contentType, "codeBlock")}
+                >{`Content Type: ${contentType}`}</pre>
+                <CodeBlock
+                  language="javascript"
+                  className={styles.responseSamplesCodeBlock}
+                >
                   {JSON.stringify(exampleValue.value, null, 2)}
                 </CodeBlock>
               </TabItem>
@@ -40,9 +50,17 @@ function ResponseSamples({ responseExamples }) {
       );
 
       return (
-        <CodeBlock className={styles.responseSamplesCodeBlock}>
-          {responseSampleContent}
-        </CodeBlock>
+        <>
+          <pre
+            className={clsx(styles.contentType, "codeBlock")}
+          >{`Content Type: ${contentType}`}</pre>
+          <CodeBlock
+            language="javascript"
+            className={styles.responseSamplesCodeBlock}
+          >
+            {responseSampleContent}
+          </CodeBlock>
+        </>
       );
     }
   };

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
@@ -1,0 +1,52 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React from "react";
+import CodeBlock from "@theme/CodeBlock";
+import SchemaTabs from "@theme/SchemaTabs";
+import TabItem from "@theme/TabItem";
+import styles from "./styles.module.css";
+
+function ResponseSamples({ responseExamples }) {
+  const hasMultipleExamples = Object.keys(responseExamples).length > 1;
+
+  const renderResponseSamples = () => {
+    if (hasMultipleExamples) {
+      return (
+        <SchemaTabs>
+          {Object.entries(responseExamples).map(
+            ([exampleKey, exampleValue]) => (
+              <TabItem label={exampleKey} value={exampleKey}>
+                <CodeBlock>
+                  {JSON.stringify(exampleValue.value, null, 2)}
+                </CodeBlock>
+              </TabItem>
+            )
+          )}
+        </SchemaTabs>
+      );
+    } else {
+      const responseExampleKey = Object.keys(responseExamples)[0];
+      const responseSampleContent = JSON.stringify(
+        responseExamples[responseExampleKey].value,
+        null,
+        2
+      );
+
+      return <CodeBlock>{responseSampleContent}</CodeBlock>;
+    }
+  };
+
+  return (
+    <div className={styles.responseSamplesContainer}>
+      <strong className={styles.responseSamplesHeader}>Response Samples</strong>
+      {renderResponseSamples()}
+    </div>
+  );
+}
+
+export default ResponseSamples;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
@@ -6,9 +6,11 @@
  * ========================================================================== */
 
 import React from "react";
+
 import CodeBlock from "@theme/CodeBlock";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
+
 import styles from "./styles.module.css";
 
 function ResponseSamples({ responseExamples }) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/index.js
@@ -8,68 +8,18 @@
 import React from "react";
 
 import CodeBlock from "@theme/CodeBlock";
-import SchemaTabs from "@theme/SchemaTabs";
-import TabItem from "@theme/TabItem";
-import clsx from "clsx";
 
 import styles from "./styles.module.css";
 
-function ResponseSamples({
-  responseExamples,
-  responseContentKey: contentType,
-}) {
-  const hasMultipleExamples = Object.keys(responseExamples).length > 1;
-
-  const renderResponseSamples = () => {
-    if (hasMultipleExamples) {
-      return (
-        <SchemaTabs>
-          {Object.entries(responseExamples).map(
-            ([exampleKey, exampleValue]) => (
-              <TabItem label={exampleKey} value={exampleKey}>
-                <pre
-                  className={clsx(styles.contentType, "codeBlock")}
-                >{`Content Type: ${contentType}`}</pre>
-                <CodeBlock
-                  language="javascript"
-                  className={styles.responseSamplesCodeBlock}
-                >
-                  {JSON.stringify(exampleValue.value, null, 2)}
-                </CodeBlock>
-              </TabItem>
-            )
-          )}
-        </SchemaTabs>
-      );
-    } else {
-      const responseExampleKey = Object.keys(responseExamples)[0];
-      const responseSampleContent = JSON.stringify(
-        responseExamples[responseExampleKey].value,
-        null,
-        2
-      );
-
-      return (
-        <>
-          <pre
-            className={clsx(styles.contentType, "codeBlock")}
-          >{`Content Type: ${contentType}`}</pre>
-          <CodeBlock
-            language="javascript"
-            className={styles.responseSamplesCodeBlock}
-          >
-            {responseSampleContent}
-          </CodeBlock>
-        </>
-      );
-    }
-  };
-
+function ResponseSamples({ responseExample }) {
   return (
     <div className={styles.responseSamplesContainer}>
-      <strong className={styles.responseSamplesHeader}>Response Samples</strong>
-      <hr />
-      {renderResponseSamples()}
+      <CodeBlock
+        language="javascript"
+        className={styles.responseSamplesCodeBlock}
+      >
+        {responseExample}
+      </CodeBlock>
     </div>
   );
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
@@ -1,7 +1,31 @@
+:root {
+  --prism-color: #393a34;
+  --prism-background-color: #f6f8fa;
+}
+
+[data-theme="dark"]:root {
+  --prism-color: #f8f8f2;
+  --prism-background-color: #282a36;
+}
+
 .responseSamplesContainer {
   margin-top: 2rem;
 }
 
 .responseSamplesCodeBlock code {
-  max-height: 400px;
+  padding-top: 0;
+}
+
+.responseSamplesCodeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.contentType {
+  width: 100%;
+  margin-bottom: 0;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
@@ -1,0 +1,7 @@
+.responseSamplesContainer {
+  margin-top: 2rem;
+}
+
+.responseSamplesCodeBlock code {
+  max-height: 400px;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
@@ -1,3 +1,7 @@
 .responseSamplesContainer {
   margin-top: 2rem;
 }
+
+.responseSamplesTabItem {
+  width: 100%;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSamples/styles.module.css
@@ -1,31 +1,3 @@
-:root {
-  --prism-color: #393a34;
-  --prism-background-color: #f6f8fa;
-}
-
-[data-theme="dark"]:root {
-  --prism-color: #f8f8f2;
-  --prism-background-color: #282a36;
-}
-
 .responseSamplesContainer {
   margin-top: 2rem;
-}
-
-.responseSamplesCodeBlock code {
-  padding-top: 0;
-}
-
-.responseSamplesCodeBlock {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.contentType {
-  width: 100%;
-  margin-bottom: 0;
-  background: var(--prism-background-color);
-  color: var(--prism-color);
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
@@ -38,14 +38,6 @@
   display: none;
 }
 
-.schemaTabsContainer {
-  display: flex;
-  align-items: center;
-  max-width: 390px;
-  padding-left: 3px;
-  overflow: hidden;
-}
-
 .schemaTabsListContainer {
   padding: 0 0.25rem;
   overflow-y: hidden;


### PR DESCRIPTION
## Description

This PR introduces added support for response status code examples. Users will now be able to toggle between the Response Schema and any provided examples via `SchemaTabs`.

- Code Sample (`CodeBlock` component)
- Ability to copy or wrap code text for better readability (`CodeBlock` component)
- Status codes containing multiple examples can be selected through tabs (`SchemaTabs` component)

## Motivation and Context
See #119 

## How Has This Been Tested?

So far tested with IoT API, which contains single status code examples and multiple status code examples. Will do further testing on other product API's that contain status code examples.

- [x] Code Security API 

## Screenshots (if appropriate)

**Response Status Code examples provided**

https://user-images.githubusercontent.com/48506502/182264634-0fe428ab-1b9f-4ce4-820a-f08e32315dc8.mov

**Response Status Code examples not provided**

![image](https://user-images.githubusercontent.com/48506502/182264794-eb0c22f9-1295-4b94-9281-7c1226c9c945.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
