### PR TITLE
[Bug] Switch from nowrap to pre

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/styles.module.css
@@ -416,5 +416,5 @@
 
 /* Prism code styles */
 :global(.prism-code.language-json) {
-  white-space: nowrap !important;
+  white-space: pre !important;
 }


### PR DESCRIPTION
## Description

Addresses issue with mobile devices losing all formatting (white space) for json syntax highlighting in `Body`.