### PR TITLE
Hide edit URL by default

### DIFF
--- a/demo/api.mustache
+++ b/demo/api.mustache
@@ -24,7 +24,7 @@ sidebar_class_name: "{{{api.method}}} api-method"
 {{#infoPath}}
 info_path: {{{infoPath}}}
 {{/infoPath}}
-custom_edit_url: "https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/new?labels=documentation&template=documentation_problem.md&title=[Documentation] Requesting changes to '{{{title}}}' ({{{id}}})"
+custom_edit_url: null
 ---
 
 {{{markdown}}}

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -182,6 +182,7 @@ sidebar_class_name: "{{{api.method}}} api-method"
 {{#infoPath}}
 info_path: {{{infoPath}}}
 {{/infoPath}}
+custom_edit_url: null
 ---
 
 {{{markdown}}}


### PR DESCRIPTION
## Description

Hides the edit URL by default for all generated API docs. Users will still have the option to use a `template` to set `custom_edit_url` to the desired value.

## Motivation and Context

Should be considered an anti-pattern to encourage editing of generated MDX.

## How Has This Been Tested?

Tested with API Zoo.