### PR TITLE
[Bug] SchemaTabs arrows not rendering for response examples

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -147,12 +147,21 @@ function SchemaTabsComponent(props) {
   const [showTabArrows, setShowTabArrows] = useState(false);
 
   useEffect(() => {
-    const tabOffsetWidth = tabItemListContainerRef.current.offsetWidth;
-    const tabScrollWidth = tabItemListContainerRef.current.scrollWidth;
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        if (entry.target.offsetWidth < entry.target.scrollWidth) {
+          setShowTabArrows(true);
+        } else {
+          setShowTabArrows(false);
+        }
+      }
+    });
 
-    if (tabOffsetWidth < tabScrollWidth) {
-      setShowTabArrows(true);
-    }
+    resizeObserver.observe(tabItemListContainerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
   }, []);
 
   const handleRightClick = () => {


### PR DESCRIPTION
## Description

This PR consists of fixing `SchemaTabs` arrows not being rendered for Response examples. Currently, arrows are rendered when `SchemaTabs` are first mounted and satisfy the condition that `tabOffsetWidth < tabScrollWidth`. The issue is that this condition only applies to the first `SchemaTabs` ref and does not carry on to subsequent tabs with their respective `tabOffsetWidth` and `tabScrollWidth` values. To remedy this, the [ResizeObserver API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is used to accurately capture each `SchemaTabs` ref and their respective `tabOffsetWidth` and `tabScrollWidth` values.

## How Has This Been Tested?

Tested with Prisma Access Configuration API: 
- Tab through different response status codes and ensure arrows render on both sides of example tabs when necessary

## Screenshots (if appropriate)

### Before: 

https://user-images.githubusercontent.com/48506502/199889581-ae2d9cf8-a548-4348-bd1a-c9904edd2578.mov

### After: 

### Desktop | macOS | Chrome
https://user-images.githubusercontent.com/48506502/199889662-03293daf-62c9-497a-92b6-07fd8b32ea4d.mov

### Mobile | macOS | iOS Simulator
<img width="1421" alt="Screen Shot 2022-11-03 at 9 54 53 PM" src="https://user-images.githubusercontent.com/48506502/199890936-cadbdbd1-e36a-4525-ab4f-09bfb995b183.png">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
