### PR TITLE
[Experimental] Improve support for swizzling theme components

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -99,6 +99,7 @@ export interface ApiItem extends OperationObject {
     [key: string]: SecuritySchemeObject;
   };
   postman?: Request;
+  proxy?: string;
   info: InfoObject;
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
@@ -67,13 +67,17 @@ declare module "@theme/ApiDemoPanel/Accept" {
   export default function Accept(): JSX.Element;
 }
 
+declare module "@theme/ApiDemoPanel/Accept/slice" {
+  export default accept as Reducer<State, AnyAction>;
+}
+
 declare module "@theme/ApiDemoPanel/Authorization" {
   export default function Authorization(): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/Authorization/slice" {
   export { AuthState, Scheme, setAuthData, setSelectedAuth, createAuth };
-  export default function Authorization(): JSX.Element;
+  export default auth as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/Body" {
@@ -87,10 +91,11 @@ declare module "@theme/ApiDemoPanel/Body/json2xml" {
 }
 
 declare module "@theme/ApiDemoPanel/Body/slice" {
-  import { Body, Content } from "@theme/ApiDemoPanel/Body/slice";
+  import { Body, Content, State } from "@theme/ApiDemoPanel/Body/slice";
 
-  export { Body, Content };
+  export { Body, Content, State };
   export function setStringRawBody(any, any?): any;
+  export default body as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/buildPostmanRequest" {
@@ -105,6 +110,10 @@ declare module "@theme/ApiDemoPanel/CodeTabs" {
 
 declare module "@theme/ApiDemoPanel/ContentType" {
   export default function ContentType(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/ContentType/slice" {
+  export default contentType as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/Curl" {
@@ -182,6 +191,7 @@ declare module "@theme/ApiDemoPanel/ParamOptions" {
 
 declare module "@theme/ApiDemoPanel/ParamOptions/slice" {
   export type { Param };
+  export default params as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/persistanceMiddleware" {
@@ -203,6 +213,7 @@ declare module "@theme/ApiDemoPanel/Response" {
 
 declare module "@theme/ApiDemoPanel/Response/slice" {
   export { setResponse };
+  export default response as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/SecuritySchemes" {
@@ -211,6 +222,10 @@ declare module "@theme/ApiDemoPanel/SecuritySchemes" {
 
 declare module "@theme/ApiDemoPanel/Server" {
   export default function Server(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Server/slice" {
+  export default server as Reducer<State, AnyAction>;
 }
 
 declare module "@theme/ApiDemoPanel/storage-utils" {

--- a/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
@@ -113,6 +113,7 @@ declare module "@theme/ApiDemoPanel/ContentType" {
 }
 
 declare module "@theme/ApiDemoPanel/ContentType/slice" {
+  export { setContentType };
   export default contentType as Reducer<State, AnyAction>;
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
@@ -46,3 +46,120 @@ declare module "@docusaurus/plugin-content-docs-types" {
 declare module "docusaurus-theme-openapi-docs" {
   export type ThemeConfig = Partial<import("./types").ThemeConfig>;
 }
+
+declare module "@theme/ApiItem/hooks" {
+  export { useTypedDispatch, useTypedSelector };
+}
+
+declare module "@theme/SchemaTabs" {
+  export default function SchemaTabs(props: any): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Accept" {
+  export default function Accept(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Authorization" {
+  export default function Authorization(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Body" {
+  import { Props as BodyProps } from "@theme/ApiDemoPanel/Body";
+  export default function Body(props: BodyProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Body/json2xml" {
+  export default function json2xml(any, any?): any;
+}
+
+declare module "@theme/ApiDemoPanel/CodeTabs" {
+  import { Props as CodeTabsProps } from "@theme/ApiDemoPanel/CodeTabs";
+  export default function CodeTabs(props: CodeTabsProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/ContentType" {
+  export default function ContentType(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Curl" {
+  import { Props as CurlProps } from "@theme/ApiDemoPanel/Curl";
+  export { languageSet, Language } from "@theme/ApiDemoPanel/Curl";
+  export default function Curl(props: CurlProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FloatingButton" {
+  import { Props as FloatingButtonProps } from "@theme/ApiDemoPanel/FloatingButton";
+  export default function FloatingButton(
+    props: FloatingButtonProps
+  ): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FormItem" {
+  import { Props as FormItemProps } from "@theme/ApiDemoPanel/FormItem";
+  export default function FormItem(props: FormItemProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FormSelect" {
+  import { Props as FormSelectProps } from "@theme/ApiDemoPanel/FormSelect";
+  export default function FormSelect(props: FormSelectProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FormTextInput" {
+  import { Props as FormTextInputProps } from "@theme/ApiDemoPanel/FormTextInput";
+  export default function FormTextInput(props: FormTextInputProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FormFileUpload" {
+  import { Props as FormFileUploadProps } from "@theme/ApiDemoPanel/FormFileUpload";
+  export default function FormFileUpload(
+    props: FormFileUploadProps
+  ): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/FormMultiSelect" {
+  import { Props as FormMultiSelectProps } from "@theme/ApiDemoPanel/FormMultiSelect";
+  export default function FormMultiSelect(
+    props: FormMultiSelectProps
+  ): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Execute" {
+  import { Props as ExecuteProps } from "@theme/ApiDemoPanel/Execute";
+  export default function Execute(props: ExecuteProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/LiveEditor" {
+  export default function LiveEditor(props: any): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/MethodEndpoint" {
+  import { Props as MethodEndpointProps } from "@theme/ApiDemoPanel/MethodEndpoint";
+  export default function MethodEndpoint(
+    props: MethodEndpointProps
+  ): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/ParamOptions" {
+  import { ParamProps } from "@theme/ApiDemoPanel/ParamOptions";
+  export default function ParamOptions(props: ParamProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Request" {
+  import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+  export interface RequestProps {
+    item: NonNullable<ApiItem>;
+  }
+  export default function Request(props: RequestProps): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Response" {
+  export default function Response(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/SecuritySchemes" {
+  export default function SecuritySchemes(props: any): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/Server" {
+  export default function Server(): JSX.Element;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
@@ -65,6 +65,7 @@ declare module "@theme/ApiDemoPanel/Authorization" {
 
 declare module "@theme/ApiDemoPanel/Body" {
   import { Props as BodyProps } from "@theme/ApiDemoPanel/Body";
+
   export default function Body(props: BodyProps): JSX.Element;
 }
 
@@ -74,6 +75,7 @@ declare module "@theme/ApiDemoPanel/Body/json2xml" {
 
 declare module "@theme/ApiDemoPanel/CodeTabs" {
   import { Props as CodeTabsProps } from "@theme/ApiDemoPanel/CodeTabs";
+
   export default function CodeTabs(props: CodeTabsProps): JSX.Element;
 }
 
@@ -83,12 +85,14 @@ declare module "@theme/ApiDemoPanel/ContentType" {
 
 declare module "@theme/ApiDemoPanel/Curl" {
   import { Props as CurlProps } from "@theme/ApiDemoPanel/Curl";
+
   export { languageSet, Language } from "@theme/ApiDemoPanel/Curl";
   export default function Curl(props: CurlProps): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/FloatingButton" {
   import { Props as FloatingButtonProps } from "@theme/ApiDemoPanel/FloatingButton";
+
   export default function FloatingButton(
     props: FloatingButtonProps
   ): JSX.Element;
@@ -96,21 +100,25 @@ declare module "@theme/ApiDemoPanel/FloatingButton" {
 
 declare module "@theme/ApiDemoPanel/FormItem" {
   import { Props as FormItemProps } from "@theme/ApiDemoPanel/FormItem";
+
   export default function FormItem(props: FormItemProps): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/FormSelect" {
   import { Props as FormSelectProps } from "@theme/ApiDemoPanel/FormSelect";
+
   export default function FormSelect(props: FormSelectProps): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/FormTextInput" {
   import { Props as FormTextInputProps } from "@theme/ApiDemoPanel/FormTextInput";
+
   export default function FormTextInput(props: FormTextInputProps): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/FormFileUpload" {
   import { Props as FormFileUploadProps } from "@theme/ApiDemoPanel/FormFileUpload";
+
   export default function FormFileUpload(
     props: FormFileUploadProps
   ): JSX.Element;
@@ -118,6 +126,7 @@ declare module "@theme/ApiDemoPanel/FormFileUpload" {
 
 declare module "@theme/ApiDemoPanel/FormMultiSelect" {
   import { Props as FormMultiSelectProps } from "@theme/ApiDemoPanel/FormMultiSelect";
+
   export default function FormMultiSelect(
     props: FormMultiSelectProps
   ): JSX.Element;
@@ -125,6 +134,7 @@ declare module "@theme/ApiDemoPanel/FormMultiSelect" {
 
 declare module "@theme/ApiDemoPanel/Execute" {
   import { Props as ExecuteProps } from "@theme/ApiDemoPanel/Execute";
+
   export default function Execute(props: ExecuteProps): JSX.Element;
 }
 
@@ -134,6 +144,7 @@ declare module "@theme/ApiDemoPanel/LiveEditor" {
 
 declare module "@theme/ApiDemoPanel/MethodEndpoint" {
   import { Props as MethodEndpointProps } from "@theme/ApiDemoPanel/MethodEndpoint";
+
   export default function MethodEndpoint(
     props: MethodEndpointProps
   ): JSX.Element;
@@ -141,11 +152,13 @@ declare module "@theme/ApiDemoPanel/MethodEndpoint" {
 
 declare module "@theme/ApiDemoPanel/ParamOptions" {
   import { ParamProps } from "@theme/ApiDemoPanel/ParamOptions";
+
   export default function ParamOptions(props: ParamProps): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/Request" {
   import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+
   export interface RequestProps {
     item: NonNullable<ApiItem>;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-openapi.d.ts
@@ -51,6 +51,14 @@ declare module "@theme/ApiItem/hooks" {
   export { useTypedDispatch, useTypedSelector };
 }
 
+declare module "@theme/ApiItem/Layout" {
+  export default function Layout(props: any): JSX.Element;
+}
+
+declare module "@theme/ApiItem/store" {
+  export { AppDispatch, RootState };
+}
+
 declare module "@theme/SchemaTabs" {
   export default function SchemaTabs(props: any): JSX.Element;
 }
@@ -63,6 +71,11 @@ declare module "@theme/ApiDemoPanel/Authorization" {
   export default function Authorization(): JSX.Element;
 }
 
+declare module "@theme/ApiDemoPanel/Authorization/slice" {
+  export { AuthState, Scheme, setAuthData, setSelectedAuth, createAuth };
+  export default function Authorization(): JSX.Element;
+}
+
 declare module "@theme/ApiDemoPanel/Body" {
   import { Props as BodyProps } from "@theme/ApiDemoPanel/Body";
 
@@ -71,6 +84,17 @@ declare module "@theme/ApiDemoPanel/Body" {
 
 declare module "@theme/ApiDemoPanel/Body/json2xml" {
   export default function json2xml(any, any?): any;
+}
+
+declare module "@theme/ApiDemoPanel/Body/slice" {
+  import { Body, Content } from "@theme/ApiDemoPanel/Body/slice";
+
+  export { Body, Content };
+  export function setStringRawBody(any, any?): any;
+}
+
+declare module "@theme/ApiDemoPanel/buildPostmanRequest" {
+  export default function buildPostmanRequest(any, any?): any;
 }
 
 declare module "@theme/ApiDemoPanel/CodeTabs" {
@@ -156,6 +180,14 @@ declare module "@theme/ApiDemoPanel/ParamOptions" {
   export default function ParamOptions(props: ParamProps): JSX.Element;
 }
 
+declare module "@theme/ApiDemoPanel/ParamOptions/slice" {
+  export type { Param };
+}
+
+declare module "@theme/ApiDemoPanel/persistanceMiddleware" {
+  export { createPersistanceMiddleware };
+}
+
 declare module "@theme/ApiDemoPanel/Request" {
   import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
@@ -169,10 +201,18 @@ declare module "@theme/ApiDemoPanel/Response" {
   export default function Response(): JSX.Element;
 }
 
+declare module "@theme/ApiDemoPanel/Response/slice" {
+  export { setResponse };
+}
+
 declare module "@theme/ApiDemoPanel/SecuritySchemes" {
   export default function SecuritySchemes(props: any): JSX.Element;
 }
 
 declare module "@theme/ApiDemoPanel/Server" {
   export default function Server(): JSX.Element;
+}
+
+declare module "@theme/ApiDemoPanel/storage-utils" {
+  export { createStorage, hashArray };
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
@@ -8,8 +8,8 @@
 import React from "react";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import FormItem from "./../FormItem";
-import FormSelect from "./../FormSelect";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import { setAccept } from "./slice";
 
 function Accept() {
@@ -26,7 +26,7 @@ function Accept() {
       <FormSelect
         value={value}
         options={options}
-        onChange={(e) => dispatch(setAccept(e.target.value))}
+        onChange={(e: any) => dispatch(setAccept(e.target.value))}
       />
     </FormItem>
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
@@ -7,9 +7,10 @@
 
 import React from "react";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+
+import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setAccept } from "./slice";
 
 function Accept() {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Accept/index.tsx
@@ -9,13 +9,13 @@ import React from "react";
 
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setAccept } from "./slice";
 
 function Accept() {
-  const value = useTypedSelector((state) => state.accept.value);
-  const options = useTypedSelector((state) => state.accept.options);
+  const value = useTypedSelector((state: any) => state.accept.value);
+  const options = useTypedSelector((state: any) => state.accept.options);
   const dispatch = useTypedDispatch();
 
   if (options.length <= 1) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -10,14 +10,14 @@ import React from "react";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setAuthData, setSelectedAuth } from "./slice";
 
 function Authorization() {
-  const data = useTypedSelector((state) => state.auth.data);
-  const options = useTypedSelector((state) => state.auth.options);
-  const selected = useTypedSelector((state) => state.auth.selected);
+  const data = useTypedSelector((state: any) => state.auth.data);
+  const options = useTypedSelector((state: any) => state.auth.options);
+  const selected = useTypedSelector((state: any) => state.auth.selected);
 
   const dispatch = useTypedDispatch();
 
@@ -42,7 +42,7 @@ function Authorization() {
           />
         </FormItem>
       )}
-      {selectedAuth.map((a) => {
+      {selectedAuth.map((a: any) => {
         if (a.type === "http" && a.scheme === "bearer") {
           return (
             <FormItem label="Bearer Token" key={a.key + "-bearer"}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -7,10 +7,11 @@
 
 import React from "react";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+
+import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setAuthData, setSelectedAuth } from "./slice";
 
 function Authorization() {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -8,9 +8,9 @@
 import React from "react";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import FormItem from "../FormItem";
-import FormSelect from "../FormSelect";
-import FormTextInput from "../FormTextInput";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
 import { setAuthData, setSelectedAuth } from "./slice";
 
 function Authorization() {
@@ -35,7 +35,7 @@ function Authorization() {
           <FormSelect
             options={optionKeys}
             value={selected}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               dispatch(setSelectedAuth(e.target.value));
             }}
           />
@@ -48,7 +48,7 @@ function Authorization() {
               <FormTextInput
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
-                onChange={(e) => {
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value.trim();
                   dispatch(
                     setAuthData({
@@ -69,7 +69,7 @@ function Authorization() {
               <FormTextInput
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
-                onChange={(e) => {
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value.trim();
                   dispatch(
                     setAuthData({
@@ -91,7 +91,7 @@ function Authorization() {
                 <FormTextInput
                   placeholder="Username"
                   value={data[a.key].username ?? ""}
-                  onChange={(e) => {
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const value = e.target.value.trim();
                     dispatch(
                       setAuthData({
@@ -108,7 +108,7 @@ function Authorization() {
                   placeholder="Password"
                   password
                   value={data[a.key].password ?? ""}
-                  onChange={(e) => {
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const value = e.target.value.trim();
                     dispatch(
                       setAuthData({
@@ -130,7 +130,7 @@ function Authorization() {
               <FormTextInput
                 placeholder={`${a.key}`}
                 value={data[a.key].apiKey ?? ""}
-                onChange={(e) => {
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value.trim();
                   dispatch(
                     setAuthData({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/slice.ts
@@ -6,13 +6,14 @@
  * ========================================================================== */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createStorage, hashArray } from "@theme/ApiDemoPanel/storage-utils";
 import {
   SecurityRequirementObject,
   SecuritySchemeObject,
 } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
-import { ThemeConfig } from "../../../types";
-import { createStorage, hashArray } from "../storage-utils";
 import { getAuthDataKeys } from "./auth-types";
 
 // The global definitions

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -7,19 +7,19 @@
 
 import React from "react";
 
+import json2xml from "@theme/ApiDemoPanel/Body/json2xml";
+import ContentType from "@theme/ApiDemoPanel/ContentType";
+import FormFileUpload from "@theme/ApiDemoPanel/FormFileUpload";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+import LiveApp from "@theme/ApiDemoPanel/LiveEditor";
+import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import SchemaTabs from "@theme/SchemaTabs";
-import ContentType from "@theme/ApiDemoPanel/ContentType";
-import FormSelect from "@theme/ApiDemoPanel/FormSelect";
-import LiveApp from "@theme/ApiDemoPanel/LiveEditor";
-import FormFileUpload from "@theme/ApiDemoPanel/FormFileUpload";
-import FormItem from "@theme/ApiDemoPanel/FormItem";
-import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
-import json2xml from "@theme/ApiDemoPanel/Body/json2xml";
 import {
   clearFormBodyKey,
   clearRawBody,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -12,16 +12,14 @@ import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/ty
 import format from "xml-formatter";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-// @ts-ignore
-import SchemaTabs from "../../SchemaTabs";
-import ContentType from "../ContentType";
-import FormSelect from "../FormSelect";
-import LiveApp from "../LiveEditor";
-import FormFileUpload from "./../FormFileUpload";
-import FormItem from "./../FormItem";
-import FormTextInput from "./../FormTextInput";
-// @ts-ignore
-import json2xml from "./json2xml";
+import SchemaTabs from "@theme/SchemaTabs";
+import ContentType from "@theme/ApiDemoPanel/ContentType";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import LiveApp from "@theme/ApiDemoPanel/LiveEditor";
+import FormFileUpload from "@theme/ApiDemoPanel/FormFileUpload";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+import json2xml from "@theme/ApiDemoPanel/Body/json2xml";
 import {
   clearFormBodyKey,
   clearRawBody,
@@ -30,7 +28,7 @@ import {
   setStringFormBody,
 } from "./slice";
 
-interface Props {
+export interface Props {
   jsonRequestBodyExample: string;
   requestBodyMetadata?: RequestBodyObject;
 }
@@ -93,7 +91,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
       <FormItem label="Body" required={required}>
         <FormFileUpload
           placeholder={schema.description || "Body"}
-          onChange={(file) => {
+          onChange={(file: any) => {
             if (file === undefined) {
               dispatch(clearRawBody());
               return;
@@ -138,7 +136,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
                 >
                   <FormFileUpload
                     placeholder={val.description || key}
-                    onChange={(file) => {
+                    onChange={(file: any) => {
                       if (file === undefined) {
                         dispatch(clearFormBodyKey(key));
                         return;
@@ -170,7 +168,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
                 >
                   <FormSelect
                     options={["---", ...val.enum]}
-                    onChange={(e) => {
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                       const val = e.target.value;
                       if (val === "---") {
                         dispatch(clearFormBodyKey(key));
@@ -199,7 +197,7 @@ function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
               >
                 <FormTextInput
                   placeholder={val.description || key}
-                  onChange={(e) => {
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     dispatch(
                       setStringFormBody({ key: key, value: e.target.value })
                     );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Body/index.tsx
@@ -14,12 +14,12 @@ import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
 import LiveApp from "@theme/ApiDemoPanel/LiveEditor";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import {
   clearFormBodyKey,
   clearRawBody,
@@ -34,7 +34,7 @@ export interface Props {
 }
 
 function BodyWrap({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
-  const contentType = useTypedSelector((state) => state.contentType.value);
+  const contentType = useTypedSelector((state: any) => state.contentType.value);
 
   // NOTE: We used to check if body was required, but opted to always show the request body
   // to reduce confusion, see: https://github.com/cloud-annotations/docusaurus-openapi/issues/145
@@ -56,7 +56,7 @@ function BodyWrap({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
 }
 
 function Body({ requestBodyMetadata, jsonRequestBodyExample }: Props) {
-  const contentType = useTypedSelector((state) => state.contentType.value);
+  const contentType = useTypedSelector((state: any) => state.contentType.value);
   const required = requestBodyMetadata?.required;
 
   const dispatch = useTypedDispatch();

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
@@ -14,12 +14,12 @@ import React, {
 
 import { duplicates } from "@docusaurus/theme-common";
 import useIsBrowser from "@docusaurus/useIsBrowser";
+import { languageSet } from "@theme/ApiDemoPanel/Curl";
+import { Language } from "@theme/ApiDemoPanel/Curl";
 import type { Props as TabItemProps } from "@theme/TabItem";
 import clsx from "clsx";
 
-import { languageSet } from "@theme/ApiDemoPanel/Curl";
 import styles from "./styles.module.css";
-import { Language } from "@theme/ApiDemoPanel/Curl";
 
 const {
   useScrollPositionBlocker,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
@@ -17,8 +17,9 @@ import useIsBrowser from "@docusaurus/useIsBrowser";
 import type { Props as TabItemProps } from "@theme/TabItem";
 import clsx from "clsx";
 
-import { languageSet } from "../Curl";
+import { languageSet } from "@theme/ApiDemoPanel/Curl";
 import styles from "./styles.module.css";
+import { Language } from "@theme/ApiDemoPanel/Curl";
 
 const {
   useScrollPositionBlocker,
@@ -133,7 +134,7 @@ function TabsComponent(props: Props): JSX.Element {
       setSelectedValue(newTabValue);
       if (action) {
         const newLanguage = languageSet.filter(
-          (lang) => lang.language === newTabValue
+          (lang: Language) => lang.language === newTabValue
         );
         action(newLanguage[0]);
       }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
@@ -7,9 +7,10 @@
 
 import React from "react";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+
+import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setContentType } from "./slice";
 
 function ContentType() {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
@@ -8,8 +8,8 @@
 import React from "react";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import FormItem from "./../FormItem";
-import FormSelect from "./../FormSelect";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import { setContentType } from "./slice";
 
 function ContentType() {
@@ -26,7 +26,9 @@ function ContentType() {
       <FormSelect
         value={value}
         options={options}
-        onChange={(e) => dispatch(setContentType(e.target.value))}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          dispatch(setContentType(e.target.value))
+        }
       />
     </FormItem>
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ContentType/index.tsx
@@ -9,13 +9,13 @@ import React from "react";
 
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setContentType } from "./slice";
 
 function ContentType() {
-  const value = useTypedSelector((state) => state.contentType.value);
-  const options = useTypedSelector((state) => state.contentType.options);
+  const value = useTypedSelector((state: any) => state.contentType.value);
+  const options = useTypedSelector((state: any) => state.contentType.options);
   const dispatch = useTypedDispatch();
 
   if (options.length <= 1) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -10,12 +10,12 @@ import React, { useState, useEffect } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import codegen from "@paloaltonetworks/postman-code-generators";
 import sdk from "@paloaltonetworks/postman-collection";
+import buildPostmanRequest from "@theme/ApiDemoPanel/buildPostmanRequest";
 import CodeTabs from "@theme/ApiDemoPanel/CodeTabs";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
 import CodeBlock from "@theme/CodeBlock";
 import clsx from "clsx";
 
-import { useTypedSelector } from "../../ApiItem/hooks";
-import buildPostmanRequest from "./../buildPostmanRequest";
 import styles from "./styles.module.css";
 
 export interface Language {
@@ -124,17 +124,17 @@ function Curl({ postman, codeSamples }: Props) {
 
   const { siteConfig } = useDocusaurusContext();
 
-  const contentType = useTypedSelector((state) => state.contentType.value);
-  const accept = useTypedSelector((state) => state.accept.value);
-  const server = useTypedSelector((state) => state.server.value);
-  const body = useTypedSelector((state) => state.body);
+  const contentType = useTypedSelector((state: any) => state.contentType.value);
+  const accept = useTypedSelector((state: any) => state.accept.value);
+  const server = useTypedSelector((state: any) => state.server.value);
+  const body = useTypedSelector((state: any) => state.body);
 
-  const pathParams = useTypedSelector((state) => state.params.path);
-  const queryParams = useTypedSelector((state) => state.params.query);
-  const cookieParams = useTypedSelector((state) => state.params.cookie);
-  const headerParams = useTypedSelector((state) => state.params.header);
+  const pathParams = useTypedSelector((state: any) => state.params.path);
+  const queryParams = useTypedSelector((state: any) => state.params.query);
+  const cookieParams = useTypedSelector((state: any) => state.params.cookie);
+  const headerParams = useTypedSelector((state: any) => state.params.header);
 
-  const auth = useTypedSelector((state) => state.auth);
+  const auth = useTypedSelector((state: any) => state.auth);
 
   // TODO
   const langs = [

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -14,11 +14,11 @@ import CodeBlock from "@theme/CodeBlock";
 import clsx from "clsx";
 
 import { useTypedSelector } from "../../ApiItem/hooks";
-import CodeTabs from "../CodeTabs";
+import CodeTabs from "@theme/ApiDemoPanel/CodeTabs";
 import buildPostmanRequest from "./../buildPostmanRequest";
 import styles from "./styles.module.css";
 
-interface Language {
+export interface Language {
   highlight?: string;
   language: string;
   logoClass?: string;
@@ -102,7 +102,7 @@ export const languageSet: Language[] = [
   },
 ];
 
-interface Props {
+export interface Props {
   postman: sdk.Request;
   codeSamples: any; // TODO: Type this...
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -10,11 +10,11 @@ import React, { useState, useEffect } from "react";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import codegen from "@paloaltonetworks/postman-code-generators";
 import sdk from "@paloaltonetworks/postman-collection";
+import CodeTabs from "@theme/ApiDemoPanel/CodeTabs";
 import CodeBlock from "@theme/CodeBlock";
 import clsx from "clsx";
 
 import { useTypedSelector } from "../../ApiItem/hooks";
-import CodeTabs from "@theme/ApiDemoPanel/CodeTabs";
 import buildPostmanRequest from "./../buildPostmanRequest";
 import styles from "./styles.module.css";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
@@ -32,7 +32,7 @@ function validateRequest(params: {
   return true;
 }
 
-interface Props {
+export interface Props {
   postman: sdk.Request;
   proxy?: string;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Execute/index.tsx
@@ -8,12 +8,12 @@
 import React from "react";
 
 import sdk from "@paloaltonetworks/postman-collection";
+import buildPostmanRequest from "@theme/ApiDemoPanel/buildPostmanRequest";
+import { Param } from "@theme/ApiDemoPanel/ParamOptions/slice";
+import { setResponse } from "@theme/ApiDemoPanel/Response/slice";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import Modal from "react-modal";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import { Param } from "../ParamOptions/slice";
-import { setResponse } from "../Response/slice";
-import buildPostmanRequest from "./../buildPostmanRequest";
 import makeRequest from "./makeRequest";
 
 function validateRequest(params: {
@@ -38,16 +38,16 @@ export interface Props {
 }
 
 function Execute({ postman, proxy }: Props) {
-  const pathParams = useTypedSelector((state) => state.params.path);
-  const queryParams = useTypedSelector((state) => state.params.query);
-  const cookieParams = useTypedSelector((state) => state.params.cookie);
-  const headerParams = useTypedSelector((state) => state.params.header);
-  const contentType = useTypedSelector((state) => state.contentType.value);
-  const body = useTypedSelector((state) => state.body);
-  const accept = useTypedSelector((state) => state.accept.value);
-  const server = useTypedSelector((state) => state.server.value);
-  const params = useTypedSelector((state) => state.params);
-  const auth = useTypedSelector((state) => state.auth);
+  const pathParams = useTypedSelector((state: any) => state.params.path);
+  const queryParams = useTypedSelector((state: any) => state.params.query);
+  const cookieParams = useTypedSelector((state: any) => state.params.cookie);
+  const headerParams = useTypedSelector((state: any) => state.params.header);
+  const contentType = useTypedSelector((state: any) => state.contentType.value);
+  const body = useTypedSelector((state: any) => state.body);
+  const accept = useTypedSelector((state: any) => state.accept.value);
+  const server = useTypedSelector((state: any) => state.server.value);
+  const params = useTypedSelector((state: any) => state.params);
+  const auth = useTypedSelector((state: any) => state.auth);
 
   const isValidRequest = validateRequest(params);
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FloatingButton/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FloatingButton/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-interface Props {
+export interface Props {
   label?: string;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children?: React.ReactNode;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormFileUpload/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormFileUpload/index.tsx
@@ -7,9 +7,9 @@
 
 import React, { useState } from "react";
 
+import FloatingButton from "@theme/ApiDemoPanel/FloatingButton";
 import MagicDropzone from "react-magic-dropzone";
 
-import FloatingButton from "../FloatingButton";
 import styles from "./styles.module.css";
 
 type PreviewFile = { preview: string } & File;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormFileUpload/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormFileUpload/index.tsx
@@ -61,7 +61,7 @@ function RenderPreview({ file }: RenderPreviewProps) {
   }
 }
 
-interface Props {
+export interface Props {
   placeholder: string;
   onChange?(file?: File): any;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormItem/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-interface Props {
+export interface Props {
   label?: string;
   type?: string;
   required?: boolean | undefined;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormMultiSelect/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormMultiSelect/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-interface Props {
+export interface Props {
   value?: string;
   options: string[];
   onChange?: React.ChangeEventHandler<HTMLSelectElement>;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormSelect/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormSelect/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-interface Props {
+export interface Props {
   value?: string;
   options?: string[];
   onChange?: React.ChangeEventHandler<HTMLSelectElement>;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/FormTextInput/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 
 import styles from "./styles.module.css";
 
-interface Props {
+export interface Props {
   value?: string;
   placeholder?: string;
   password?: boolean;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/LiveEditor/index.tsx
@@ -9,9 +9,9 @@ import React, { useEffect, useState } from "react";
 
 import { usePrismTheme } from "@docusaurus/theme-common";
 import useIsBrowser from "@docusaurus/useIsBrowser";
+import { setStringRawBody } from "@theme/ApiDemoPanel/Body/slice";
 import { LiveProvider, LiveEditor, withLive } from "react-live";
 
-import { setStringRawBody } from "../Body/slice";
 import styles from "./styles.module.css";
 
 function Live({ onEdit }: any) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/MethodEndpoint/index.tsx
@@ -30,7 +30,7 @@ function colorForMethod(method: string) {
   }
 }
 
-interface Props {
+export interface Props {
   method: string;
   path: string;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -8,12 +8,12 @@
 import React, { useState, useEffect } from "react";
 
 import { nanoid } from "@reduxjs/toolkit";
-
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormMultiSelect from "@theme/ApiDemoPanel/FormMultiSelect";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+
+import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { Param, setParam } from "./slice";
 import styles from "./styles.module.css";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -12,8 +12,8 @@ import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormMultiSelect from "@theme/ApiDemoPanel/FormMultiSelect";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { Param, setParam } from "./slice";
 import styles from "./styles.module.css";
 
@@ -54,10 +54,10 @@ function ParamOptionWrapper({ param }: ParamProps) {
 function ParamOptions() {
   const [showOptional, setShowOptional] = useState(false);
 
-  const pathParams = useTypedSelector((state) => state.params.path);
-  const queryParams = useTypedSelector((state) => state.params.query);
-  const cookieParams = useTypedSelector((state) => state.params.cookie);
-  const headerParams = useTypedSelector((state) => state.params.header);
+  const pathParams = useTypedSelector((state: any) => state.params.path);
+  const queryParams = useTypedSelector((state: any) => state.params.query);
+  const cookieParams = useTypedSelector((state: any) => state.params.cookie);
+  const headerParams = useTypedSelector((state: any) => state.params.header);
 
   const allParams = [
     ...pathParams,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -10,14 +10,14 @@ import React, { useState, useEffect } from "react";
 import { nanoid } from "@reduxjs/toolkit";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import FormItem from "./../FormItem";
-import FormMultiSelect from "./../FormMultiSelect";
-import FormSelect from "./../FormSelect";
-import FormTextInput from "./../FormTextInput";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormMultiSelect from "@theme/ApiDemoPanel/FormMultiSelect";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
 import { Param, setParam } from "./slice";
 import styles from "./styles.module.css";
 
-interface ParamProps {
+export interface ParamProps {
   param: Param;
 }
 
@@ -142,7 +142,7 @@ function ArrayItem({
     return (
       <FormSelect
         options={["---", "true", "false"]}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           const val = e.target.value;
           onChange(val === "---" ? undefined : val);
         }}
@@ -153,7 +153,7 @@ function ArrayItem({
   return (
     <FormTextInput
       placeholder={param.description || param.name}
-      onChange={(e) => {
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onChange(e.target.value);
       }}
     />
@@ -246,7 +246,7 @@ function ParamSelectFormItem({ param }: ParamProps) {
   return (
     <FormSelect
       options={["---", ...(options as string[])]}
-      onChange={(e) => {
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         const val = e.target.value;
         dispatch(
           setParam({
@@ -265,7 +265,7 @@ function ParamBooleanFormItem({ param }: ParamProps) {
   return (
     <FormSelect
       options={["---", "true", "false"]}
-      onChange={(e) => {
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         const val = e.target.value;
         dispatch(
           setParam({
@@ -286,7 +286,7 @@ function ParamMultiSelectFormItem({ param }: ParamProps) {
   return (
     <FormMultiSelect
       options={options as string[]}
-      onChange={(e) => {
+      onChange={(e: any) => {
         const values = Array.prototype.filter
           .call(e.target.options, (o) => o.selected)
           .map((o) => o.value);
@@ -308,7 +308,9 @@ function ParamTextFormItem({ param }: ParamProps) {
   return (
     <FormTextInput
       placeholder={param.description || param.name}
-      onChange={(e) => dispatch(setParam({ ...param, value: e.target.value }))}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        dispatch(setParam({ ...param, value: e.target.value }))
+      }
     />
   );
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -9,17 +9,17 @@ import React from "react";
 
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import sdk from "@paloaltonetworks/postman-collection";
-import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
-
-import { ThemeConfig } from "../../../types";
-import { useTypedSelector } from "@theme/ApiItem/hooks";
 import Accept from "@theme/ApiDemoPanel/Accept";
 import Authorization from "@theme/ApiDemoPanel/Authorization";
 import Body from "@theme/ApiDemoPanel/Body";
 import Execute from "@theme/ApiDemoPanel/Execute";
 import ParamOptions from "@theme/ApiDemoPanel/ParamOptions";
 import Server from "@theme/ApiDemoPanel/Server";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
+import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+
+import { ThemeConfig } from "../../../types";
 import styles from "./styles.module.css";
 
 function Request({ item }: { item: NonNullable<ApiItem> }) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { ThemeConfig } from "@docusaurus/types";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import sdk from "@paloaltonetworks/postman-collection";
 import Accept from "@theme/ApiDemoPanel/Accept";
@@ -19,14 +20,13 @@ import { useTypedSelector } from "@theme/ApiItem/hooks";
 import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
-import { ThemeConfig } from "../../../types";
 import styles from "./styles.module.css";
 
 function Request({ item }: { item: NonNullable<ApiItem> }) {
   const response = useTypedSelector((state: any) => state.response.value);
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
-  const options = themeConfig.api;
+  const options = themeConfig.api as ApiItem;
   const postman = new sdk.Request(item.postman);
 
   const params = {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -13,17 +13,17 @@ import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/type
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 import { ThemeConfig } from "../../../types";
-import { useTypedSelector } from "../../ApiItem/hooks";
-import Accept from "../Accept";
-import Authorization from "../Authorization";
-import Body from "../Body";
-import Execute from "../Execute";
-import ParamOptions from "../ParamOptions";
-import Server from "../Server";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
+import Accept from "@theme/ApiDemoPanel/Accept";
+import Authorization from "@theme/ApiDemoPanel/Authorization";
+import Body from "@theme/ApiDemoPanel/Body";
+import Execute from "@theme/ApiDemoPanel/Execute";
+import ParamOptions from "@theme/ApiDemoPanel/ParamOptions";
+import Server from "@theme/ApiDemoPanel/Server";
 import styles from "./styles.module.css";
 
 function Request({ item }: { item: NonNullable<ApiItem> }) {
-  const response = useTypedSelector((state) => state.response.value);
+  const response = useTypedSelector((state: any) => state.response.value);
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Response/index.tsx
@@ -7,9 +7,9 @@
 
 import React from "react";
 
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import CodeBlock from "@theme/CodeBlock";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { clearResponse } from "./slice";
 
 // TODO: We probably shouldn't attempt to format XML...
@@ -33,7 +33,7 @@ function formatXml(xml: string) {
 }
 
 function Response() {
-  const response = useTypedSelector((state) => state.response.value);
+  const response = useTypedSelector((state: any) => state.response.value);
   const dispatch = useTypedDispatch();
 
   if (response === undefined) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/SecuritySchemes/index.tsx
@@ -8,12 +8,11 @@
 import React from "react";
 
 import Link from "@docusaurus/Link";
-
-import { useTypedSelector } from "../../ApiItem/hooks";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
 
 function SecuritySchemes(props: any) {
-  const options = useTypedSelector((state) => state.auth.options);
-  const selected = useTypedSelector((state) => state.auth.selected);
+  const options = useTypedSelector((state: any) => state.auth.options);
+  const selected = useTypedSelector((state: any) => state.auth.selected);
   const infoAuthPath = `/${props.infoPath}#authentication`;
 
   if (selected === undefined) return null;
@@ -24,7 +23,7 @@ function SecuritySchemes(props: any) {
       <summary className={`details__request-summary`}>
         <h4>Authorization</h4>
       </summary>
-      {selectedAuth.map((auth) => {
+      {selectedAuth.map((auth: any) => {
         const isApiKey = auth.type === "apiKey";
         const isBearer = auth.type === "http" && auth.key === "Bearer";
         const isOauth2 = auth.type === "oauth2";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
@@ -8,10 +8,10 @@
 import React, { useState } from "react";
 
 import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
-import FloatingButton from "../FloatingButton";
-import FormItem from "./../FormItem";
-import FormSelect from "./../FormSelect";
-import FormTextInput from "./../FormTextInput";
+import FloatingButton from "@theme/ApiDemoPanel/FloatingButton";
+import FormItem from "@theme/ApiDemoPanel/FormItem";
+import FormSelect from "@theme/ApiDemoPanel/FormSelect";
+import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
 import { setServer, setServerVariable } from "./slice";
 import styles from "./styles.module.css";
 
@@ -77,7 +77,7 @@ function Server() {
         <FormItem label="Base URL">
           <FormSelect
             options={options.map((s) => s.url)}
-            onChange={(e) => {
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               dispatch(
                 setServer(
                   JSON.stringify(
@@ -97,7 +97,7 @@ function Server() {
                 <FormItem label={key}>
                   <FormSelect
                     options={value.variables[key].enum}
-                    onChange={(e) => {
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                       dispatch(
                         setServerVariable(
                           JSON.stringify({ key, value: e.target.value })
@@ -113,7 +113,7 @@ function Server() {
               <FormItem label={key}>
                 <FormTextInput
                   placeholder={value.variables?.[key].default}
-                  onChange={(e) => {
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     dispatch(
                       setServerVariable(
                         JSON.stringify({ key, value: e.target.value })

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
@@ -11,15 +11,15 @@ import FloatingButton from "@theme/ApiDemoPanel/FloatingButton";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setServer, setServerVariable } from "./slice";
 import styles from "./styles.module.css";
 
 function Server() {
   const [isEditing, setIsEditing] = useState(false);
-  const value = useTypedSelector((state) => state.server.value);
-  const options = useTypedSelector((state) => state.server.options);
+  const value = useTypedSelector((state: any) => state.server.value);
+  const options = useTypedSelector((state: any) => state.server.options);
   const dispatch = useTypedDispatch();
 
   if (options.length <= 0) {
@@ -37,7 +37,7 @@ function Server() {
 
   // Default to first option when existing server state is mismatched
   if (value) {
-    const urlExists = options.find((s) => s.url === value.url);
+    const urlExists = options.find((s: any) => s.url === value.url);
     if (!urlExists) {
       const defaultOption = options[0];
       dispatch(setServer(JSON.stringify(defaultOption)));
@@ -77,12 +77,12 @@ function Server() {
       <FloatingButton onClick={() => setIsEditing(false)} label="Hide">
         <FormItem label="Base URL">
           <FormSelect
-            options={options.map((s) => s.url)}
+            options={options.map((s: any) => s.url)}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               dispatch(
                 setServer(
                   JSON.stringify(
-                    options.filter((s) => s.url === e.target.value)[0]
+                    options.filter((s: any) => s.url === e.target.value)[0]
                   )
                 )
               );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Server/index.tsx
@@ -7,11 +7,12 @@
 
 import React, { useState } from "react";
 
-import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import FloatingButton from "@theme/ApiDemoPanel/FloatingButton";
 import FormItem from "@theme/ApiDemoPanel/FormItem";
 import FormSelect from "@theme/ApiDemoPanel/FormSelect";
 import FormTextInput from "@theme/ApiDemoPanel/FormTextInput";
+
+import { useTypedDispatch, useTypedSelector } from "../../ApiItem/hooks";
 import { setServer, setServerVariable } from "./slice";
 import styles from "./styles.module.css";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/buildPostmanRequest.ts
@@ -6,14 +6,13 @@
  * ========================================================================== */
 
 import sdk from "@paloaltonetworks/postman-collection";
+import { AuthState, Scheme } from "@theme/ApiDemoPanel/Authorization/slice";
+import { Body, Content } from "@theme/ApiDemoPanel/Body/slice";
 import {
   ParameterObject,
   ServerObject,
 } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import cloneDeep from "lodash/cloneDeep";
-
-import { AuthState, Scheme } from "./Authorization/slice";
-import { Body, Content } from "./Body/slice";
 
 type Param = {
   value?: string | string[];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -8,13 +8,12 @@
 import React from "react";
 
 import sdk from "@paloaltonetworks/postman-collection";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
-
 import Curl from "@theme/ApiDemoPanel/Curl";
 import MethodEndpoint from "@theme/ApiDemoPanel/MethodEndpoint";
 import Request from "@theme/ApiDemoPanel/Request";
 import Response from "@theme/ApiDemoPanel/Response";
 import SecuritySchemes from "@theme/ApiDemoPanel/SecuritySchemes";
+import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 function ApiDemoPanel({
   item,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -10,11 +10,11 @@ import React from "react";
 import sdk from "@paloaltonetworks/postman-collection";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
-import Curl from "./Curl";
-import MethodEndpoint from "./MethodEndpoint";
-import Request from "./Request";
-import Response from "./Response";
-import SecuritySchemes from "./SecuritySchemes";
+import Curl from "@theme/ApiDemoPanel/Curl";
+import MethodEndpoint from "@theme/ApiDemoPanel/MethodEndpoint";
+import Request from "@theme/ApiDemoPanel/Request";
+import Response from "@theme/ApiDemoPanel/Response";
+import SecuritySchemes from "@theme/ApiDemoPanel/SecuritySchemes";
 
 function ApiDemoPanel({
   item,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/persistanceMiddleware.ts
@@ -6,10 +6,14 @@
  * ========================================================================== */
 
 import { Middleware } from "@reduxjs/toolkit";
+import {
+  setAuthData,
+  setSelectedAuth,
+} from "@theme/ApiDemoPanel/Authorization/slice";
+import { AppDispatch, RootState } from "@theme/ApiItem/store";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
-import { ThemeConfig } from "../../types";
-import { AppDispatch, RootState } from "../ApiItem/store";
-import { setAuthData, setSelectedAuth } from "./Authorization/slice";
 import { createStorage, hashArray } from "./storage-utils";
 
 export function createPersistanceMiddleware(options: ThemeConfig["api"]) {
@@ -23,7 +27,7 @@ export function createPersistanceMiddleware(options: ThemeConfig["api"]) {
 
       if (action.type === setAuthData.type) {
         for (const [key, value] of Object.entries(state.auth.data)) {
-          if (Object.values(value).filter(Boolean).length > 0) {
+          if (Object.values(value as any).filter(Boolean).length > 0) {
             storage.setItem(key, JSON.stringify(value));
           } else {
             storage.removeItem(key);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -12,19 +12,22 @@ import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { HtmlClassNameProvider } from "@docusaurus/theme-common";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useIsBrowser from "@docusaurus/useIsBrowser";
+import { createAuth } from "@theme/ApiDemoPanel/Authorization/slice";
+import { createPersistanceMiddleware } from "@theme/ApiDemoPanel/persistanceMiddleware";
+import DocItemLayout from "@theme/ApiItem/Layout";
 import type { Props } from "@theme/DocItem";
 import DocItemMetadata from "@theme/DocItem/Metadata";
 import clsx from "clsx";
 import { ServerObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import type { ApiItem as ApiItemType } from "docusaurus-plugin-openapi-docs/src/types";
+/* eslint-disable import/no-extraneous-dependencies*/
+import type {
+  DocFrontMatter,
+  ThemeConfig,
+} from "docusaurus-theme-openapi-docs/src/types";
 import { Provider } from "react-redux";
 
-import { DocFrontMatter } from "../../types";
-import { ThemeConfig } from "../../types";
-import { createAuth } from "../ApiDemoPanel/Authorization/slice";
-import { createPersistanceMiddleware } from "../ApiDemoPanel/persistanceMiddleware";
-import DocItemLayout from "./Layout";
 import { createStoreWithoutState, createStoreWithState } from "./store";
 
 const { DocProvider } = require("@docusaurus/theme-common/internal");

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/store.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/store.ts
@@ -6,14 +6,13 @@
  * ========================================================================== */
 
 import { configureStore, combineReducers } from "@reduxjs/toolkit";
-
-import accept from "../ApiDemoPanel/Accept/slice";
-import auth from "../ApiDemoPanel/Authorization/slice";
-import body from "../ApiDemoPanel/Body/slice";
-import contentType from "../ApiDemoPanel/ContentType/slice";
-import params from "../ApiDemoPanel/ParamOptions/slice";
-import response from "../ApiDemoPanel/Response/slice";
-import server from "../ApiDemoPanel/Server/slice";
+import accept from "@theme/ApiDemoPanel/Accept/slice";
+import auth from "@theme/ApiDemoPanel/Authorization/slice";
+import body from "@theme/ApiDemoPanel/Body/slice";
+import contentType from "@theme/ApiDemoPanel/ContentType/slice";
+import params from "@theme/ApiDemoPanel/ParamOptions/slice";
+import response from "@theme/ApiDemoPanel/Response/slice";
+import server from "@theme/ApiDemoPanel/Server/slice";
 
 const rootReducer = combineReducers({
   accept,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
@@ -16,7 +16,8 @@ import React, {
 
 import { duplicates } from "@docusaurus/theme-common";
 import useIsBrowser from "@docusaurus/useIsBrowser";
-import { setAccept, setContentType } from "@theme/ApiDemoPanel/Accept/slice";
+import { setAccept } from "@theme/ApiDemoPanel/Accept/slice";
+import { setContentType } from "@theme/ApiDemoPanel/ContentType/slice";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import clsx from "clsx";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
@@ -16,19 +16,16 @@ import React, {
 
 import { duplicates } from "@docusaurus/theme-common";
 import useIsBrowser from "@docusaurus/useIsBrowser";
+import { setAccept, setContentType } from "@theme/ApiDemoPanel/Accept/slice";
+import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import clsx from "clsx";
 
-import { setAccept } from "../ApiDemoPanel/Accept/slice";
-import { setContentType } from "../ApiDemoPanel/ContentType/slice";
-import { useTypedDispatch, useTypedSelector } from "../ApiItem/hooks";
-import styles from "./styles.module.css"; // A very rough duck type, but good enough to guard against mistakes while
+import styles from "./styles.module.css";
 
 const {
   useScrollPositionBlocker,
   useTabGroupChoice,
 } = require("@docusaurus/theme-common/internal");
-
-// allowing customization
 
 function isTabItem(comp) {
   return typeof comp.props.value !== "undefined";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -8,12 +8,18 @@
 import React from "react";
 
 import CodeBlock from "@theme/CodeBlock";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { createDescription } from "docusaurus-theme-openapi-docs/src/markdown/createDescription";
+/* eslint-disable import/no-extraneous-dependencies*/
+import {
+  getQualifierMessage,
+  getSchemaName,
+} from "docusaurus-theme-openapi-docs/src/markdown/schema";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { guard } from "docusaurus-theme-openapi-docs/src/markdown/utils";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 
-import { createDescription } from "../../markdown/createDescription";
-import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
-import { guard } from "../../markdown/utils";
 import styles from "./styles.module.css";
 
 function ParamsItem({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
@@ -8,11 +8,13 @@
 import React from "react";
 
 import CodeBlock from "@theme/CodeBlock";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { createDescription } from "docusaurus-theme-openapi-docs/src/markdown/createDescription";
+/* eslint-disable import/no-extraneous-dependencies*/
+import { guard } from "docusaurus-theme-openapi-docs/src/markdown/utils";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 
-import { createDescription } from "../../markdown/createDescription";
-import { guard } from "../../markdown/utils";
 import styles from "./styles.module.css";
 
 function SchemaItem({


### PR DESCRIPTION
## Description

Addresses issue #246.

Previously, we were using relative paths to import/cross-reference theme components. Swizzling these components caused those import paths to break. The primary change is to instead import from `@theme` and `@theme/ApiDemoPanel` respectively.

> Note: As of now, all OpenAPI docs theme components should be considered unsafe for ejecting and wrapping as they are subject to changes. This could involve renaming and/or eliminating some components. Swizzle at your own risk! 

> Note: Once the internal components are finalized we will use `getSwizzleConfig.tsx` to properly define/tag which components are safe and unsafe to wrap/eject.
 
## Motivation and Context

Allow support for swizzling and overriding theme components.

## How Has This Been Tested?

Tested using the demo site. Swizzled the `Request` component and overrode some text for testing. Will post screenshots later.