### PR TITLE
[Bug] Prevent ApiDemoPanel collapse for invalid requests

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
@@ -112,6 +112,7 @@ function Execute({ postman, proxy }: Props) {
       <button
         className="button button--sm button--secondary"
         disabled={!isValidRequest}
+        style={!isValidRequest ? { pointerEvents: "all" } : {}}
         onClick={async () => {
           dispatch(setResponse("Fetching..."));
           try {


### PR DESCRIPTION
## Description

This PR addresses the issue of collapsing `ApiDemoPanel` when the user tries to submit an invalid request (ie. leaving required fields blank) through the 'Send API Request' button. 

> Note: Further implementation for handling input field validations is the ideal solution and will be introduced in a later PR, as this solution only prevents collapsing of the `ApiDemoPanel`.

## Motivation and Context

See #316

## How Has This Been Tested?

Tested locally with [Petstore API | Find pet by ID](https://docusaurus-openapi-36b86--pr331-03i8bi4p.web.app/petstore/get-pet-by-id)

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/48506502/200649522-c38647b4-3a4d-48b3-af8d-9c90ad8312fd.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
