### PR TITLE
[Bug] Handle both items and non-items schemas in renderDefaultValue

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -53,7 +53,11 @@ function ParamsItem({
   ));
 
   const renderDefaultValue = guard(
-    schema.items ? schema.items.default : schema.default,
+    schema && schema.items
+      ? schema.items.default
+      : schema
+      ? schema.default
+      : undefined,
     (value) => (
       <div>
         <ReactMarkdown children={`**Default value:** \`${value}\``} />


### PR DESCRIPTION
## Description

Extends support for both items and non-items params for rendering default value.