### PR TITLE
[Bug] Use endsWith to match docsPluginId to preset

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -8,7 +8,6 @@
 import fs from "fs";
 import path from "path";
 
-import plugin from "@docusaurus/mdx-loader/lib/remark/admonitions";
 import type { LoadContext, Plugin } from "@docusaurus/types";
 import { Globby } from "@docusaurus/utils";
 import chalk from "chalk";

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -8,6 +8,7 @@
 import fs from "fs";
 import path from "path";
 
+import plugin from "@docusaurus/mdx-loader/lib/remark/admonitions";
 import type { LoadContext, Plugin } from "@docusaurus/types";
 import { Globby } from "@docusaurus/utils";
 import chalk from "chalk";
@@ -29,7 +30,8 @@ export function getDocsPluginConfig(
 ): Object | undefined {
   // eslint-disable-next-line array-callback-return
   const filteredConfig = presetsPlugins.filter((data) => {
-    if (data[0] === pluginId) {
+    // Search presets
+    if (data[0].endsWith(pluginId)) {
       return data[1];
     }
 
@@ -43,7 +45,7 @@ export function getDocsPluginConfig(
   })[0];
   if (filteredConfig) {
     // Search presets, e.g. "classic"
-    if (filteredConfig[0] === pluginId) {
+    if (filteredConfig[0].endsWith(pluginId)) {
       return filteredConfig[1].docs;
     }
 


### PR DESCRIPTION
## Description

See #295 for background.

Issue stemmed from a discrepancy between the ways "preset-classic" can be defined in `docusaurus.config.js`.

```
presets: [
    [
      "classic",
```

vs

```
presets: [
    [
      "@docusaurus/preset-classic",
```

The difference went unnoticed which led to a broken `infoPath`.