### PR TITLE
Update posixPath to wrap path.join to fix backslash issue when buildi…

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -9,7 +9,7 @@ import fs from "fs";
 import path from "path";
 
 import type { LoadContext, Plugin } from "@docusaurus/types";
-import { Globby } from "@docusaurus/utils";
+import { Globby, posixPath } from "@docusaurus/utils";
 import chalk from "chalk";
 import { render } from "mustache";
 
@@ -338,7 +338,7 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
   async function cleanApiDocs(options: APIOptions) {
     const { outputDir } = options;
-    const apiDir = path.join(siteDir, outputDir);
+    const apiDir = posixPath(path.join(siteDir, outputDir));
     const apiMdxFiles = await Globby(["*.api.mdx", "*.info.mdx", "*.tag.mdx"], {
       cwd: path.resolve(apiDir),
       deep: 1,

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -7,6 +7,7 @@
 
 import path from "path";
 
+import { posixPath } from "@docusaurus/utils";
 import { readOpenapiFiles } from ".";
 
 // npx jest packages/docusaurus-plugin-openapi/src/openapi/openapi.test.ts --watch
@@ -15,7 +16,7 @@ describe("openapi", () => {
   describe("readOpenapiFiles", () => {
     it("readOpenapiFiles", async () => {
       const results = await readOpenapiFiles(
-        path.join(__dirname, "__fixtures__/examples"),
+        posixPath(path.join(__dirname, "__fixtures__/examples")),
         { specPath: "./", outputDir: "./" }
       );
       const categoryMeta = results.find((x) =>

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -8,6 +8,7 @@
 import path from "path";
 
 import { posixPath } from "@docusaurus/utils";
+
 import { readOpenapiFiles } from ".";
 
 // npx jest packages/docusaurus-plugin-openapi/src/openapi/openapi.test.ts --watch

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -7,7 +7,7 @@
 
 import path from "path";
 
-import { Globby, GlobExcludeDefault } from "@docusaurus/utils";
+import { Globby, GlobExcludeDefault, posixPath } from "@docusaurus/utils";
 import Converter from "@paloaltonetworks/openapi-to-postmanv2";
 import sdk from "@paloaltonetworks/postman-collection";
 import Collection from "@paloaltonetworks/postman-collection";
@@ -320,7 +320,7 @@ export async function readOpenapiFiles(
       return Promise.all(
         sources.map(async (source) => {
           // TODO: make a function for this
-          const fullPath = path.join(openapiPath, source);
+          const fullPath = posixPath(path.join(openapiPath, source));
           const data = (await loadAndResolveSpec(
             fullPath
           )) as unknown as OpenApiObject;

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -13,6 +13,7 @@ import {
   SidebarItemCategoryLinkConfig,
   SidebarItemDoc,
 } from "@docusaurus/plugin-content-docs/src/sidebars/types";
+import { posixPath } from "@docusaurus/utils";
 import clsx from "clsx";
 import { kebabCase } from "lodash";
 import uniq from "lodash/uniq";
@@ -24,8 +25,6 @@ import type {
   ApiPageMetadata,
   ApiMetadata,
 } from "../types";
-
-import { posixPath } from "@docusaurus/utils";
 
 function isApiItem(item: ApiMetadata): item is ApiMetadata {
   return item.type === "api";

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -25,6 +25,8 @@ import type {
   ApiMetadata,
 } from "../types";
 
+import { posixPath } from "@docusaurus/utils";
+
 function isApiItem(item: ApiMetadata): item is ApiMetadata {
   return item.type === "api";
 }
@@ -148,8 +150,15 @@ function groupByTags(
           type: "generated-index" as "generated-index",
           title: tag,
           slug: label
-            ? path.join("/category", basePath, kebabCase(label), kebabCase(tag))
-            : path.join("/category", basePath, kebabCase(tag)),
+            ? posixPath(
+                path.join(
+                  "/category",
+                  basePath,
+                  kebabCase(label),
+                  kebabCase(tag)
+                )
+              )
+            : posixPath(path.join("/category", basePath, kebabCase(tag))),
         } as SidebarItemCategoryLinkConfig;
       }
 


### PR DESCRIPTION
Update posixPath to wrap path.join to fix backslash issue when building on Windows

## Description

windows path.join merged with \ instead of / which broke some pages

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
