### PR TITLE
kebab case fix for info pages

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -41,7 +41,7 @@ info:
     and standard method from web, mobile and desktop applications.
 
   version: 2.0.0
-  title: Swagger Petstore YAML APIs IoT
+  title: Swagger Petstore YAML
   termsOfService: "http://swagger.io/terms/"
   contact:
     name: API Support

--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -41,7 +41,7 @@ info:
     and standard method from web, mobile and desktop applications.
 
   version: 2.0.0
-  title: Swagger Petstore YAML
+  title: Swagger Petstore YAML APIs IoT
   termsOfService: "http://swagger.io/terms/"
   contact:
     name: API Support

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -83,7 +83,8 @@ function createItems(
 ): ApiMetadata[] {
   // TODO: Find a better way to handle this
   let items: PartialPage<ApiMetadata>[] = [];
-  const infoId = kebabCase(openapiData.info.title);
+  const infoIdSpaces = openapiData.info.title.replace(" ", "-").toLowerCase();
+  const infoId = kebabCase(infoIdSpaces);
 
   if (sidebarOptions?.categoryLinkSource === "tag") {
     // Only create an tag pages if categoryLinkSource set to tag.


### PR DESCRIPTION
## Description

Change the way we kebab case info page id's. Instead of taking the title, which likely has spaces, we will replace the spaces with `-` and push to lowercase. 

## Motivation and Context

IoT was io-t 

APIs was ap-is 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
