### PR TITLE
Support Multi Instance

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -393,7 +393,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         .usage("<id>")
         .arguments("<id>")
         .action(async (command, instance, args) => {
-          if (!args || command !== "gen-api-docs") {
+          if (command !== "gen-api-docs") {
             return;
           }
           const id = args[0];
@@ -427,7 +427,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         .usage("<id:version>")
         .arguments("<id:version>")
         .action(async (command, instance, args) => {
-          if (!args || command !== "gen-api-docs:version") {
+          if (command !== "gen-api-docs:version") {
             return;
           }
           const id = args[0];
@@ -495,7 +495,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         .usage("<id>")
         .arguments("<id>")
         .action(async (command, instance, args) => {
-          if (!args || command !== "clean-api-docs") {
+          if (command !== "clean-api-docs") {
             return;
           }
           const id = args[0];
@@ -525,7 +525,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         .usage("<id:version>")
         .arguments("<id:version>")
         .action(async (command, instance, args) => {
-          if (!args || command !== "clean-api-docs:version") {
+          if (command !== "clean-api-docs:version") {
             return;
           }
           const id = args[0];

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -392,7 +392,11 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .action(async (id) => {
+        .action(async (command, instance, args) => {
+          if (!args || command !== "gen-api-docs") {
+            return;
+          }
+          const id = args[0];
           if (id === "all") {
             if (config[id]) {
               console.error(
@@ -412,7 +416,8 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           } else {
             await generateApiDocs(config[id]);
           }
-        });
+        })
+        .parseAsync();
 
       cli
         .command(`gen-api-docs:version`)
@@ -421,7 +426,11 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .action(async (id) => {
+        .action(async (command, instance, args) => {
+          if (!args || command !== "gen-api-docs:version") {
+            return;
+          }
+          const id = args[0];
           const [parentId, versionId] = id.split(":");
           const parentConfig = Object.assign({}, config[parentId]);
 
@@ -475,7 +484,8 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
             await generateVersions(mergedVersions, parentConfig.outputDir);
             await generateApiDocs(mergedConfig);
           }
-        });
+        })
+        .parseAsync();
 
       cli
         .command(`clean-api-docs`)
@@ -484,7 +494,11 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .action(async (id) => {
+        .action(async (command, instance, args) => {
+          if (!args || command !== "clean-api-docs") {
+            return;
+          }
+          const id = args[0];
           if (id === "all") {
             if (config[id]) {
               console.error(
@@ -500,7 +514,8 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           } else {
             await cleanApiDocs(config[id]);
           }
-        });
+        })
+        .parseAsync();
 
       cli
         .command(`clean-api-docs:version`)
@@ -509,7 +524,11 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .action(async (id) => {
+        .action(async (command, instance, args) => {
+          if (!args || command !== "clean-api-docs:version") {
+            return;
+          }
+          const id = args[0];
           const [parentId, versionId] = id.split(":");
           const { versions } = config[parentId] as any;
 
@@ -540,7 +559,8 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
             };
             await cleanApiDocs(mergedConfig);
           }
-        });
+        })
+        .parseAsync();
     },
   };
 }


### PR DESCRIPTION
## Description

Added ability to generate and clean api docs for all instances when more than one are defined

## Motivation and Context

This fixes an issue where you cannot cli commands when more than one instance is defined
(https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/231)

## How Has This Been Tested?

Ran the CLI with multi and single instance defined, ensured docs are created and cleaned without issue

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
