### PR TITLE
[Bug] Improve support for items.allOf

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -258,10 +258,14 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.anyOf !== undefined
     ) {
       return create("div", {
-        children: [
-          createAnyOneOf(mergedSchemas),
-          createProperties(mergedSchemas),
-        ],
+        children: [createAnyOneOf(mergedSchemas)],
+      });
+    }
+
+    // Handles properties
+    if (mergedSchemas.properties !== undefined) {
+      return create("div", {
+        children: [createProperties(mergedSchemas)],
       });
     }
   }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -263,10 +263,14 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.anyOf !== undefined
     ) {
       return create("div", {
-        children: [
-          createAnyOneOf(mergedSchemas),
-          createProperties(mergedSchemas),
-        ],
+        children: [createAnyOneOf(mergedSchemas)],
+      });
+    }
+
+    // Handles properties
+    if (mergedSchemas.properties !== undefined) {
+      return create("div", {
+        children: [createProperties(mergedSchemas)],
       });
     }
   }


### PR DESCRIPTION
## Description

See #349 for context.

## Motivation and Context

Adds missing condition for handling `item.allOf` that resolve to properties.

## How Has This Been Tested?

Tested with Sailpoint API spec.

## Screenshots (if appropriate)

<img width="834" alt="Screen Shot 2022-12-02 at 11 27 45 AM" src="https://user-images.githubusercontent.com/9343811/205339420-6805c2cf-be8d-48f6-bc7e-9a691532595f.png">

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)