### PR TITLE
[Enhancement] Use CodeBlock to render code fences

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import CodeBlock from "@theme/CodeBlock";
 import ReactMarkdown from "react-markdown";
 
 import { createDescription } from "../../markdown/createDescription";
@@ -33,7 +34,21 @@ function ParamsItem({
 
   const renderDescription = guard(description, (description) => (
     <div>
-      <ReactMarkdown children={createDescription(description)} />
+      <ReactMarkdown
+        children={createDescription(description)}
+        components={{
+          pre: "div",
+          code({ node, inline, className, children, ...props }) {
+            const match = /language-(\w+)/.exec(className || "");
+            if (inline) return <code>{children}</code>;
+            return !inline && match ? (
+              <CodeBlock className={className}>{children}</CodeBlock>
+            ) : (
+              <CodeBlock>{children}</CodeBlock>
+            );
+          },
+        }}
+      />
     </div>
   ));
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import CodeBlock from "@theme/CodeBlock";
 import ReactMarkdown from "react-markdown";
 
 import { createDescription } from "../../markdown/createDescription";
@@ -29,8 +30,22 @@ function SchemaItem({
   );
 
   const renderSchemaDescription = guard(schemaDescription, (description) => (
-    <div className={styles.schemaDescription}>
-      <ReactMarkdown children={createDescription(description)} />
+    <div>
+      <ReactMarkdown
+        children={createDescription(description)}
+        components={{
+          pre: "div",
+          code({ node, inline, className, children, ...props }) {
+            const match = /language-(\w+)/.exec(className || "");
+            if (inline) return <code>{children}</code>;
+            return !inline && match ? (
+              <CodeBlock className={className}>{children}</CodeBlock>
+            ) : (
+              <CodeBlock>{children}</CodeBlock>
+            );
+          },
+        }}
+      />
     </div>
   ));
 


### PR DESCRIPTION
## Description

Uses `react-markdown` components feature to render `SchemaItem` and `ParamsItem` code fences with Docusaurus `CodeBlock` component.

## Motivation and Context

Keeps consistency with Docusaurus code blocks including the theme, and copy and text wrap buttons.

## How Has This Been Tested?

Tested with Threat API, PANOS API, Petstore.

See deploy preview.