### PR TITLE
[Enhancement] Split placeholder by newline and add title for tooltip

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
@@ -7,7 +7,10 @@
 
 import React from "react";
 
+import tippy from "tippy.js";
+
 import styles from "./styles.module.css";
+import "tippy.js/dist/tippy.css";
 
 interface Props {
   value?: string;
@@ -17,11 +20,13 @@ interface Props {
 }
 
 function FormTextInput({ value, placeholder, password, onChange }: Props) {
+  placeholder = placeholder?.split("\n")[0];
   return (
     <input
       className={styles.input}
       type={password ? "password" : "text"}
       placeholder={placeholder}
+      title={placeholder}
       value={value}
       onChange={onChange}
       autoComplete="off"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
@@ -7,10 +7,7 @@
 
 import React from "react";
 
-import tippy from "tippy.js";
-
 import styles from "./styles.module.css";
-import "tippy.js/dist/tippy.css";
 
 interface Props {
   value?: string;


### PR DESCRIPTION
## Description

Adds tooltips to input fields for handling placeholders that extend beyond the visible width.