### PR TITLE
[Enhancement] Add support for request examples

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -434,6 +434,28 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/Order"
+            examples:
+              OrderDelivered:
+                summary: Order delivered
+                value:
+                  quantity: 4
+                  shipDate: 2022-10-12
+                  status: delivered
+                  requestId: 444-4444-444-4444
+              OrderPlaced:
+                summary: Order placed
+                value:
+                  quantity: 10
+                  shipDate: 2022-10-01
+                  status: placed
+                  requestId: 111-222-333-444
+              OrderApproved:
+                summary: Order approved
+                value:
+                  quantity: 1000
+                  shipDate: 2022-09-01
+                  status: approved
+                  requestId: 000-111-222-333
         description: order placed for purchasing the pet
         required: true
   "/store/order/{orderId}":
@@ -1153,6 +1175,19 @@ components:
               - description: My Pet
                 title: Pettie
               - $ref: "#/components/schemas/Pet"
+          example:
+            category:
+              name: Great Dane
+              sub:
+                prop1: Just a test property
+            name: Pepper
+            photoUrls:
+              - https://assets.orvis.com/is/image/orvisprd/great-dane
+            tags:
+              - name: Great Danes
+            status: pending
+            petType:
+              huntingSkill: lazy
         application/xml:
           schema:
             type: "object"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -319,7 +319,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
               <TabItem label={example.label} value={example.label}>
                 {example.summary && <p>{example.summary}</p>}
                 <LiveApp action={dispatch} language={language}>
-                  {example.body}
+                  {example.body ?? "unable to render value"}
                 </LiveApp>
               </TabItem>
             );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -237,7 +237,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
     language = "json";
   }
 
-  if (contentType === "application/xml") {
+  if (contentType === "application/xml" || contentType.endsWith("+xml")) {
     if (jsonRequestBodyExample) {
       try {
         defaultBody = format(json2xml(jsonRequestBodyExample, ""), {
@@ -261,26 +261,22 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
       }
     }
     if (examples) {
-      try {
-        for (const [key, example] of Object.entries(examples)) {
-          examplesBodies.push({
-            label: key,
-            body: format(json2xml(example.value, ""), {
-              indentation: "  ",
-              lineSeparator: "\n",
-              collapseContent: true,
-            }),
-            summary: example.summary,
+      for (const [key, example] of Object.entries(examples)) {
+        let formattedXmlBody;
+        try {
+          formattedXmlBody = format(example.value, {
+            indentation: "  ",
+            lineSeparator: "\n",
+            collapseContent: true,
           });
+        } catch {
+          formattedXmlBody = example.value;
         }
-      } catch {
-        for (const [key, example] of Object.entries(examples)) {
-          examplesBodies.push({
-            label: key,
-            body: json2xml(example.value),
-            summary: example.summary,
-          });
-        }
+        examplesBodies.push({
+          label: key,
+          body: formattedXmlBody,
+          summary: example.summary,
+        });
       }
     }
     language = "xml";
@@ -297,7 +293,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
           </TabItem>
           <TabItem label="Example" value="example">
             <LiveApp action={dispatch} language={language}>
-              {exampleBody}
+              {exampleBody ?? "Unable to render value"}
             </LiveApp>
           </TabItem>
         </SchemaTabs>
@@ -323,7 +319,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
               >
                 {example.summary && <p>{example.summary}</p>}
                 <LiveApp action={dispatch} language={language}>
-                  {example.body ?? "unable to render value"}
+                  {example.body ?? "Unable to render value"}
                 </LiveApp>
               </TabItem>
             );
@@ -332,6 +328,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
       </FormItem>
     );
   }
+
   return (
     <FormItem label="Body" required={required}>
       <LiveApp action={dispatch} language={language}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -316,7 +316,11 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
           </TabItem>
           {examplesBodies.map((example: any) => {
             return (
-              <TabItem label={example.label} value={example.label}>
+              <TabItem
+                label={example.label}
+                value={example.label}
+                key={example.label}
+              >
                 {example.summary && <p>{example.summary}</p>}
                 <LiveApp action={dispatch} language={language}>
                   {example.body ?? "unable to render value"}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -292,9 +292,11 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
             </LiveApp>
           </TabItem>
           <TabItem label="Example" value="example">
-            <LiveApp action={dispatch} language={language}>
-              {exampleBody ?? "Unable to render value"}
-            </LiveApp>
+            {exampleBody && (
+              <LiveApp action={dispatch} language={language}>
+                {exampleBody}
+              </LiveApp>
+            )}
           </TabItem>
         </SchemaTabs>
       </FormItem>
@@ -318,9 +320,11 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
                 key={example.label}
               >
                 {example.summary && <p>{example.summary}</p>}
-                <LiveApp action={dispatch} language={language}>
-                  {example.body ?? "Unable to render value"}
-                </LiveApp>
+                {example.body && (
+                  <LiveApp action={dispatch} language={language}>
+                    {example.body}
+                  </LiveApp>
+                )}
               </TabItem>
             );
           })}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
@@ -154,19 +154,8 @@
   margin-bottom: 0;
 }
 
+:global([class^="paramsItem"]::before),
 :global([class^="schemaItem"]::before) {
-  position: absolute;
-  top: 10px;
-  left: 0;
-  width: 0.7rem; /* width of horizontal line */
-  height: 0.5rem; /* vertical position of line */
-  vertical-align: top;
-  border-bottom: thin solid var(--ifm-color-gray-500);
-  content: "";
-  display: inline-block;
-}
-
-:global([class^="paramsItem"]::before) {
   position: absolute;
   top: 10px;
   left: 0;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
@@ -154,12 +154,26 @@
   margin-bottom: 0;
 }
 
-:global(.theme-api-markdown li::before) {
+:global([class^="schemaItem"]::before) {
   position: absolute;
   top: 10px;
   left: 0;
   width: 0.7rem; /* width of horizontal line */
   height: 0.5rem; /* vertical position of line */
+  vertical-align: top;
+  border-bottom: thin solid var(--ifm-color-gray-500);
+  content: "";
+  display: inline-block;
+}
+
+:global([class^="paramsItem"]::before) {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  width: 0.7rem;
+  /* width of horizontal line */
+  height: 0.5rem;
+  /* vertical position of line */
   vertical-align: top;
   border-bottom: thin solid var(--ifm-color-gray-500);
   content: "";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
@@ -413,3 +413,8 @@
   max-height: 500px;
   overflow: auto;
 }
+
+/* Prism code styles */
+:global(.prism-code.language-json) {
+  white-space: nowrap !important;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/styles.module.css
@@ -17,6 +17,7 @@
   font-weight: var(--ifm-font-weight-normal);
   /* color: var(--openapi-code-dim-dark); */
   font-size: 12px;
+  white-space: nowrap;
 }
 
 .tabItem:active {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -227,7 +227,10 @@ function SchemaTabsComponent(props) {
         cloneElement(
           children.filter(
             (tabItem) => tabItem.props.value === selectedValue
-          )[0],
+          )[0] ?? // TODO: see if there's a better way to handle this
+            children.filter(
+              (tabItem) => tabItem.props.value === defaultValue
+            )[0],
           {
             className: "margin-vert--md",
           }


### PR DESCRIPTION
## Description

See #280 for background.

Renders `requestBody` example(s) inside `SchemaTabs`. Uses `lazy` option to prevent all tab items from rendering on first load - instead, the code sample should update each time an example tab is selected.

If you're looking to test use this: https://gist.github.com/biggates/4955d608379a8b1b3224e815c7dd0dc9