### PR TITLE
Disable warning when loading specs from directory

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -280,12 +280,6 @@ export async function readOpenapiFiles(
   if (!isURL(openapiPath)) {
     const stat = await fs.lstat(openapiPath);
     if (stat.isDirectory()) {
-      console.warn(
-        chalk.yellow(
-          "WARNING: Loading a directory of OpenAPI definitions is experimental and subject to unannounced breaking changes."
-        )
-      );
-
       // TODO: Add config for inlcude/ignore
       const allFiles = await Globby(["**/*.{json,yaml,yml}"], {
         cwd: openapiPath,


### PR DESCRIPTION
## Description

Disables warning message when loading specs from directory path.