### PR TITLE
[Bug] Add condition for handling arrays of discriminators

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -104,16 +104,16 @@ function createAnyOneOf(schema: SchemaObject): any {
 
 function createProperties(schema: SchemaObject) {
   const discriminator = schema.discriminator;
-  return Object.entries(schema.properties!).map(([key, val]) =>
-    createEdges({
+  return Object.entries(schema.properties!).map(([key, val]) => {
+    return createEdges({
       name: key,
       schema: val,
       required: Array.isArray(schema.required)
         ? schema.required.includes(key)
         : false,
       discriminator,
-    })
-  );
+    });
+  });
 }
 
 function createAdditionalProperties(schema: SchemaObject) {
@@ -610,6 +610,10 @@ function createEdges({
 
   // array of objects
   if (schema.items?.properties !== undefined) {
+    return createDetailsNode(name, schemaName, schema, required);
+  }
+
+  if (schema.items?.anyOf !== undefined || schema.items?.oneOf !== undefined) {
     return createDetailsNode(name, schemaName, schema, required);
   }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -109,16 +109,16 @@ function createAnyOneOf(schema: SchemaObject): any {
 
 function createProperties(schema: SchemaObject) {
   const discriminator = schema.discriminator;
-  return Object.entries(schema.properties!).map(([key, val]) =>
-    createEdges({
+  return Object.entries(schema.properties!).map(([key, val]) => {
+    return createEdges({
       name: key,
       schema: val,
       required: Array.isArray(schema.required)
         ? schema.required.includes(key)
         : false,
       discriminator,
-    })
-  );
+    });
+  });
 }
 
 function createAdditionalProperties(schema: SchemaObject) {
@@ -610,6 +610,10 @@ function createEdges({
 
   // array of objects
   if (schema.items?.properties !== undefined) {
+    return createDetailsNode(name, schemaName, schema, required);
+  }
+
+  if (schema.items?.anyOf !== undefined || schema.items?.oneOf !== undefined) {
     return createDetailsNode(name, schemaName, schema, required);
   }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/styles.module.css
@@ -12,14 +12,19 @@
   height: 1.8rem;
   margin-top: 0 !important;
   margin-right: 0.5rem;
-  border: 1px solid var(--openapi-code-dim-dark);
+  border: 1px solid var(--ifm-color-primary);
   border-radius: var(--ifm-global-radius);
-  color: var(--openapi-code-dim-dark);
+  color: var(--ifm-color-primary);
   font-size: 12px;
 }
 
+.tabItem:not(.discriminatorTabActive) {
+  opacity: 0.65;
+}
+
 .tabItem:hover {
-  color: var(--ifm-color-emphasis-500) !important;
+  opacity: 1;
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .tabItem:last-child {
@@ -59,8 +64,7 @@
 }
 
 .tabItem.discriminatorTabActive {
-  border: 1px solid var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
+  background-color: var(--ifm-color-emphasis-100);
 }
 
 .discriminatorTabLabel {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -14,6 +14,7 @@
   --openapi-card-background-color: var(--ifm-color-gray-100);
   --openapi-card-border-radius: var(--ifm-pre-border-radius);
   --openapi-input-border: var(--ifm-color-primary);
+  --openapi-input-background: var(--openapi-card-background-color);
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
## Description

* Adds support for `items.anyOf` and `items.oneOf`
* Adds missing return statement in `createProperties` that would have prevented `properties` from rendering in some cases

### Additional Changes

* Adds missing `--openapi-input-background` variable to `styles.css`
* Matches discriminator tab styles to schema tab styles for consistency

## Motivation and Context

Addresses #343 

## How Has This Been Tested?

Tested with OpenAPI snippet shared in #343 

## Screenshots (if appropriate)

See deploy preview and #343 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)