### PR TITLE
[Experimental] Adds multi-instance support to plugin CLI

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -230,6 +230,24 @@ const config = {
       },
     ],
     [
+      "docusaurus-plugin-openapi-docs",
+      {
+        id: "openapi2",
+        docsPluginId: "classic",
+        config: {
+          petstore: {
+            specPath: "examples/petstore.yaml",
+            outputDir: "docs/petstore",
+            sidebarOptions: {
+              groupPathsBy: "tag",
+              categoryLinkSource: "tag",
+            },
+            template: "api.mustache", // Customize API MDX with mustache template
+          },
+        },
+      },
+    ],
+    [
       "@docusaurus/plugin-pwa",
       {
         debug: true,

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -230,24 +230,6 @@ const config = {
       },
     ],
     [
-      "docusaurus-plugin-openapi-docs",
-      {
-        id: "openapi2",
-        docsPluginId: "classic",
-        config: {
-          petstore: {
-            specPath: "examples/petstore.yaml",
-            outputDir: "docs/petstore",
-            sidebarOptions: {
-              groupPathsBy: "tag",
-              categoryLinkSource: "tag",
-            },
-            template: "api.mustache", // Customize API MDX with mustache template
-          },
-        },
-      },
-    ],
-    [
       "@docusaurus/plugin-pwa",
       {
         debug: true,

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -421,6 +421,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
                   "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
+              return;
             }
             targetConfig = config;
           }
@@ -476,6 +477,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
                   "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
+              return;
             }
             targetConfig = config;
           }
@@ -564,6 +566,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
                   "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
+              return;
             }
             targetConfig = config;
           }
@@ -614,6 +617,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
                   "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
+              return;
             }
             targetConfig = config;
           }

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -23,35 +23,37 @@ export function isURL(str: string): boolean {
   return /^(https?:)\/\//m.test(str);
 }
 
