### PR TITLE
[Bug] Use find instead of include to match tags

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -110,7 +110,7 @@ function groupByTags(
     .map((tag) => {
       // Map info object to tag
       const taggedInfoObject = intros.find((i) =>
-        i.tags ? i.tags.includes(tag) : undefined
+        i.tags ? i.tags.find((t: any) => t.name === tag) : undefined
       );
       const tagObject = tags.flat().find(
         (t) =>


### PR DESCRIPTION
## Description

Improper use of `includes` resulted in `taggedInfoObject` being `undefined`. This, in turn, led to a broken `link` config when setting `categoryLinkSource` to "info", which, in turn, resulted in `info` docs not associated to a sidebar.

Before:

```javascript
      const taggedInfoObject = intros.find((i) =>
        i.tags ? i.tags.includes(tag) : undefined
      );
```

After:

```javascript
      const taggedInfoObject = intros.find((i) =>
        i.tags ? i.tags.find((t: any) => t.name === tag) : undefined
      );
```
## Motivation and Context

bug fix

## How Has This Been Tested?

tested with MT Monitor API using multi-spec

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/9343811/199828973-344dbfe1-8c5d-44ca-85a4-4ac08a08d011.mov

