### PR TITLE
[Bug] Check for mapping object before attempting to resolve discriminators

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -30,12 +30,17 @@ function serializer(replacer: any, cycleReplacer: any) {
     // Resolve discriminator ref pointers
     if (value?.discriminator !== undefined) {
       const parser = new OpenAPIParser(stack[0]);
-      for (let [k, v] of Object.entries(value.discriminator.mapping)) {
-        const discriminator = k as string;
-        if (typeof v === "string" && v.charAt(0) === "#") {
-          const ref = v as string;
-          const resolvedRef = parser.byRef(ref);
-          value.discriminator.mapping[discriminator] = resolvedRef;
+      if (
+        value.discriminator.mapping &&
+        typeof value.discriminator.mapping === "object"
+      ) {
+        for (let [k, v] of Object.entries(value.discriminator.mapping)) {
+          const discriminator = k as string;
+          if (typeof v === "string" && v.charAt(0) === "#") {
+            const ref = v as string;
+            const resolvedRef = parser.byRef(ref);
+            value.discriminator.mapping[discriminator] = resolvedRef;
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Not all discriminators use the `mapping` property to map which ref pointers to apply the discriminator to. This change checks to see if `mapping` exists before attempting to resolve ref pointers. Previously, this was resulting in a `TypeError` for specifications that use `discriminator` with no `mapping`.