### PR TITLE
Fix typo TabTtem -> TabItem

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -748,7 +748,7 @@ export function createResponseSchema({ title, body, ...rest }: Props) {
               groupId: "schema-tabs",
               children: [
                 firstBody &&
-                  create("TabTtem", {
+                  create("TabItem", {
                     label: `${title}`,
                     value: `${title}`,
                     children: [


### PR DESCRIPTION
There is a typo in the markdown generator code that is pulling in a `TabTtem` rather than a `TabItem` as expected.