### PR TITLE
[UI] Fix Schema Tabs arrow render

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -229,11 +229,11 @@ function SchemaTabsComponent(props) {
             (tabItem) => tabItem.props.value === selectedValue
           )[0],
           {
-            className: clsx("margin-vert--md", styles.schemaTabsContainer),
+            className: "margin-vert--md",
           }
         )
       ) : (
-        <div className={clsx("margin-vert--md", styles.schemaTabsContainer)}>
+        <div className="margin-vert--md">
           {children.map((tabItem, i) =>
             cloneElement(tabItem, {
               key: i,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
@@ -59,7 +59,10 @@
 }
 
 .schemaTabsContainer {
+  display: flex;
+  align-items: center;
   max-width: 600px;
+  overflow: hidden;
 }
 
 /* Tab Arrows */


### PR DESCRIPTION
## Description

Currently, the `<SchemaTabs />` component displays an incorrect render of arrows and displays an overflow when there are multiple example tabs present.

## Motivation and Context

Arrows should be rendered on both left and right side of the tabs and there should be no overflow issues. The expected behavior is similar to `<ApiTabs />`.

## How Has This Been Tested?

Tested with SASE (Tennacy Service Group), which contained multiple example tabs. Ensured that the arrows were present on both left and right sides of the example tabs, as opposed to above and below. Also tested for responsiveness to ensure there weren't any overflow issues.

## Screenshots (if appropriate)

### Before: 
![Screen Shot 2022-09-07 at 5 41 22 PM](https://user-images.githubusercontent.com/48506502/189023934-e81fe1c0-b2c1-4dc1-8e8d-081e54275034.png)

<img width="1189" alt="Screen Shot 2022-09-07 at 8 13 08 PM" src="https://user-images.githubusercontent.com/48506502/189025947-ab4c4f8c-d05e-4c76-b04f-b12fbab7bdb5.png">

### After: 

https://user-images.githubusercontent.com/48506502/189026872-33aceaab-4571-4527-88d7-759591fbef0a.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
