### PR TITLE
Prepare release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.4.3 (Nov 9, 2022)
+
+High level enhancements
+
+- Added support for Algolia DocSearch
+
+Other enhancements and bug fixes
+
+- Update posixPath to wrap path.join to fix backslash issue when buildi… ([#332](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/332))
+- Add pointer events styling to Execute button for invalid requests ([#331](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/331))
+- Add algolia config ([#328](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/328))
+
 ## 1.4.2 (Nov 4, 2022)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -27,8 +27,8 @@
     "@docusaurus/preset-classic": "^2.0.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.4.2",
-    "docusaurus-theme-openapi-docs": "^1.4.2",
+    "docusaurus-plugin-openapi-docs": "^1.4.3",
+    "docusaurus-theme-openapi-docs": "^1.4.3",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.2",
+  "version": "1.4.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -51,7 +51,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.4.2",
+    "docusaurus-plugin-openapi-docs": "^1.4.3",
     "file-saver": "^2.0.5",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",


### PR DESCRIPTION
## Description

## v1.4.3 (Nov 9, 2022)

High level enhancements

- Added support for Algolia DocSearch

Other enhancements and bug fixes

- Update posixPath to wrap path.join to fix backslash issue when buildi… ([#332](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/332))
- Prevent ApiDemoPanel collapse for invalid requests ([#331](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/331))
- Add algolia config ([#328](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/328))



