### PR TITLE
[Enhancement] Allow whitespace in key/token/password input

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -50,7 +50,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value;
+                  const value = e.target.value.replace(/\s/g, "%20");
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -71,7 +71,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value;
+                  const value = e.target.value.replace(/\s/g, "%20");
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -93,7 +93,7 @@ function Authorization() {
                   placeholder="Username"
                   value={data[a.key].username ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value;
+                    const value = e.target.value.replace(/\s/g, "%20");
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -110,7 +110,7 @@ function Authorization() {
                   password
                   value={data[a.key].password ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value;
+                    const value = e.target.value.replace(/\s/g, "%20");
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -132,7 +132,7 @@ function Authorization() {
                 placeholder={`${a.key}`}
                 value={data[a.key].apiKey ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value;
+                  const value = e.target.value.replace(/\s/g, "%20");
                   dispatch(
                     setAuthData({
                       scheme: a.key,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -50,7 +50,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -71,7 +71,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -93,7 +93,7 @@ function Authorization() {
                   placeholder="Username"
                   value={data[a.key].username ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value.trim();
+                    const value = e.target.value;
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -110,7 +110,7 @@ function Authorization() {
                   password
                   value={data[a.key].password ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value.trim();
+                    const value = e.target.value;
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -132,7 +132,7 @@ function Authorization() {
                 placeholder={`${a.key}`}
                 value={data[a.key].apiKey ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.trim();
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Authorization/index.tsx
@@ -50,7 +50,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.replace(/\s/g, "%20");
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -71,7 +71,7 @@ function Authorization() {
                 placeholder="Bearer Token"
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.replace(/\s/g, "%20");
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,
@@ -93,7 +93,7 @@ function Authorization() {
                   placeholder="Username"
                   value={data[a.key].username ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value.replace(/\s/g, "%20");
+                    const value = e.target.value;
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -110,7 +110,7 @@ function Authorization() {
                   password
                   value={data[a.key].password ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const value = e.target.value.replace(/\s/g, "%20");
+                    const value = e.target.value;
                     dispatch(
                       setAuthData({
                         scheme: a.key,
@@ -132,7 +132,7 @@ function Authorization() {
                 placeholder={`${a.key}`}
                 value={data[a.key].apiKey ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  const value = e.target.value.replace(/\s/g, "%20");
+                  const value = e.target.value;
                   dispatch(
                     setAuthData({
                       scheme: a.key,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -309,7 +309,9 @@ function ParamTextFormItem({ param }: ParamProps) {
     <FormTextInput
       placeholder={param.description || param.name}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-        dispatch(setParam({ ...param, value: e.target.value }))
+        dispatch(
+          setParam({ ...param, value: e.target.value.replace(/\s/g, "%20") })
+        )
       }
     />
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/ParamOptions/index.tsx
@@ -310,7 +310,13 @@ function ParamTextFormItem({ param }: ParamProps) {
       placeholder={param.description || param.name}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
         dispatch(
-          setParam({ ...param, value: e.target.value.replace(/\s/g, "%20") })
+          setParam({
+            ...param,
+            value:
+              param.in === "path" || param.in === "query"
+                ? e.target.value.replace(/\s/g, "%20")
+                : e.target.value,
+          })
         )
       }
     />


### PR DESCRIPTION
## Description

Allows whitespace in security scheme key/token/password input. 

## Motivation and Context

See #350 for context

## How Has This Been Tested?

Tested with petstore API