### PR TITLE
fix jsonSchemaMergeAllOf options in createRequestSchema

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -29,8 +29,8 @@ export function mergeAllOf(allOf: SchemaObject[]) {
       "x-examples": function () {
         return true;
       },
-      ignoreAdditionalProperties: true,
     },
+    ignoreAdditionalProperties: true,
   });
 
   const required = allOf.reduce((acc, cur) => {


### PR DESCRIPTION
## Description

The creation of a request schema works incorrectly. If there is a request body with allOf refs there will be no correct request body.

## Motivation and Context

It will fix bug

## Screenshots

<img width="300" alt="image" src="https://user-images.githubusercontent.com/26583544/209667266-0e053794-8de0-41b3-92e5-27a1bd76911b.png"> ➡️ <img width="300" alt="image" src="https://user-images.githubusercontent.com/26583544/209667136-f1e3fddc-8988-4db8-ad98-25340a93abd7.png">

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
