### PR TITLE
[Experimental] Switch to patched json-schema-ref-parser

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -39,7 +39,7 @@
     "utility-types": "^3.10.0"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^9.0.9",
+    "@paloaltonetworks/json-schema-ref-parser": "0.0.0-dev-hotfix1",
     "@docusaurus/mdx-loader": "^2.0.1",
     "@docusaurus/plugin-content-docs": "^2.0.1",
     "@docusaurus/utils": "^2.0.1",

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import $RefParser from "@apidevtools/json-schema-ref-parser";
+import $RefParser from "@paloaltonetworks/json-schema-ref-parser";
 import { bundle, Config } from "@redocly/openapi-core";
 import type { Source, Document } from "@redocly/openapi-core";
 import { ResolvedConfig } from "@redocly/openapi-core/lib/config";

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,16 +147,6 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apidevtools/json-schema-ref-parser@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#d720f9256e3609621280584f2b47ae165359268b"
-  integrity sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==
-  dependencies:
-    "@jsdevtools/ono" "^7.1.3"
-    "@types/json-schema" "^7.0.6"
-    call-me-maybe "^1.0.1"
-    js-yaml "^4.1.0"
-
 "@babel/cli@^7.16.0":
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.19.3.tgz#55914ed388e658e0b924b3a95da1296267e278e2"
@@ -3083,6 +3073,16 @@
   integrity sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==
   dependencies:
     "@octokit/openapi-types" "^14.0.0"
+
+"@paloaltonetworks/json-schema-ref-parser@0.0.0-dev-hotfix1":
+  version "0.0.0-dev-hotfix1"
+  resolved "https://registry.yarnpkg.com/@paloaltonetworks/json-schema-ref-parser/-/json-schema-ref-parser-0.0.0-dev-hotfix1.tgz#a0d1d6b4e61034210dc4d6473c7aefdb5381a1c3"
+  integrity sha512-X4ZyW43uPOF2oa8EMKZIpgkvaRw0mJ2a9DHNfGIZelJYU9zwB+KvMM5PvAMZSM/dMnc7g+HJja6jbhMrBW0Z1w==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
 
 "@paloaltonetworks/openapi-to-postmanv2@3.1.0-hotfix.1":
   version "3.1.0-hotfix.1"


### PR DESCRIPTION
## Description

In some environments, solutions like SSL decryption can prevent the remote `$ref` resolver from fetching `$ref` pointers. This change attempts to use a custom `https.agent` to disable TLS verification on these connections, since it is not possible to do so through other traditional means, e.g. CAFILE, envars, yarn, etc.

## Motivation and Context

Allow remote `$ref` URL pointers to resolve even with SSL decryption in the path.

## How Has This Been Tested?

Will test with `compute` API.