### PR TITLE
[Bug] Fix createPostmanCollection method where a copy of openapiData is generated

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -13,7 +13,7 @@ import sdk from "@paloaltonetworks/postman-collection";
 import Collection from "@paloaltonetworks/postman-collection";
 import chalk from "chalk";
 import fs from "fs-extra";
-import { kebabCase } from "lodash";
+import { kebabCase, cloneDeep } from "lodash";
 
 import { isURL } from "../index";
 import {
@@ -54,7 +54,7 @@ async function createPostmanCollection(
   openapiData: OpenApiObject
 ): Promise<Collection> {
   // Create copy of openapiData
-  const data = Object.assign({}, openapiData) as OpenApiObject;
+  const data = cloneDeep(openapiData) as OpenApiObject;
 
   // Including `servers` breaks postman, so delete all of them.
   delete data.servers;

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -13,7 +13,8 @@ import sdk from "@paloaltonetworks/postman-collection";
 import Collection from "@paloaltonetworks/postman-collection";
 import chalk from "chalk";
 import fs from "fs-extra";
-import { kebabCase, cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import kebabCase from "lodash/kebabCase";
 
 import { isURL } from "../index";
 import {


### PR DESCRIPTION
## Description

This PR introduces the following changes:

1. Fix `createPostmanCollection` method where a copy of `openapiData` is generated
2. Add `groupId` to `Tabs` component for Authentication section in generated `*.info.mdx` file

## Motivation and Context

1. The motivation is to fix the problem when some paths can have their own server object. For example:
```yaml
openapi: 3.0.3
info:
  title: Burger Example
  version: 1.0.0
  description: Sample description.
servers:
  - url: https://api.example.com/v1
paths:
  /user:
    get:
      servers:
        - url: https://users.example.com/v1
      responses:
        200:
          description: OK
  /flavors:
    get:
      responses:
        200:
          description: OK
```
The previous realization with `Object.assign` does not copy nested objects, and the next operation with deleting 'servers' attributes removes them into the parent object too.

2. Fix problem when changing of Authentication method in `*.info.mdx` file does not save user choice to storage and does not change security scheme all over the documentation

## How Has This Been Tested?

Environment: Local

Changes were tested by viewing specific API docs to ensure functionality for API docs were intact and ensuring that the app builds successfully upon each change.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.