-export function getDocsData(
-  dataArray: any[],
-  filter: string
+export function getDocsPluginConfig(
+  presetsPlugins: any[],
+  pluginId: string
 ): Object | undefined {
   // eslint-disable-next-line array-callback-return
-  const filteredData = dataArray.filter((data) => {
-    if (data[0] === filter) {
+  const filteredConfig = presetsPlugins.filter((data) => {
+    if (data[0] === pluginId) {
       return data[1];
     }
 
     // Search plugin-content-docs instances
     if (data[0] === "@docusaurus/plugin-content-docs") {
-      const pluginId = data[1].id ? data[1].id : "default";
-      if (pluginId === filter) {
+      const configPluginId = data[1].id ? data[1].id : "default";
+      if (configPluginId === pluginId) {
         return data[1];
       }
     }
   })[0];
-  if (filteredData) {
+  if (filteredConfig) {
     // Search presets, e.g. "classic"
-    if (filteredData[0] === filter) {
-      return filteredData[1].docs;
+    if (filteredConfig[0] === pluginId) {
+      return filteredConfig[1].docs;
     }
 
     // Search plugin-content-docs instances
-    if (filteredData[0] === "@docusaurus/plugin-content-docs") {
-      const pluginId = filteredData[1].id ? filteredData[1].id : "default";
-      if (pluginId === filter) {
-        return filteredData[1];
+    if (filteredConfig[0] === "@docusaurus/plugin-content-docs") {
+      const configPluginId = filteredConfig[1].id
+        ? filteredConfig[1].id
+        : "default";
+      if (configPluginId === pluginId) {
+        return filteredConfig[1];
       }
     }
   }
@@ -73,7 +75,7 @@ export default function pluginOpenAPIDocs(
   const presets: any = siteConfig.presets;
   const plugins: any = siteConfig.plugins;
   const presetsPlugins = presets.concat(plugins);
-  const docData: any = getDocsData(presetsPlugins, docsPluginId);
+  const docData: any = getDocsPluginConfig(presetsPlugins, docsPluginId);
   const docRouteBasePath = docData ? docData.routeBasePath : undefined;
   const docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
 

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -405,13 +405,20 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
-            const pluginConfig = getPluginConfig(plugins, pluginId);
-            targetConfig = pluginConfig.config ?? {};
+            try {
+              const pluginConfig = getPluginConfig(plugins, pluginId);
+              targetConfig = pluginConfig.config ?? {};
+            } catch {
+              console.error(
+                chalk.red(`OpenAPI docs plugin ID '${pluginId}' not found.`)
+              );
+              return;
+            }
           } else {
             if (pluginInstances.length > 1) {
               console.error(
                 chalk.red(
-                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                  "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
             }
@@ -453,13 +460,20 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
-            const pluginConfig = getPluginConfig(plugins, pluginId);
-            targetConfig = pluginConfig.config ?? {};
+            try {
+              const pluginConfig = getPluginConfig(plugins, pluginId);
+              targetConfig = pluginConfig.config ?? {};
+            } catch {
+              console.error(
+                chalk.red(`OpenAPI docs plugin ID '${pluginId}' not found.`)
+              );
+              return;
+            }
           } else {
             if (pluginInstances.length > 1) {
               console.error(
                 chalk.red(
-                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                  "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
             }
@@ -534,13 +548,20 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
-            const pluginConfig = getPluginConfig(plugins, pluginId);
-            targetConfig = pluginConfig.config ?? {};
+            try {
+              const pluginConfig = getPluginConfig(plugins, pluginId);
+              targetConfig = pluginConfig.config ?? {};
+            } catch {
+              console.error(
+                chalk.red(`OpenAPI docs plugin ID '${pluginId}' not found.`)
+              );
+              return;
+            }
           } else {
             if (pluginInstances.length > 1) {
               console.error(
                 chalk.red(
-                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                  "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
             }
@@ -577,13 +598,20 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
-            const pluginConfig = getPluginConfig(plugins, pluginId);
-            targetConfig = pluginConfig.config ?? {};
+            try {
+              const pluginConfig = getPluginConfig(plugins, pluginId);
+              targetConfig = pluginConfig.config ?? {};
+            } catch {
+              console.error(
+                chalk.red(`OpenAPI docs plugin ID '${pluginId}' not found.`)
+              );
+              return;
+            }
           } else {
             if (pluginInstances.length > 1) {
               console.error(
                 chalk.red(
-                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                  "OpenAPI docs plugin ID must be specified when more than one plugin instance exists."
                 )
               );
             }

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -64,6 +64,10 @@ function getPluginConfig(plugins: any[], pluginId: string): any {
   return plugins.filter((data) => data[1].id === pluginId)[0][1];
 }
 
+function getPluginInstances(plugins: any[]): any {
+  return plugins.filter((data) => data[0] === "docusaurus-plugin-openapi-docs");
+}
+
 export default function pluginOpenAPIDocs(
   context: LoadContext,
   options: PluginOptions
@@ -394,15 +398,23 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID.")
         .action(async (id, instance) => {
           const options = instance.opts();
           const pluginId = options.pluginId;
+          const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
             const pluginConfig = getPluginConfig(plugins, pluginId);
             targetConfig = pluginConfig.config ?? {};
           } else {
+            if (pluginInstances.length > 1) {
+              console.error(
+                chalk.red(
+                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                )
+              );
+            }
             targetConfig = config;
           }
 
@@ -434,15 +446,23 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID.")
         .action(async (id, instance) => {
           const options = instance.opts();
           const pluginId = options.pluginId;
+          const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
             const pluginConfig = getPluginConfig(plugins, pluginId);
             targetConfig = pluginConfig.config ?? {};
           } else {
+            if (pluginInstances.length > 1) {
+              console.error(
+                chalk.red(
+                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                )
+              );
+            }
             targetConfig = config;
           }
           const [parentId, versionId] = id.split(":");
@@ -507,15 +527,23 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID.")
         .action(async (id, instance) => {
           const options = instance.opts();
           const pluginId = options.pluginId;
+          const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
             const pluginConfig = getPluginConfig(plugins, pluginId);
             targetConfig = pluginConfig.config ?? {};
           } else {
+            if (pluginInstances.length > 1) {
+              console.error(
+                chalk.red(
+                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                )
+              );
+            }
             targetConfig = config;
           }
           if (id === "all") {
@@ -542,15 +570,23 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID.")
         .action(async (id, instance) => {
           const options = instance.opts();
           const pluginId = options.pluginId;
+          const pluginInstances = getPluginInstances(plugins);
           let targetConfig: any;
           if (pluginId) {
             const pluginConfig = getPluginConfig(plugins, pluginId);
             targetConfig = pluginConfig.config ?? {};
           } else {
+            if (pluginInstances.length > 1) {
+              console.error(
+                chalk.red(
+                  "OpenAPI plugin ID must be specified when more than one plugin instance exists."
+                )
+              );
+            }
             targetConfig = config;
           }
           const [parentId, versionId] = id.split(":");

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -58,6 +58,10 @@ export function getDocsData(
   return;
 }
 
+function getPluginConfig(plugins: any[], pluginId: string): any {
+  return plugins.filter((data) => data[1].id === pluginId)[0][1];
+}
+
 export default function pluginOpenAPIDocs(
   context: LoadContext,
   options: PluginOptions
@@ -388,25 +392,36 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .action(async (id) => {
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .action(async (id, instance) => {
+          const options = instance.opts();
+          const pluginId = options.pluginId;
+          let targetConfig: any;
+          if (pluginId) {
+            const pluginConfig = getPluginConfig(plugins, pluginId);
+            targetConfig = pluginConfig.config ?? {};
+          } else {
+            targetConfig = config;
+          }
+
           if (id === "all") {
-            if (config[id]) {
+            if (targetConfig[id]) {
               console.error(
                 chalk.red(
                   "Can't use id 'all' for OpenAPI docs configuration key."
                 )
               );
             } else {
-              Object.keys(config).forEach(async function (key) {
-                await generateApiDocs(config[key]);
+              Object.keys(targetConfig).forEach(async function (key) {
+                await generateApiDocs(targetConfig[key]);
               });
             }
-          } else if (!config[id]) {
+          } else if (!targetConfig[id]) {
             console.error(
               chalk.red(`ID '${id}' does not exist in OpenAPI docs config.`)
             );
           } else {
-            await generateApiDocs(config[id]);
+            await generateApiDocs(targetConfig[id]);
           }
         });
 
@@ -417,9 +432,19 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .action(async (id) => {
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .action(async (id, instance) => {
+          const options = instance.opts();
+          const pluginId = options.pluginId;
+          let targetConfig: any;
+          if (pluginId) {
+            const pluginConfig = getPluginConfig(plugins, pluginId);
+            targetConfig = pluginConfig.config ?? {};
+          } else {
+            targetConfig = config;
+          }
           const [parentId, versionId] = id.split(":");
-          const parentConfig = Object.assign({}, config[parentId]);
+          const parentConfig = Object.assign({}, targetConfig[parentId]);
 
           const version = parentConfig.version as string;
           const label = parentConfig.label as string;
@@ -428,7 +453,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           let parentVersion = {} as any;
           parentVersion[version] = { label: label, baseUrl: baseUrl };
 
-          const { versions } = config[parentId] as any;
+          const { versions } = targetConfig[parentId] as any;
           const mergedVersions = Object.assign(parentVersion, versions);
 
           // Prepare for merge
@@ -480,21 +505,31 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id>")
         .arguments("<id>")
-        .action(async (id) => {
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .action(async (id, instance) => {
+          const options = instance.opts();
+          const pluginId = options.pluginId;
+          let targetConfig: any;
+          if (pluginId) {
+            const pluginConfig = getPluginConfig(plugins, pluginId);
+            targetConfig = pluginConfig.config ?? {};
+          } else {
+            targetConfig = config;
+          }
           if (id === "all") {
-            if (config[id]) {
+            if (targetConfig[id]) {
               console.error(
                 chalk.red(
                   "Can't use id 'all' for OpenAPI docs configuration key."
                 )
               );
             } else {
-              Object.keys(config).forEach(async function (key) {
-                await cleanApiDocs(config[key]);
+              Object.keys(targetConfig).forEach(async function (key) {
+                await cleanApiDocs(targetConfig[key]);
               });
             }
           } else {
-            await cleanApiDocs(config[id]);
+            await cleanApiDocs(targetConfig[id]);
           }
         });
 
@@ -505,11 +540,21 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         )
         .usage("<id:version>")
         .arguments("<id:version>")
-        .action(async (id) => {
+        .option("-p, --plugin-id <plugin>", "OpenAPI docs plugin ID")
+        .action(async (id, instance) => {
+          const options = instance.opts();
+          const pluginId = options.pluginId;
+          let targetConfig: any;
+          if (pluginId) {
+            const pluginConfig = getPluginConfig(plugins, pluginId);
+            targetConfig = pluginConfig.config ?? {};
+          } else {
+            targetConfig = config;
+          }
           const [parentId, versionId] = id.split(":");
-          const { versions } = config[parentId] as any;
+          const { versions } = targetConfig[parentId] as any;
 
-          const parentConfig = Object.assign({}, config[parentId]);
+          const parentConfig = Object.assign({}, targetConfig[parentId]);
           delete parentConfig.versions;
 
           if (versionId === "all") {


### PR DESCRIPTION
## Description

See #243 and #231  for background.

This approach differs from #243 in that it does not introduce `parseAsync` for performing commands against all plugin instances and configs. Instead, it adds support for a new option, `-p` or `--plugin-id`, which can be used to specify which plugin config to run the command against.

Example usage:

```bash
Usage: docusaurus gen-api-docs <id>

Generates OpenAPI docs in MDX file format and sidebar.js (if enabled).

Options:
  -p, --plugin-id <plugin>  OpenAPI docs plugin ID
  -h, --help                display help for command
```

### Expected usage/behavior

* When *no* `-p` or `--plugin-id` option is passed and more than 1 plugin instance exists the command will return an error indicating the plugin ID is required.
* When a `-p` or `--plugin-id` option is passed the command will be executed only against the OpenAPI docs plugin config matching the option value.
* If no plugin ID matches the command option a `TypeError` will be thrown (need to improve error handling)> 

> Note: All other behavior should remain the same. 

> Config keys do not need to be globally unique across all plugin instances.
 
## Motivation and Context

Multi-plugin instance should be supported to allow users to isolate plugin instances and their configs.

## How Has This Been Tested?

Tested with Petstore API and config by configuring another `docusaurus-plugin-openapi-docs` instance.

## Screenshots (if appropriate)

n/a