### PR TITLE
[Bug] Wait for component to mount before calling setStringRawBody

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/LiveEditor/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { usePrismTheme } from "@docusaurus/theme-common";
 import useIsBrowser from "@docusaurus/useIsBrowser";
@@ -51,7 +51,11 @@ function App({
 }: any): JSX.Element {
   const prismTheme = usePrismTheme();
   const [code, setCode] = React.useState(children);
-  action(setStringRawBody(code));
+
+  useEffect(() => {
+    action(setStringRawBody(code));
+  }, [action, code]);
+
   return (
     <div className={styles.playgroundContainer}>
       <LiveProvider


### PR DESCRIPTION
## Description

This PR addresses the following error observed in dev and prod builds:

```
Warning: Cannot update a component (`Execute`) while rendering a different component (`App`). To locate the bad setState() call inside `App`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
```

After tracing, the root cause appears to stem from `action(setStringRawBody(code));` being called before the `LiveProvider` component was mounted.
 
## Motivation and Context

I believe this is also the root cause of the following warnings:

```
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/Users/sserrata/projects/panw/docusaurus-template-openapi-docs/node_modules/webpack-dev-server/client/modules/logger/index.js': No serializer registered for ProvidedDependency
```

## How Has This Been Tested?

Tested with Petstore API.