### PR TITLE
[Bug] Support SSR for ApiItem

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -746,7 +746,8 @@ export function createResponseSchema({ title, body, ...rest }: Props) {
           value: `${mimeType}`,
           children: [
             create("SchemaTabs", {
-              groupId: "schema-tabs",
+              // TODO: determine if we should persist this
+              // groupId: "schema-tabs",
               children: [
                 firstBody &&
                   create("TabItem", {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
@@ -40,6 +40,7 @@ export function createPersistanceMiddleware(options: ThemeConfig["api"]) {
         }
       }
 
+      // TODO: determine way to rehydrate without flashing
       // if (action.type === "contentType/setContentType") {
       //   storage.setItem("contentType", action.payload);
       // }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
@@ -40,13 +40,13 @@ export function createPersistanceMiddleware(options: ThemeConfig["api"]) {
         }
       }
 
-      if (action.type === "contentType/setContentType") {
-        storage.setItem("contentType", action.payload);
-      }
+      // if (action.type === "contentType/setContentType") {
+      //   storage.setItem("contentType", action.payload);
+      // }
 
-      if (action.type === "accept/setAccept") {
-        storage.setItem("accept", action.payload);
-      }
+      // if (action.type === "accept/setAccept") {
+      //   storage.setItem("accept", action.payload);
+      // }
 
       if (action.type === "server/setServer") {
         storage.setItem("server", action.payload);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -127,7 +127,7 @@ export default function ApiItem(props: Props): JSX.Element {
                   <MDXComponent />
                 </div>
                 <div className="col col--5">
-                  <ApiDemoPanel item={api} infoPath={infoPath} />
+                  {isBrowser && <ApiDemoPanel item={api} infoPath={infoPath} />}
                 </div>
               </div>
             </Provider>
@@ -136,6 +136,7 @@ export default function ApiItem(props: Props): JSX.Element {
       </DocProvider>
     );
   }
+
   // Non-API docs
   return (
     <DocProvider content={props.content}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -88,6 +88,7 @@ export default function ApiItem(props: Props): JSX.Element {
       securitySchemes: api?.securitySchemes,
       options,
     });
+    // TODO: determine way to rehydrate without flashing
     // const acceptValue = window?.sessionStorage.getItem("accept");
     // const contentTypeValue = window?.sessionStorage.getItem("contentType");
     const server = window?.sessionStorage.getItem("server");

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -116,7 +116,6 @@ export default function ApiItem(props: Props): JSX.Element {
   }
 
   if (api) {
-    // TODO: determine if there's a way to SSR and hydrate ApiItem/ApiDemoPanel
     return (
       <DocProvider content={props.content}>
         <HtmlClassNameProvider className={docHtmlClassName}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import BrowserOnly from "@docusaurus/BrowserOnly";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { HtmlClassNameProvider } from "@docusaurus/theme-common";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
@@ -87,19 +88,19 @@ export default function ApiItem(props: Props): JSX.Element {
       securitySchemes: api?.securitySchemes,
       options,
     });
-    const acceptValue = window?.sessionStorage.getItem("accept");
-    const contentTypeValue = window?.sessionStorage.getItem("contentType");
+    // const acceptValue = window?.sessionStorage.getItem("accept");
+    // const contentTypeValue = window?.sessionStorage.getItem("contentType");
     const server = window?.sessionStorage.getItem("server");
     const serverObject = (JSON.parse(server!) as ServerObject) ?? {};
 
     store2 = createStoreWithState(
       {
         accept: {
-          value: acceptValue || acceptArray[0],
+          value: acceptArray[0],
           options: acceptArray,
         },
         contentType: {
-          value: contentTypeValue || contentTypeArray[0],
+          value: contentTypeArray[0],
           options: contentTypeArray,
         },
         server: {
@@ -127,7 +128,11 @@ export default function ApiItem(props: Props): JSX.Element {
                   <MDXComponent />
                 </div>
                 <div className="col col--5">
-                  {isBrowser && <ApiDemoPanel item={api} infoPath={infoPath} />}
+                  <BrowserOnly fallback={<div>Loading...</div>}>
+                    {() => {
+                      return <ApiDemoPanel item={api} infoPath={infoPath} />;
+                    }}
+                  </BrowserOnly>
                 </div>
               </div>
             </Provider>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/store.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/store.ts
@@ -38,4 +38,15 @@ export const createStoreWithState = (
       getDefaultMiddleware().concat(...middlewares),
   });
 
+export const createStoreWithoutState = (
+  preloadedState: {},
+  middlewares: any[]
+) =>
+  configureStore({
+    reducer: rootReducer,
+    preloadedState,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(...middlewares),
+  });
+
 export type AppDispatch = ReturnType<typeof createStoreWithState>["dispatch"];


### PR DESCRIPTION
## Description

Re-introduces support for SSR of API docs. Effect is that only the first column under `ApiItem` will be SSR, meaning the `ApiDemoPanel` will continue to be CSR.

## Motivation and Context

Ability to SSR API docs will help improve SEO scores and provide greater support for third-party search engines.

## How Has This Been Tested?

Test with deploy preview. Disable javascript to test SSR.