### PR TITLE
[Bug] Ensure operation tags match global tags before building sidebar

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -124,9 +124,7 @@ function createItems(
       securitySchemes: openapiData.components?.securitySchemes,
       info: {
         ...openapiData.info,
-        tags: openapiData.tags?.map((tagName) =>
-          getTagDisplayName(tagName.name!, openapiData.tags ?? [])
-        ),
+        tags: openapiData.tags,
         title: openapiData.info.title ?? "Introduction",
         logo: openapiData.info["x-logo"]! as any,
         darkLogo: openapiData.info["x-dark-logo"]! as any,
@@ -200,9 +198,7 @@ function createItems(
         frontMatter: {},
         api: {
           ...defaults,
-          tags: operationObject.tags?.map((tagName) =>
-            getTagDisplayName(tagName, openapiData.tags ?? [])
-          ),
+          tags: operationObject.tags,
           method,
           path,
           servers,

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -41,7 +41,7 @@ export interface InfoObject {
   contact?: ContactObject;
   license?: LicenseObject;
   version: string;
-  tags?: String[];
+  tags?: TagObject[];
   "x-logo"?: LogoObject;
   "x-dark-logo"?: LogoObject;
   logo?: LogoObject;

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -65,9 +65,10 @@ function groupByTags(
       .flatMap((item) => item.api.tags)
       .filter((item): item is string => !!item)
   );
+
+  // Only include operation tags that are globally defined
   const apiTags: string[] = [];
-  // eslint-disable-next-line array-callback-return
-  tags.map((tag) => {
+  tags.forEach((tag) => {
     if (operationTags.includes(tag.name!)) {
       apiTags.push(tag.name!);
     }
@@ -114,7 +115,7 @@ function groupByTags(
       );
       const tagObject = tags.flat().find(
         (t) =>
-          (tag === t.name || tag === t["x-displayName"]) ?? {
+          tag === t.name ?? {
             name: tag,
             description: `${tag} Index`,
           }
@@ -155,7 +156,7 @@ function groupByTags(
 
       return {
         type: "category" as const,
-        label: tag,
+        label: tagObject?.["x-displayName"] ?? tag,
         link: linkConfig,
         collapsible: sidebarCollapsible,
         collapsed: sidebarCollapsed,


### PR DESCRIPTION
## Description

This change is a regression bug introduced while addressing #199. Essentially, matching operation tag to global tag was failing when `x-displayName` was present. This change eliminates that possibility by avoiding resolving `x-displayName` until immediately before the category label is assigned.

## Motivation and Context

Regression bug fix.

## How Has This Been Tested?

Tested with both Petstore and the sample Unleash API spec.

## Screenshots (if appropriate)

n/a

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
