### PR TITLE
[Enhancement] Increase contrast between active/non-active Schema/Response Tabs

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/styles.module.css
@@ -12,14 +12,19 @@
   height: 2.5rem;
   margin-top: 0 !important;
   margin-right: 0.5rem;
-  border: 1px solid var(--openapi-code-dim-dark);
+  border: 1px solid var(--ifm-color-primary);
   border-radius: var(--ifm-global-radius);
+  color: var(--ifm-color-primary);
   font-weight: var(--ifm-font-weight-normal);
-  color: var(--openapi-code-dim-dark);
+}
+
+.tabItem:not(.responseTabActive) {
+  opacity: 0.65;
 }
 
 .tabItem:hover {
-  color: var(--ifm-color-emphasis-500) !important;
+  opacity: 1;
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .tabItem:last-child {
@@ -74,8 +79,7 @@
 }
 
 .responseTabActive {
-  border: 1px solid var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .responseSchemaContainer {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
@@ -12,14 +12,19 @@
   height: 1.8rem;
   margin-top: 0 !important;
   margin-right: 0.5rem;
-  border: 1px solid var(--openapi-code-dim-dark);
+  border: 1px solid var(--ifm-color-primary);
   border-radius: var(--ifm-global-radius);
-  color: var(--openapi-code-dim-dark);
+  color: var(--ifm-color-primary);
   font-size: 12px;
 }
 
+.tabItem:not(.schemaTabActive) {
+  opacity: 0.65;
+}
+
 .tabItem:hover {
-  color: var(--ifm-color-emphasis-500) !important;
+  opacity: 1;
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .tabItem:last-child {
@@ -49,9 +54,8 @@
   display: none;
 }
 
-.tabItem.schemaTabActive {
-  border: 1px solid var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+.schemaTabActive {
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .schemaTabLabel {


### PR DESCRIPTION
## Description

This PR introduces the following changes to our current `<SchemaTabs />` and `<ResponseTabs />` styles: 
- Added background color for both hover and active states: `--ifm-color-emphasis-100`
- Decreased opacity for non-active tabs 

## Motivation and Context

In effort to increase contrast between active/non-active tabs, while maintaining readability for the end-user. In cases where there are only 2 available tabs, there may be a slight confusion in determining which tab is selected.

## Screenshots (if appropriate)

### Dark Mode
<img width="661" alt="Screen Shot 2022-09-26 at 2 58 19 PM" src="https://user-images.githubusercontent.com/48506502/192390872-3e0fd8ed-74a3-423e-bbc9-d4322e5d8f10.png">

### Light Mode 
<img width="650" alt="Screen Shot 2022-09-26 at 2 58 39 PM" src="https://user-images.githubusercontent.com/48506502/192390908-66ffe7cb-f528-4fad-8491-a3f4f95b3313.png">


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
