### PR TITLE
Add resolveInternal to swagger2openapi options

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -66,7 +66,13 @@ export function convertSwagger2OpenAPI(spec: object) {
   return new Promise((resolve, reject) =>
     convertObj(
       spec,
-      { patch: true, warnOnly: true, text: "{}", anchors: true, resolveInternal: true},
+      {
+        patch: true,
+        warnOnly: true,
+        text: "{}",
+        anchors: true,
+        resolveInternal: true,
+      },
       (err: any, res: any) => {
         // TODO: log any warnings
         if (err) {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -66,7 +66,7 @@ export function convertSwagger2OpenAPI(spec: object) {
   return new Promise((resolve, reject) =>
     convertObj(
       spec,
-      { patch: true, warnOnly: true, text: "{}", anchors: true },
+      { patch: true, warnOnly: true, text: "{}", anchors: true, resolveInternal: true},
       (err: any, res: any) => {
         // TODO: log any warnings
         if (err) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adding `resolveInternal` option when using `swagger2openapi` to convert Swagger 2.0 to oapi3.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some `$ref` doesn't seem to get resolved without it.
https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/372
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After adding this option i ran the gen-commands and all `$ref`s seemed to have been resolved. The generated docs looked as expected.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
