### PR TITLE
[Bug] Include global tags and tag docs only if referenced by operation

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -68,9 +68,13 @@ function groupByTags(
   );
 
   // Combine globally defined tags with operation tags
+  // Only include global tag if referenced in operation tags
   let apiTags: string[] = [];
   tags.flat().forEach((tag) => {
-    apiTags.push(tag.name!);
+    // Should we also check x-displayName?
+    if (operationTags.includes(tag.name!)) {
+      apiTags.push(tag.name!);
+    }
   });
   apiTags = uniq(apiTags.concat(operationTags));
 


### PR DESCRIPTION
## Description

See #323 thread for background. Essentially, the plugin was creating tag docs for tags not actually referenced by an operation. This resulted in "orphaned" docs or docs without a sidebar which led to build errors.

The fix is to cross-check that a global/root tag is actually referenced in an operation prior to creating the tag doc item. A similar logic was applied to sidebars for consistency.