### PR TITLE
[Bug] Wrap API docs in BrowserOnly

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import BrowserOnly from "@docusaurus/BrowserOnly";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { HtmlClassNameProvider } from "@docusaurus/theme-common";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -31,27 +32,25 @@ let ApiDemoPanel = (_: { item: any; infoPath: any }) => (
   <div style={{ marginTop: "3.5em" }} />
 );
 
-let DocItem = (props: Props) => {
-  return <div style={{ marginTop: "3.5em" }} />;
-};
+if (ExecutionEnvironment.canUseDOM) {
+  ApiDemoPanel = require("@theme/ApiDemoPanel").default;
+}
 
 interface ApiFrontMatter extends DocFrontMatter {
   readonly api?: ApiItemType;
 }
 
-if (ExecutionEnvironment.canUseDOM) {
-  ApiDemoPanel = require("@theme/ApiDemoPanel").default;
+export default function ApiItem(props: Props): JSX.Element {
+  const docHtmlClassName = `docs-doc-id-${props.content.metadata.unversionedId}`;
+  const MDXComponent = props.content;
+  const { frontMatter } = MDXComponent;
+  const { info_path: infoPath } = frontMatter as DocFrontMatter;
+  const { api } = frontMatter as ApiFrontMatter;
+  const { siteConfig } = useDocusaurusContext();
+  const themeConfig = siteConfig.themeConfig as ThemeConfig;
+  const options = themeConfig.api;
 
-  DocItem = function DocItem(props: Props): JSX.Element {
-    const docHtmlClassName = `docs-doc-id-${props.content.metadata.unversionedId}`;
-    const MDXComponent = props.content;
-    const { frontMatter } = MDXComponent;
-    const { info_path: infoPath } = frontMatter as DocFrontMatter;
-    const { api } = frontMatter as ApiFrontMatter;
-    const { siteConfig } = useDocusaurusContext();
-    const themeConfig = siteConfig.themeConfig as ThemeConfig;
-    const options = themeConfig.api;
-
+  const DocContent = () => {
     const acceptArray = Array.from(
       new Set(
         Object.values(api?.responses ?? {})
@@ -92,7 +91,10 @@ if (ExecutionEnvironment.canUseDOM) {
     const serverObject = (JSON.parse(server!) as ServerObject) ?? {};
     const store2 = createStoreWithState(
       {
-        accept: { value: acceptValue || acceptArray[0], options: acceptArray },
+        accept: {
+          value: acceptValue || acceptArray[0],
+          options: acceptArray,
+        },
         contentType: {
           value: contentTypeValue || contentTypeArray[0],
           options: contentTypeArray,
@@ -108,9 +110,8 @@ if (ExecutionEnvironment.canUseDOM) {
       },
       [persistanceMiddleware]
     );
-
-    const DocContent = () => {
-      return (
+    return (
+      <Provider store={store2}>
         <div className="row">
           <div className={clsx("col", api ? "col--7" : "col--12")}>
             <MDXComponent />
@@ -121,22 +122,40 @@ if (ExecutionEnvironment.canUseDOM) {
             </div>
           )}
         </div>
-      );
-    };
-
-    return (
-      <Provider store={store2}>
-        <DocProvider content={props.content}>
-          <HtmlClassNameProvider className={docHtmlClassName}>
-            <DocItemMetadata />
-            <DocItemLayout>
-              <DocContent />
-            </DocItemLayout>
-          </HtmlClassNameProvider>
-        </DocProvider>
       </Provider>
     );
   };
-}
 
-export default DocItem;
+  if (api) {
+    return (
+      <DocProvider content={props.content}>
+        <HtmlClassNameProvider className={docHtmlClassName}>
+          <DocItemMetadata />
+          <DocItemLayout>
+            {
+              <BrowserOnly fallback={<div />}>
+                {() => {
+                  return <DocContent />;
+                }}
+              </BrowserOnly>
+            }
+          </DocItemLayout>
+        </HtmlClassNameProvider>
+      </DocProvider>
+    );
+  }
+  return (
+    <DocProvider content={props.content}>
+      <HtmlClassNameProvider className={docHtmlClassName}>
+        <DocItemMetadata />
+        <DocItemLayout>
+          <div className="row">
+            <div className={clsx("col col--12")}>
+              <MDXComponent />
+            </div>
+          </div>
+        </DocItemLayout>
+      </HtmlClassNameProvider>
+    </DocProvider>
+  );
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -50,7 +50,7 @@ export default function ApiItem(props: Props): JSX.Element {
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;
 
-  const DocContent = () => {
+  const ApiDocContent = () => {
     const acceptArray = Array.from(
       new Set(
         Object.values(api?.responses ?? {})
@@ -58,18 +58,15 @@ export default function ApiItem(props: Props): JSX.Element {
           .flat()
       )
     );
-
     const content = api?.requestBody?.content ?? {};
     const contentTypeArray = Object.keys(content);
     const servers = api?.servers ?? [];
-
     const params = {
       path: [] as ParameterObject[],
       query: [] as ParameterObject[],
       header: [] as ParameterObject[],
       cookie: [] as ParameterObject[],
     };
-
     api?.parameters?.forEach(
       (param: { in: "path" | "query" | "header" | "cookie" }) => {
         const paramType = param.in;
@@ -77,18 +74,17 @@ export default function ApiItem(props: Props): JSX.Element {
         paramsArray.push(param as ParameterObject);
       }
     );
-
     const auth = createAuth({
       security: api?.security,
       securitySchemes: api?.securitySchemes,
       options,
     });
-
-    const persistanceMiddleware = createPersistanceMiddleware(options);
     const acceptValue = window?.sessionStorage.getItem("accept");
     const contentTypeValue = window?.sessionStorage.getItem("contentType");
     const server = window?.sessionStorage.getItem("server");
     const serverObject = (JSON.parse(server!) as ServerObject) ?? {};
+
+    const persistanceMiddleware = createPersistanceMiddleware(options);
     const store2 = createStoreWithState(
       {
         accept: {
@@ -110,6 +106,7 @@ export default function ApiItem(props: Props): JSX.Element {
       },
       [persistanceMiddleware]
     );
+
     return (
       <Provider store={store2}>
         <div className="row">
@@ -127,6 +124,7 @@ export default function ApiItem(props: Props): JSX.Element {
   };
 
   if (api) {
+    // TODO: determine if there's a way to SSR and hydrate ApiItem/ApiDemoPanel
     return (
       <DocProvider content={props.content}>
         <HtmlClassNameProvider className={docHtmlClassName}>
@@ -135,7 +133,7 @@ export default function ApiItem(props: Props): JSX.Element {
             {
               <BrowserOnly fallback={<div />}>
                 {() => {
-                  return <DocContent />;
+                  return <ApiDocContent />;
                 }}
               </BrowserOnly>
             }
@@ -144,6 +142,7 @@ export default function ApiItem(props: Props): JSX.Element {
       </DocProvider>
     );
   }
+  // Non-API docs
   return (
     <DocProvider content={props.content}>
       <HtmlClassNameProvider className={docHtmlClassName}>


### PR DESCRIPTION
## Description

Wraps API doc items in `BrowserOnly` to prevent SSR issues while conditionally pre-rendering non-API docs.

(Notice the TOC doesn't render on first load)

https://user-images.githubusercontent.com/9343811/198031260-6d5cd9de-225f-4252-8647-0fe5061ea707.mov

> Note: this has the side-effect of making API docs CSR only, which could negatively impact SEO. Will continue to work on ways to SSR + hydrate API docs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
