### PR TITLE
Fix error when allOf two refs

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -26,8 +26,8 @@ export function mergeAllOf(allOf: SchemaObject[]) {
       example: function () {
         return true;
       },
-      'x-examples': function () {
-          return true;
+      "x-examples": function () {
+        return true;
       },
       ignoreAdditionalProperties: true,
     },

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -26,6 +26,9 @@ export function mergeAllOf(allOf: SchemaObject[]) {
       example: function () {
         return true;
       },
+      'x-examples': function () {
+          return true;
+      },
       ignoreAdditionalProperties: true,
     },
   });

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -31,6 +31,9 @@ export function mergeAllOf(allOf: SchemaObject[]) {
       example: function () {
         return true;
       },
+      'x-examples': function () {
+          return true;
+      },
     },
     ignoreAdditionalProperties: true,
   });

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -31,8 +31,8 @@ export function mergeAllOf(allOf: SchemaObject[]) {
       example: function () {
         return true;
       },
-      'x-examples': function () {
-          return true;
+      "x-examples": function () {
+        return true;
       },
     },
     ignoreAdditionalProperties: true,


### PR DESCRIPTION
## Description

Add `x-examples` resolver for json-schema-merge-allof

## Motivation and Context
Generate throw error: 
```
WARNING: failed to create example from schema object: Error: No resolver found for key x-examples. You can provide a resolver for this keyword in the options, or provide a default resolver.
[ERROR] Error: No resolver found for key x-examples. You can provide a resolver for this keyword in the options, or provide a default resolver.
```
in this case
```yaml
Test:
  description: Test
  allOf:
    - $ref: '#/components/schemas/TestA'
    - $ref: '#/components/schemas/TestB'
  x-examples:
    Example:
      value:
        test1: false
        test2: false

TestA:
  type: object
  description: testA
  properties:
    test1:
      type: boolean
      example: false
  required:
    - test1
  x-examples:
    Example:
      value:
        test1: true

TestB:
  type: object
  description: TestB
  properties:
    test2:
      type: boolean
      example: false
  required:
    - test2
  x-examples:
    Example:
      value:
        test2: true
```

## How Has This Been Tested?

1. `yarn test` - success
2. Generate for my specification, which throw error before that


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
