### PR TITLE
[Enhancement] Introduce support for downloading OpenAPI spec

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -215,6 +215,8 @@ const config = {
               categoryLinkSource: "tag",
             },
             template: "api.mustache", // Customize API MDX with mustache template
+            downloadUrl:
+              "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
           },
           cos: {
             specPath: "examples/openapi-cos.json",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -85,7 +85,8 @@ export default function pluginOpenAPIDocs(
   let docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
 
   async function generateApiDocs(options: APIOptions, pluginId: any) {
-    let { specPath, outputDir, template, sidebarOptions } = options;
+    let { specPath, outputDir, template, downloadUrl, sidebarOptions } =
+      options;
 
     // Override docPath if pluginId provided
     if (pluginId) {
@@ -217,6 +218,11 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
       `;
 
       loadedApi.map(async (item) => {
+        if (item.type === "info") {
+          if (downloadUrl && isURL(downloadUrl)) {
+            item.downloadUrl = downloadUrl;
+          }
+        }
         const markdown =
           item.type === "api"
             ? createApiPageMD(item)

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createDownload.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createDownload.ts
@@ -1,0 +1,15 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { create, guard } from "./utils";
+
+export function createDownload(url: string | undefined) {
+  return guard(url, (url) => [
+    create("Export", { url: url, proxy: undefined }),
+    `\n\n`,
+  ]);
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -16,6 +16,7 @@ import { createAuthentication } from "./createAuthentication";
 import { createContactInfo } from "./createContactInfo";
 import { createDeprecationNotice } from "./createDeprecationNotice";
 import { createDescription } from "./createDescription";
+import { createDownload } from "./createDownload";
 import { createLicense } from "./createLicense";
 import { createLogo } from "./createLogo";
 import { createParamsDetails } from "./createParamsDetails";
@@ -83,13 +84,16 @@ export function createInfoPageMD({
     darkLogo,
   },
   securitySchemes,
+  downloadUrl,
 }: InfoPageMetadata) {
   return render([
     `import ApiLogo from "@theme/ApiLogo";\n`,
     `import Tabs from "@theme/Tabs";\n`,
-    `import TabItem from "@theme/TabItem";\n\n`,
+    `import TabItem from "@theme/TabItem";\n`,
+    `import Export from "@theme/ApiDemoPanel/Export";\n\n`,
 
     createVersionBadge(version),
+    createDownload(downloadUrl),
     `# ${title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")}\n\n`,
     createLogo(logo, darkLogo),
     createDescription(description),

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -25,6 +25,7 @@ export const OptionsSchema = Joi.object({
         specPath: Joi.string().required(),
         outputDir: Joi.string().required(),
         template: Joi.string(),
+        downloadUrl: Joi.string(),
         sidebarOptions: sidebarOptions,
         version: Joi.string().when("versions", {
           is: Joi.exist(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -32,6 +32,7 @@ export interface APIOptions {
   specPath: string;
   outputDir: string;
   template?: string;
+  downloadUrl?: string;
   sidebarOptions?: SidebarOptions;
   version?: string;
   label?: string;
@@ -72,6 +73,7 @@ export interface ApiMetadataBase {
   unversionedId: string; // TODO new unversioned id => try to rename to "id"
   infoId?: string;
   infoPath?: string;
+  downloadUrl?: string;
   title: string;
   description: string;
   source: string; // @site aliased source => "@site/docs/folder/subFolder/subSubFolder/myDoc.md"

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -35,6 +35,7 @@
     "@docusaurus/types": "2.0.1",
     "@types/concurrently": "^6.3.0",
     "@types/crypto-js": "^4.1.0",
+    "@types/file-saver": "^2.0.5",
     "@types/fs-extra": "^9.0.13",
     "@types/lodash": "^4.14.176",
     "@types/mdx-js__react": "^1.5.4",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -51,6 +51,7 @@
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
     "docusaurus-plugin-openapi-docs": "^1.3.2",
+    "file-saver": "^2.0.5",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",
     "process": "^0.11.10",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
@@ -20,7 +20,7 @@ function Export({ url, proxy }: any) {
       style={{ float: "right" }}
       className="dropdown dropdown--hoverable dropdown--right"
     >
-      <button className="button button--sm button--secondary">Export 💾</button>
+      <button className="button button--sm button--secondary">Export</button>
       <ul className="dropdown__menu">
         <li>
           <a

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
@@ -7,7 +7,6 @@
 
 import React from "react";
 
-// @ts-ignore
 import fileSaver from "file-saver";
 
 const saveFile = (url: string) => {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
@@ -11,7 +11,11 @@ import React from "react";
 import fileSaver from "file-saver";
 
 const saveFile = (url: string) => {
-  fileSaver.saveAs(url, url.endsWith("json") ? "openapi.json" : "openapi.yaml");
+  let fileName;
+  if (url.endsWith("json") || url.endsWith("yaml") || url.endsWith("yml")) {
+    fileName = url.substring(url.lastIndexOf("/") + 1);
+  }
+  fileSaver.saveAs(url, fileName ? fileName : "openapi.txt");
 };
 
 function Export({ url, proxy }: any) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
@@ -1,0 +1,42 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React from "react";
+
+// @ts-ignore
+import fileSaver from "file-saver";
+
+const saveFile = (url: string) => {
+  fileSaver.saveAs(url, url.endsWith("json") ? "openapi.json" : "openapi.yaml");
+};
+
+function Export({ url, proxy }: any) {
+  return (
+    <div
+      style={{ float: "right" }}
+      className="dropdown dropdown--hoverable dropdown--right"
+    >
+      <button className="button button--sm button--secondary">Export 💾</button>
+      <ul className="dropdown__menu">
+        <li>
+          <a
+            onClick={(e) => {
+              e.preventDefault();
+              saveFile(`${url}`);
+            }}
+            className="dropdown__link"
+            href={`${url}`}
+          >
+            OpenAPI Spec
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default Export;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Export/index.tsx
@@ -23,8 +23,10 @@ function Export({ url, proxy }: any) {
       style={{ float: "right" }}
       className="dropdown dropdown--hoverable dropdown--right"
     >
-      <button className="button button--sm button--secondary">Export</button>
-      <ul className="dropdown__menu">
+      <button className="export-button button button--sm button--secondary">
+        Export
+      </button>
+      <ul className="export-dropdown dropdown__menu">
         <li>
           <a
             onClick={(e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,6 +4008,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/file-saver@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.5.tgz#9ee342a5d1314bb0928375424a2f162f97c310c7"
+  integrity sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==
+
 "@types/fs-extra@^9.0.13":
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7774,6 +7774,11 @@ file-loader@^6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
+
 file-type@3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"


### PR DESCRIPTION
## Description

See #113 for background

Usage:

Add the `downloadUrl` option to your OpenAPI plugin config.

```
          petstore: {
            specPath: "examples/petstore.yaml",
            outputDir: "docs/petstore",
            sidebarOptions: {
              groupPathsBy: "tag",
              categoryLinkSource: "tag",
            },
            downloadUrl:
              "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
          },
```

TODO:
- [x] Ensure `Export` component adequately supports overriding styles
- [x] Negative testing, e.g. malformed URL and no `info` section
- [x] Test using `::after` to insert icon in dropdown label

Findings:
* Requires the spec to have an `info` section
* GitHub seems to respond with proper CORS headers

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
