### PR TITLE
[Bug] Throw exception when operationId and summary not defined

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -235,6 +235,12 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         if (item.type === "api") {
           if (!fs.existsSync(`${outputDir}/${item.id}.api.mdx`)) {
             try {
+              // kebabCase(arg) returns 0-length string when arg is undefined
+              if (item.id.length === 0) {
+                throw Error(
+                  "Operation must have summary or operationId defined"
+                );
+              }
               fs.writeFileSync(`${outputDir}/${item.id}.api.mdx`, view, "utf8");
               console.log(
                 chalk.green(


### PR DESCRIPTION
## Description

See #267 for background

## Motivation and Context

All operations are required to have either an `operationId` or a `summary` defined, as they are used to generate the filename for the MDX output.

## How Has This Been Tested?

Tested with Burgers API.

## Screenshots (if appropriate)

```bash
$ docusaurus gen-api-docs burgers
Successfully created "docs/food/burgers/burger-example.info.mdx"
Failed to write "docs/food/burgers/.api.mdx" Error: Operation must have summary or operationId defined
```