### PR TITLE
[Enhancement] Add proxy support

### DIFF
--- a/demo/api.mustache
+++ b/demo/api.mustache
@@ -1,12 +1,12 @@
 ---
 id: {{{id}}}
-title: {{{title}}}
-description: "{{{description}}}"
+title: "{{{title}}}"
+description: "{{{frontMatter.description}}}"
 {{^api}}
 sidebar_label: Introduction
 {{/api}}
 {{#api}}
-sidebar_label: {{{title}}}
+sidebar_label: "{{{title}}}"
 {{/api}}
 {{^api}}
 sidebar_position: 0
@@ -25,6 +25,9 @@ sidebar_class_name: "{{{api.method}}} api-method"
 info_path: {{{infoPath}}}
 {{/infoPath}}
 custom_edit_url: null
+{{#frontMatter.proxy}}
+proxy: {{{frontMatter.proxy}}}
+{{/frontMatter.proxy}}
 ---
 
 {{{markdown}}}

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -214,6 +214,7 @@ const config = {
           },
           petstore: {
             specPath: "examples/petstore.yaml",
+            proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {
               groupPathsBy: "tag",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -184,6 +184,9 @@ sidebar_class_name: "{{{api.method}}} api-method"
 info_path: {{{infoPath}}}
 {{/infoPath}}
 custom_edit_url: null
+{{#frontMatter.proxy}}
+proxy: {{{frontMatter.proxy}}}
+{{/frontMatter.proxy}}
 ---
 
 {{{markdown}}}

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -106,9 +106,10 @@ export default function pluginOpenAPIDocs(
       : path.resolve(siteDir, specPath);
 
     try {
-      const openapiFiles = await readOpenapiFiles(contentPath, options);
+      const openapiFiles = await readOpenapiFiles(contentPath);
       const [loadedApi, tags] = await processOpenapiFiles(
         openapiFiles,
+        options,
         sidebarOptions!
       );
       if (!fs.existsSync(outputDir)) {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -17,8 +17,7 @@ describe("openapi", () => {
   describe("readOpenapiFiles", () => {
     it("readOpenapiFiles", async () => {
       const results = await readOpenapiFiles(
-        posixPath(path.join(__dirname, "__fixtures__/examples")),
-        { specPath: "./", outputDir: "./" }
+        posixPath(path.join(__dirname, "__fixtures__/examples"))
       );
       const categoryMeta = results.find((x) =>
         x.source.endsWith("_category_.json")

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -23,6 +23,7 @@ export const OptionsSchema = Joi.object({
       /^/,
       Joi.object({
         specPath: Joi.string().required(),
+        proxy: Joi.string(),
         outputDir: Joi.string().required(),
         template: Joi.string(),
         downloadUrl: Joi.string(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -40,6 +40,7 @@ export interface APIOptions {
   versions?: {
     [key: string]: APIVersionOptions;
   };
+  proxy?: string;
 }
 
 export interface SidebarOptions {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { useDoc } from "@docusaurus/theme-common/internal";
 import sdk from "@paloaltonetworks/postman-collection";
 import Accept from "@theme/ApiDemoPanel/Accept";
 import Authorization from "@theme/ApiDemoPanel/Authorization";
@@ -19,7 +20,6 @@ import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/type
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 import styles from "./styles.module.css";
-import { useDoc } from "@docusaurus/theme-common/internal";
 
 function Request({ item }: { item: NonNullable<ApiItem> }) {
   const response = useTypedSelector((state: any) => state.response.value);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -7,8 +7,6 @@
 
 import React from "react";
 
-import { ThemeConfig } from "@docusaurus/types";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import sdk from "@paloaltonetworks/postman-collection";
 import Accept from "@theme/ApiDemoPanel/Accept";
 import Authorization from "@theme/ApiDemoPanel/Authorization";
@@ -21,13 +19,13 @@ import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/type
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 import styles from "./styles.module.css";
+import { useDoc } from "@docusaurus/theme-common/internal";
 
 function Request({ item }: { item: NonNullable<ApiItem> }) {
   const response = useTypedSelector((state: any) => state.response.value);
-  const { siteConfig } = useDocusaurusContext();
-  const themeConfig = siteConfig.themeConfig as ThemeConfig;
-  const options = themeConfig.api as ApiItem;
   const postman = new sdk.Request(item.postman);
+  const metadata = useDoc();
+  const { proxy } = metadata.frontMatter;
 
   const params = {
     path: [] as ParameterObject[],
@@ -50,9 +48,7 @@ function Request({ item }: { item: NonNullable<ApiItem> }) {
         <summary>
           <div className={`details__request-summary`}>
             <h4>Request</h4>
-            {item.servers && (
-              <Execute postman={postman} proxy={options?.proxy} />
-            )}
+            {item.servers && <Execute postman={postman} proxy={proxy} />}
           </div>
         </summary>
         <div className={styles.optionsPanel}>


### PR DESCRIPTION
## Description

Introduce support for specifying proxy URL/server.

## Motivation and Context

Some APIs don't include the necessary CORS headers in which case a CORS proxy may be needed. Also, some APIs will require a proxy for other valid reasons.

## How Has This Been Tested?

Tested with Petstore API - see deploy preview (inspect Network tab to see the proxy URL in request)