### PR TITLE
[Bug] Handle double quotes in sidebar_label frontmatter

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -164,7 +164,7 @@ description: "{{{frontMatter.description}}}"
 sidebar_label: Introduction
 {{/api}}
 {{#api}}
-sidebar_label: {{{title}}}
+sidebar_label: "{{{title}}}"
 {{/api}}
 {{^api}}
 sidebar_position: 0
@@ -191,7 +191,7 @@ info_path: {{{infoPath}}}
 id: {{{id}}}
 title: "{{{title}}}"
 description: "{{{frontMatter.description}}}"
-sidebar_label: {{{title}}}
+sidebar_label: "{{{title}}}"
 hide_title: true
 custom_edit_url: null
 ---

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -131,7 +131,9 @@ function createItems(
       type: "info",
       id: infoId,
       unversionedId: infoId,
-      title: openapiData.info.title,
+      title: openapiData.info.title
+        ? openapiData.info.title.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
+        : "",
       description: openapiData.info.description
         ? openapiData.info.description.replace(
             /((?:^|[^\\])(?:\\{2})*)"/g,
@@ -237,7 +239,7 @@ function createItems(
         id: baseId,
         infoId: infoId ?? "",
         unversionedId: baseId,
-        title: title,
+        title: title ? title.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'") : "",
         description: operationObject.description
           ? operationObject.description.replace(
               /((?:^|[^\\])(?:\\{2})*)"/g,


### PR DESCRIPTION
## Description

This PR introduces better support for double quotes in `sidebar_label` frontmatter. The solution is to find and replace any double quotes in `title` with single quotes. Additionally, the mustache template was updated to always wrap the `sidebar_label` frontmatter in double quotes.

## Motivation and Context

See #337 for background

## How Has This Been Tested?

Tested with Petstore API

## Screenshots (if appropriate)

<img width="1482" alt="Screen Shot 2022-11-10 at 10 32 05 AM" src="https://user-images.githubusercontent.com/9343811/201137284-650becd9-4b9f-4799-a66e-b95fed6917b9.png">


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)