### PR TITLE
[Bug] Check if plugin is array before accessing first index

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -30,18 +30,24 @@ export function getDocsPluginConfig(
   // eslint-disable-next-line array-callback-return
   const filteredConfig = presetsPlugins.filter((data) => {
     // Search presets
-    if (data[0].endsWith(pluginId)) {
-      return data[1];
-    }
-
-    // Search plugin-content-docs instances
-    if (data[0] === "@docusaurus/plugin-content-docs") {
-      const configPluginId = data[1].id ? data[1].id : "default";
-      if (configPluginId === pluginId) {
+    if (Array.isArray(data)) {
+      if (typeof data[0] === "string" && data[0].endsWith(pluginId)) {
         return data[1];
+      }
+
+      // Search plugin-content-docs instances
+      if (
+        typeof data[0] === "string" &&
+        data[0] === "@docusaurus/plugin-content-docs"
+      ) {
+        const configPluginId = data[1].id ? data[1].id : "default";
+        if (configPluginId === pluginId) {
+          return data[1];
+        }
       }
     }
   })[0];
+
   if (filteredConfig) {
     // Search presets, e.g. "classic"
     if (filteredConfig[0].endsWith(pluginId)) {


### PR DESCRIPTION
## Description

This change checks that the plugin is defined as an `Array` before attempting to access the first index.

See #315 for background

Valid plugin config variations:

```javascript
{
  plugins: [
    ["@docusaurus/plugin-content-docs",options],
    "./myPlugin",
    ["./myPlugin",{someOption: 42}],
    function myPlugin() { },
    [function myPlugin() { },options]
  ],
};
```

> Basically, the `getDocsPluginConfig()` function previously assumed that `plugins` would be defined as arrays. Since plugins may also be `functions` (defined locally) or `strings` this resulted in an error when we attempted to access the first index.