### PR TITLE
[Bug] Respect readOnly/writeOnly when creating example from schema

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -6,6 +6,7 @@
  * ========================================================================== */
 
 import chalk from "chalk";
+import { values } from "lodash";
 
 import { mergeAllOf } from "../markdown/createRequestSchema";
 import { SchemaObject } from "./types";
@@ -133,6 +134,10 @@ export const sampleRequestFromSchema = (schema: SchemaObject = {}): any => {
               delete prop.items.properties[key];
             }
           }
+        }
+
+        if (prop.readOnly && prop.readOnly === true) {
+          continue;
         }
 
         if (prop.deprecated) {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -135,6 +135,10 @@ export const sampleResponseFromSchema = (schema: SchemaObject = {}): any => {
           }
         }
 
+        if (prop.writeOnly && prop.writeOnly === true) {
+          continue;
+        }
+
         if (prop.deprecated) {
           continue;
         }


### PR DESCRIPTION
## Description

Handles `readOnly` and `writeOnly` for top-level schema properties.

## Motivation and Context

See #347 for context

## How Has This Been Tested?

Tested with Sailpoint beta API

## Screenshots (if appropriate)

<img width="1128" alt="Screen Shot 2022-12-01 at 12 51 53 PM" src="https://user-images.githubusercontent.com/9343811/205124903-8fd9ecae-a0f7-45a2-b8b0-c9498ba02914.png">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
