### PR TITLE
[Enhancement] Add support for single response example

### DIFF
--- a/demo/docs/petstore/login-user.api.mdx
+++ b/demo/docs/petstore/login-user.api.mdx
@@ -23,7 +23,7 @@ import TabItem from "@theme/TabItem";
 
 successful operation
 
-</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left","marginBottom":"1rem"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
 
 calls per hour allowed by the user
 
@@ -31,15 +31,7 @@ calls per hour allowed by the user
 
 date in UTC when token expires
 
-</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-calls per hour allowed by the user
-
-</div></div></li><li class={"schemaItem"}><summary style={{}}><strong>X-Expires-After</strong><span style={{"opacity":"0.6"}}> string</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-date in UTC when token expires
-
-</div></div></li></ul></details></TabItem><TabItem label={"400"} value={"400"}><div>
+</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs></TabItem><TabItem label={"400"} value={"400"}><div>
 
 Invalid username/password supplied
 

--- a/demo/docs/petstore/place-order.api.mdx
+++ b/demo/docs/petstore/place-order.api.mdx
@@ -31,5 +31,5 @@ successful operation
 
 Invalid Order
 
-</div><div></div></TabItem></ApiTabs></div>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><div></div></TabTtem><TabItem label={"Status"} value={"Status"}><ResponseSamples responseExample={"400"}></ResponseSamples></TabItem><TabItem label={"Message"} value={"Message"}><ResponseSamples responseExample={"\"Invalid Order\""}></ResponseSamples></TabItem></SchemaTabs></TabItem></ApiTabs></div>
       

--- a/demo/docs/petstore_versioned/1.0.0/login-user.api.mdx
+++ b/demo/docs/petstore_versioned/1.0.0/login-user.api.mdx
@@ -23,7 +23,7 @@ import TabItem from "@theme/TabItem";
 
 successful operation
 
-</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left","marginBottom":"1rem"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
 
 calls per hour allowed by the user
 
@@ -31,15 +31,7 @@ calls per hour allowed by the user
 
 date in UTC when token expires
 
-</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-calls per hour allowed by the user
-
-</div></div></li><li class={"schemaItem"}><summary style={{}}><strong>X-Expires-After</strong><span style={{"opacity":"0.6"}}> string</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-date in UTC when token expires
-
-</div></div></li></ul></details></TabItem><TabItem label={"400"} value={"400"}><div>
+</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs></TabItem><TabItem label={"400"} value={"400"}><div>
 
 Invalid username/password supplied
 

--- a/demo/docs/petstore_versioned/1.0.0/place-order.api.mdx
+++ b/demo/docs/petstore_versioned/1.0.0/place-order.api.mdx
@@ -31,5 +31,5 @@ successful operation
 
 Invalid Order
 
-</div><div></div></TabItem></ApiTabs></div>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><div></div></TabTtem><TabItem label={"Status"} value={"Status"}><ResponseSamples responseExample={"400"}></ResponseSamples></TabItem><TabItem label={"Message"} value={"Message"}><ResponseSamples responseExample={"\"Invalid Order\""}></ResponseSamples></TabItem></SchemaTabs></TabItem></ApiTabs></div>
       

--- a/demo/docs/petstore_versioned/login-user.api.mdx
+++ b/demo/docs/petstore_versioned/login-user.api.mdx
@@ -23,7 +23,7 @@ import TabItem from "@theme/TabItem";
 
 successful operation
 
-</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><details style={{"textAlign":"left","marginBottom":"1rem"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
 
 calls per hour allowed by the user
 
@@ -31,15 +31,7 @@ calls per hour allowed by the user
 
 date in UTC when token expires
 
-</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs><details style={{"textAlign":"left"}} data-collaposed={false} open={true}><summary style={{}}><strong>Response Headers</strong></summary><ul style={{"marginLeft":"1rem"}}><li class={"schemaItem"}><summary style={{}}><strong>X-Rate-Limit</strong><span style={{"opacity":"0.6"}}> integer</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-calls per hour allowed by the user
-
-</div></div></li><li class={"schemaItem"}><summary style={{}}><strong>X-Expires-After</strong><span style={{"opacity":"0.6"}}> string</span></summary><div><div style={{"marginTop":".5rem","marginBottom":".5rem"}}>
-
-date in UTC when token expires
-
-</div></div></li></ul></details></TabItem><TabItem label={"400"} value={"400"}><div>
+</div></div></li></ul></details><div><MimeTabs groupId={"mime-type"}><TabItem label={"application/json"} value={"application/json"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem><TabItem label={"application/xml"} value={"application/xml"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Schema</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><li><div><strong>string</strong></div></li></ul></details></TabItem></MimeTabs></div></TabTtem><TabItem label={"Response"} value={"Response"}><ResponseSamples responseExample={"\"OK\""}></ResponseSamples></TabItem></SchemaTabs></TabItem><TabItem label={"400"} value={"400"}><div>
 
 Invalid username/password supplied
 

--- a/demo/docs/petstore_versioned/place-order.api.mdx
+++ b/demo/docs/petstore_versioned/place-order.api.mdx
@@ -31,5 +31,5 @@ successful operation
 
 Invalid Order
 
-</div><div></div></TabItem></ApiTabs></div>
+</div><SchemaTabs><TabTtem label={"Schema"} value={"Schema"}><div></div></TabTtem><TabItem label={"Status"} value={"Status"}><ResponseSamples responseExample={"400"}></ResponseSamples></TabItem><TabItem label={"Message"} value={"Message"}><ResponseSamples responseExample={"\"Invalid Order\""}></ResponseSamples></TabItem></SchemaTabs></TabItem></ApiTabs></div>
       

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -79,7 +79,11 @@ function createResponseExamples(responseExamples: any) {
         value: `${finalFormattedName}`,
         children: [
           create("ResponseSamples", {
-            responseExample: JSON.stringify(exampleValue.value, null, 2),
+            responseExample: JSON.stringify(
+              exampleValue.value ?? exampleValue,
+              null,
+              2
+            ),
           }),
         ],
       });
@@ -106,7 +110,9 @@ export function createStatusCodes({ responses }: Props) {
           const responseContentKey: any =
             responseContent && Object.keys(responseContent)[0];
           const responseExamples: any =
-            responseContentKey && responseContent[responseContentKey].examples;
+            responseContentKey &&
+            (responseContent[responseContentKey].examples ||
+              responseContent[responseContentKey].example);
 
           return create("TabItem", {
             label: code,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -132,7 +132,7 @@ export function createStatusCodes({ responses }: Props) {
                           createDetails({
                             "data-collaposed": false,
                             open: true,
-                            style: { textAlign: "left" },
+                            style: { textAlign: "left", marginBottom: "1rem" },
                             children: [
                               createDetailsSummary({
                                 children: [
@@ -158,7 +158,7 @@ export function createStatusCodes({ responses }: Props) {
                   ],
                 })
               ),
-              guard(responseHeaders, () =>
+              guard(responseHeaders && !responseExamples, () =>
                 createDetails({
                   "data-collaposed": false,
                   open: true,


### PR DESCRIPTION
## Description

See issue #205 for details background. The TL;DR is that OpenAPI supports either `example` or `examples` under responses. This PR introduces support for a single `example`.

> Note: this PR also conditionally renders `responseHeaders` depending on if examples are present

## Motivation and Context

n/a

## How Has This Been Tested?

Tested with Code API, Shopping API and Petstore.