### PR TITLE
[Enhancement] Allow grouping by operation tag if global tag not defined

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -66,13 +66,12 @@ function groupByTags(
       .filter((item): item is string => !!item)
   );
 
-  // Only include operation tags that are globally defined
-  const apiTags: string[] = [];
+  // Combine globally defined tags with operation tags
+  let apiTags: string[] = [];
   tags.flat().forEach((tag) => {
-    if (operationTags.includes(tag.name!)) {
-      apiTags.push(tag.name!);
-    }
+    apiTags.push(tag.name!);
   });
+  apiTags = uniq(apiTags.concat(operationTags));
 
   const basePath = docPath
     ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")


### PR DESCRIPTION
## Description

See #257 for background.

## Motivation and Context

Grouping by tags should be allowed when tags are defined at the operation level but not globally.

## How Has This Been Tested?

Tested with Petstore API.

<img width="801" alt="Screen Shot 2022-09-21 at 10 09 57 AM" src="https://user-images.githubusercontent.com/9343811/191527095-90cc020c-392a-47c8-8a86-2e94a36ee7c4.png">
