### PR TITLE
[Bug] Support multiple same-level node types and improve items/array support

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -239,6 +239,14 @@ const config = {
             specPath: "examples/food/yogurtstore/openapi.yaml",
             outputDir: "docs/food/yogurtstore",
           },
+          config: {
+            specPath:
+              "https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/master/openapi-specs/access/prisma-access-config/AddressGroups.yaml",
+            outputDir: "docs/config",
+            sidebarOptions: {
+              groupPathsBy: "tag",
+            },
+          },
         },
       },
     ],

--- a/demo/sidebars.js
+++ b/demo/sidebars.js
@@ -72,6 +72,16 @@ const sidebars = {
     },
     {
       type: "category",
+      label: "Address Groups",
+      link: {
+        type: "generated-index",
+        title: "Address Groups",
+        slug: "/category/config-api",
+      },
+      items: require("./docs/config/sidebar.js"),
+    },
+    {
+      type: "category",
       label: "Burgers",
       link: {
         type: "generated-index",

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createArrayBracket.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createArrayBracket.ts
@@ -1,0 +1,35 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { create } from "./utils";
+
+export function createOpeningArrayBracket() {
+  return create("li", {
+    children: create("div", {
+      style: {
+        fontSize: "var(--ifm-code-font-size)",
+        opacity: "0.6",
+        marginLeft: "-.5rem",
+        paddingBottom: ".5rem",
+      },
+      children: ["Array ["],
+    }),
+  });
+}
+
+export function createClosingArrayBracket() {
+  return create("li", {
+    children: create("div", {
+      style: {
+        fontSize: "var(--ifm-code-font-size)",
+        opacity: "0.6",
+        marginLeft: "-.5rem",
+      },
+      children: ["]"],
+    }),
+  });
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -214,15 +214,78 @@ function createAdditionalProperties(schema: SchemaObject) {
 // TODO: figure out how to handle array of objects
 function createItems(schema: SchemaObject) {
   if (schema.items?.properties !== undefined) {
-    return createProperties(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createProperties(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.additionalProperties !== undefined) {
-    return createAdditionalProperties(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createAdditionalProperties(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.oneOf !== undefined || schema.items?.anyOf !== undefined) {
-    return createAnyOneOf(schema.items!);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createAnyOneOf(schema.items!),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.allOf !== undefined) {
@@ -239,12 +302,29 @@ function createItems(schema: SchemaObject) {
         mergedSchemas.anyOf !== undefined) &&
       mergedSchemas.properties
     ) {
-      return create("div", {
-        children: [
-          createAnyOneOf(mergedSchemas),
-          createProperties(mergedSchemas),
-        ],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createAnyOneOf(mergedSchemas),
+        createProperties(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
 
     // Handles only anyOf/oneOf
@@ -252,16 +332,54 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.oneOf !== undefined ||
       mergedSchemas.anyOf !== undefined
     ) {
-      return create("div", {
-        children: [createAnyOneOf(mergedSchemas)],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createAnyOneOf(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
 
     // Handles properties
     if (mergedSchemas.properties !== undefined) {
-      return create("div", {
-        children: [createProperties(mergedSchemas)],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createProperties(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
   }
 
@@ -271,19 +389,61 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "integer" ||
     schema.items?.type === "boolean"
   ) {
-    return createNodes(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createNodes(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   // TODO: clean this up or eliminate it?
-  return Object.entries(schema.items!).map(([key, val]) =>
-    createEdges({
-      name: key,
-      schema: val,
-      required: Array.isArray(schema.required)
-        ? schema.required.includes(key)
-        : false,
-    })
-  );
+  return [
+    create("li", {
+      children: create("div", {
+        style: {
+          fontSize: "var(--ifm-code-font-size)",
+          marginLeft: "-.5rem",
+          paddingBottom: ".5rem",
+        },
+        children: ["Array ["],
+      }),
+    }),
+    Object.entries(schema.items!).map(([key, val]) =>
+      createEdges({
+        name: key,
+        schema: val,
+        required: Array.isArray(schema.required)
+          ? schema.required.includes(key)
+          : false,
+      })
+    ),
+    create("li", {
+      children: create("div", {
+        style: {
+          fontSize: "var(--ifm-code-font-size)",
+          marginLeft: "-.5rem",
+        },
+        children: ["]"],
+      }),
+    }),
+  ].flat();
 }
 
 /**

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -83,6 +83,36 @@ function createAnyOneOf(schema: SchemaObject): any {
             anyOneChildren.push(createNodes(anyOneSchema));
           }
           if (anyOneChildren.length) {
+            if (schema.type === "array") {
+              return create("TabItem", {
+                label: label,
+                value: `${index}-item-properties`,
+                children: [
+                  create("li", {
+                    children: create("div", {
+                      style: {
+                        fontSize: "var(--ifm-code-font-size)",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      },
+                      children: ["Array ["],
+                    }),
+                  }),
+                  anyOneChildren,
+                  create("li", {
+                    children: create("div", {
+                      style: {
+                        fontSize: "var(--ifm-code-font-size)",
+                        marginLeft: "-.5rem",
+                      },
+                      children: ["]"],
+                    }),
+                  }),
+                ]
+                  .filter(Boolean)
+                  .flat(),
+              });
+            }
             return create("TabItem", {
               label: label,
               value: `${index}-item-properties`,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -144,11 +144,11 @@ function createAdditionalProperties(schema: SchemaObject) {
   // }
 
   if (
-    schema.additionalProperties?.type === "string" ||
-    schema.additionalProperties?.type === "object" ||
-    schema.additionalProperties?.type === "boolean" ||
-    schema.additionalProperties?.type === "integer" ||
-    schema.additionalProperties?.type === "number"
+    (schema.additionalProperties?.type as string) === "string" ||
+    (schema.additionalProperties?.type as string) === "object" ||
+    (schema.additionalProperties?.type as string) === "boolean" ||
+    (schema.additionalProperties?.type as string) === "integer" ||
+    (schema.additionalProperties?.type as string) === "number"
   ) {
     const type = schema.additionalProperties?.type;
     const additionalProperties =

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -387,7 +387,8 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "string" ||
     schema.items?.type === "number" ||
     schema.items?.type === "integer" ||
-    schema.items?.type === "boolean"
+    schema.items?.type === "boolean" ||
+    schema.items?.type === "object"
   ) {
     return [
       create("li", {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -6,15 +6,15 @@
  * ========================================================================== */
 
 import { MediaTypeObject, SchemaObject } from "../openapi/types";
+import {
+  createClosingArrayBracket,
+  createOpeningArrayBracket,
+} from "./createArrayBracket";
 import { createDescription } from "./createDescription";
 import { createDetails } from "./createDetails";
 import { createDetailsSummary } from "./createDetailsSummary";
 import { getQualifierMessage, getSchemaName } from "./schema";
 import { create, guard } from "./utils";
-import {
-  createClosingArrayBracket,
-  createOpeningArrayBracket,
-} from "./createArrayBracket";
 
 const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -954,12 +954,6 @@ export function createRequestSchema({ title, body, ...rest }: Props) {
                   style: { textAlign: "left" },
                   children: [
                     create("strong", { children: `${title}` }),
-                    guard(firstBody.type === "array", (format) =>
-                      create("span", {
-                        style: { opacity: "0.6" },
-                        children: ` array`,
-                      })
-                    ),
                     guard(body.required && body.required === true, () => [
                       create("strong", {
                         style: {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -650,10 +650,6 @@ function createNodes(schema: SchemaObject): any {
   //   return createDiscriminator(schema);
   // }
 
-  // if ((schema.oneOf || schema.anyOf) && schema.properties) {
-  //   return [createAnyOneOf(schema), createProperties(schema)];
-  // }
-
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
     nodes.push(createAnyOneOf(schema));
   }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -11,6 +11,10 @@ import { createDetails } from "./createDetails";
 import { createDetailsSummary } from "./createDetailsSummary";
 import { getQualifierMessage, getSchemaName } from "./schema";
 import { create, guard } from "./utils";
+import {
+  createClosingArrayBracket,
+  createOpeningArrayBracket,
+} from "./createArrayBracket";
 
 const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
 
@@ -88,28 +92,9 @@ function createAnyOneOf(schema: SchemaObject): any {
                 label: label,
                 value: `${index}-item-properties`,
                 children: [
-                  create("li", {
-                    children: create("div", {
-                      style: {
-                        fontSize: "var(--ifm-code-font-size)",
-                        opacity: "0.6",
-                        marginLeft: "-.5rem",
-                        paddingBottom: ".5rem",
-                      },
-                      children: ["Array ["],
-                    }),
-                  }),
+                  createOpeningArrayBracket(),
                   anyOneChildren,
-                  create("li", {
-                    children: create("div", {
-                      style: {
-                        fontSize: "var(--ifm-code-font-size)",
-                        opacity: "0.6",
-                        marginLeft: "-.5rem",
-                      },
-                      children: ["]"],
-                    }),
-                  }),
+                  createClosingArrayBracket(),
                 ]
                   .filter(Boolean)
                   .flat(),
@@ -247,82 +232,25 @@ function createAdditionalProperties(schema: SchemaObject) {
 function createItems(schema: SchemaObject) {
   if (schema.items?.properties !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createProperties(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   if (schema.items?.additionalProperties !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createAdditionalProperties(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   if (schema.items?.oneOf !== undefined || schema.items?.anyOf !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createAnyOneOf(schema.items!),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
@@ -341,29 +269,10 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.properties
     ) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createAnyOneOf(mergedSchemas),
         createProperties(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
 
@@ -373,56 +282,18 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.anyOf !== undefined
     ) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createAnyOneOf(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
 
     // Handles properties
     if (mergedSchemas.properties !== undefined) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createProperties(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
   }
@@ -435,44 +306,15 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "object"
   ) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createNodes(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   // TODO: clean this up or eliminate it?
   return [
-    create("li", {
-      children: create("div", {
-        style: {
-          fontSize: "var(--ifm-code-font-size)",
-          opacity: "0.6",
-          marginLeft: "-.5rem",
-          paddingBottom: ".5rem",
-        },
-        children: ["Array ["],
-      }),
-    }),
+    createOpeningArrayBracket(),
     Object.entries(schema.items!).map(([key, val]) =>
       createEdges({
         name: key,
@@ -482,16 +324,7 @@ function createItems(schema: SchemaObject) {
           : false,
       })
     ),
-    create("li", {
-      children: create("div", {
-        style: {
-          fontSize: "var(--ifm-code-font-size)",
-          opacity: "0.6",
-          marginLeft: "-.5rem",
-        },
-        children: ["]"],
-      }),
-    }),
+    createClosingArrayBracket(),
   ].flat();
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -92,6 +92,7 @@ function createAnyOneOf(schema: SchemaObject): any {
                     children: create("div", {
                       style: {
                         fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
                         marginLeft: "-.5rem",
                         paddingBottom: ".5rem",
                       },
@@ -103,6 +104,7 @@ function createAnyOneOf(schema: SchemaObject): any {
                     children: create("div", {
                       style: {
                         fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
                         marginLeft: "-.5rem",
                       },
                       children: ["]"],
@@ -249,6 +251,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -260,6 +263,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -274,6 +278,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -285,6 +290,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -299,6 +305,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -310,6 +317,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -337,6 +345,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -349,6 +358,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -367,6 +377,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -378,6 +389,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -393,6 +405,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -404,6 +417,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -425,6 +439,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -436,6 +451,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -450,6 +466,7 @@ function createItems(schema: SchemaObject) {
       children: create("div", {
         style: {
           fontSize: "var(--ifm-code-font-size)",
+          opacity: "0.6",
           marginLeft: "-.5rem",
           paddingBottom: ".5rem",
         },
@@ -469,6 +486,7 @@ function createItems(schema: SchemaObject) {
       children: create("div", {
         style: {
           fontSize: "var(--ifm-code-font-size)",
+          opacity: "0.6",
           marginLeft: "-.5rem",
         },
         children: ["]"],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -100,16 +100,14 @@ function createAnyOneOf(schema: SchemaObject): any {
 function createProperties(schema: SchemaObject) {
   const discriminator = schema.discriminator;
   return Object.entries(schema.properties!).map(([key, val]) => {
-    if (val.readOnly !== true) {
-      return createEdges({
-        name: key,
-        schema: val,
-        required: Array.isArray(schema.required)
-          ? schema.required.includes(key)
-          : false,
-        discriminator,
-      });
-    }
+    return createEdges({
+      name: key,
+      schema: val,
+      required: Array.isArray(schema.required)
+        ? schema.required.includes(key)
+        : false,
+      discriminator,
+    });
   });
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -393,7 +393,8 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "string" ||
     schema.items?.type === "number" ||
     schema.items?.type === "integer" ||
-    schema.items?.type === "boolean"
+    schema.items?.type === "boolean" ||
+    schema.items?.type === "object"
   ) {
     return [
       create("li", {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -6,6 +6,10 @@
  * ========================================================================== */
 
 import { MediaTypeObject, SchemaObject } from "../openapi/types";
+import {
+  createClosingArrayBracket,
+  createOpeningArrayBracket,
+} from "./createArrayBracket";
 import { createDescription } from "./createDescription";
 import { createDetails } from "./createDetails";
 import { createDetailsSummary } from "./createDetailsSummary";
@@ -16,10 +20,6 @@ import {
 } from "./createStatusCodes";
 import { getQualifierMessage, getSchemaName } from "./schema";
 import { create, guard } from "./utils";
-import {
-  createClosingArrayBracket,
-  createOpeningArrayBracket,
-} from "./createArrayBracket";
 
 const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -976,12 +976,6 @@ export function createResponseSchema({ title, body, ...rest }: Props) {
                             style: { textAlign: "left" },
                             children: [
                               create("strong", { children: `${title}` }),
-                              guard(firstBody!.type === "array", (format) =>
-                                create("span", {
-                                  style: { opacity: "0.6" },
-                                  children: ` array`,
-                                })
-                              ),
                               guard(
                                 body.required && body.required === true,
                                 () => [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -98,6 +98,7 @@ function createAnyOneOf(schema: SchemaObject): any {
                     children: create("div", {
                       style: {
                         fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
                         marginLeft: "-.5rem",
                         paddingBottom: ".5rem",
                       },
@@ -109,6 +110,7 @@ function createAnyOneOf(schema: SchemaObject): any {
                     children: create("div", {
                       style: {
                         fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
                         marginLeft: "-.5rem",
                       },
                       children: ["]"],
@@ -255,6 +257,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -266,6 +269,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -305,6 +309,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -316,6 +321,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -343,6 +349,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -355,6 +362,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -373,6 +381,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -384,6 +393,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -399,6 +409,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
               paddingBottom: ".5rem",
             },
@@ -410,6 +421,7 @@ function createItems(schema: SchemaObject) {
           children: create("div", {
             style: {
               fontSize: "var(--ifm-code-font-size)",
+              opacity: "0.6",
               marginLeft: "-.5rem",
             },
             children: ["]"],
@@ -431,6 +443,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
             paddingBottom: ".5rem",
           },
@@ -442,6 +455,7 @@ function createItems(schema: SchemaObject) {
         children: create("div", {
           style: {
             fontSize: "var(--ifm-code-font-size)",
+            opacity: "0.6",
             marginLeft: "-.5rem",
           },
           children: ["]"],
@@ -456,6 +470,7 @@ function createItems(schema: SchemaObject) {
       children: create("div", {
         style: {
           fontSize: "var(--ifm-code-font-size)",
+          opacity: "0.6",
           marginLeft: "-.5rem",
           paddingBottom: ".5rem",
         },
@@ -475,6 +490,7 @@ function createItems(schema: SchemaObject) {
       children: create("div", {
         style: {
           fontSize: "var(--ifm-code-font-size)",
+          opacity: "0.6",
           marginLeft: "-.5rem",
         },
         children: ["]"],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -106,16 +106,14 @@ function createAnyOneOf(schema: SchemaObject): any {
 function createProperties(schema: SchemaObject) {
   const discriminator = schema.discriminator;
   return Object.entries(schema.properties!).map(([key, val]) => {
-    if (val.writeOnly !== true) {
-      return createEdges({
-        name: key,
-        schema: val,
-        required: Array.isArray(schema.required)
-          ? schema.required.includes(key)
-          : false,
-        discriminator,
-      });
-    }
+    return createEdges({
+      name: key,
+      schema: val,
+      required: Array.isArray(schema.required)
+        ? schema.required.includes(key)
+        : false,
+      discriminator,
+    });
   });
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -89,6 +89,36 @@ function createAnyOneOf(schema: SchemaObject): any {
           }
 
           if (anyOneChildren.length) {
+            if (schema.type === "array") {
+              return create("TabItem", {
+                label: label,
+                value: `${index}-item-properties`,
+                children: [
+                  create("li", {
+                    children: create("div", {
+                      style: {
+                        fontSize: "var(--ifm-code-font-size)",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      },
+                      children: ["Array ["],
+                    }),
+                  }),
+                  anyOneChildren,
+                  create("li", {
+                    children: create("div", {
+                      style: {
+                        fontSize: "var(--ifm-code-font-size)",
+                        marginLeft: "-.5rem",
+                      },
+                      children: ["]"],
+                    }),
+                  }),
+                ]
+                  .filter(Boolean)
+                  .flat(),
+              });
+            }
             return create("TabItem", {
               label: label,
               value: `${index}-item-properties`,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -16,6 +16,10 @@ import {
 } from "./createStatusCodes";
 import { getQualifierMessage, getSchemaName } from "./schema";
 import { create, guard } from "./utils";
+import {
+  createClosingArrayBracket,
+  createOpeningArrayBracket,
+} from "./createArrayBracket";
 
 const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
 
@@ -94,28 +98,9 @@ function createAnyOneOf(schema: SchemaObject): any {
                 label: label,
                 value: `${index}-item-properties`,
                 children: [
-                  create("li", {
-                    children: create("div", {
-                      style: {
-                        fontSize: "var(--ifm-code-font-size)",
-                        opacity: "0.6",
-                        marginLeft: "-.5rem",
-                        paddingBottom: ".5rem",
-                      },
-                      children: ["Array ["],
-                    }),
-                  }),
+                  createOpeningArrayBracket(),
                   anyOneChildren,
-                  create("li", {
-                    children: create("div", {
-                      style: {
-                        fontSize: "var(--ifm-code-font-size)",
-                        opacity: "0.6",
-                        marginLeft: "-.5rem",
-                      },
-                      children: ["]"],
-                    }),
-                  }),
+                  createClosingArrayBracket(),
                 ]
                   .filter(Boolean)
                   .flat(),
@@ -253,80 +238,25 @@ function createAdditionalProperties(schema: SchemaObject) {
 function createItems(schema: SchemaObject) {
   if (schema.items?.properties !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createProperties(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   if (schema.items?.additionalProperties !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createAdditionalProperties(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   if (schema.items?.oneOf !== undefined || schema.items?.anyOf !== undefined) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createAnyOneOf(schema.items!),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
@@ -345,29 +275,10 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.properties
     ) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createAnyOneOf(mergedSchemas),
         createProperties(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
 
@@ -377,56 +288,18 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.anyOf !== undefined
     ) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createAnyOneOf(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
 
     // Handles properties
     if (mergedSchemas.properties !== undefined) {
       return [
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-              paddingBottom: ".5rem",
-            },
-            children: ["Array ["],
-          }),
-        }),
+        createOpeningArrayBracket(),
         createProperties(mergedSchemas),
-        create("li", {
-          children: create("div", {
-            style: {
-              fontSize: "var(--ifm-code-font-size)",
-              opacity: "0.6",
-              marginLeft: "-.5rem",
-            },
-            children: ["]"],
-          }),
-        }),
+        createClosingArrayBracket(),
       ].flat();
     }
   }
@@ -439,44 +312,15 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "object"
   ) {
     return [
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-            paddingBottom: ".5rem",
-          },
-          children: ["Array ["],
-        }),
-      }),
+      createOpeningArrayBracket(),
       createNodes(schema.items),
-      create("li", {
-        children: create("div", {
-          style: {
-            fontSize: "var(--ifm-code-font-size)",
-            opacity: "0.6",
-            marginLeft: "-.5rem",
-          },
-          children: ["]"],
-        }),
-      }),
+      createClosingArrayBracket(),
     ].flat();
   }
 
   // TODO: clean this up or eliminate it?
   return [
-    create("li", {
-      children: create("div", {
-        style: {
-          fontSize: "var(--ifm-code-font-size)",
-          opacity: "0.6",
-          marginLeft: "-.5rem",
-          paddingBottom: ".5rem",
-        },
-        children: ["Array ["],
-      }),
-    }),
+    createOpeningArrayBracket(),
     Object.entries(schema.items!).map(([key, val]) =>
       createEdges({
         name: key,
@@ -486,16 +330,7 @@ function createItems(schema: SchemaObject) {
           : false,
       })
     ),
-    create("li", {
-      children: create("div", {
-        style: {
-          fontSize: "var(--ifm-code-font-size)",
-          opacity: "0.6",
-          marginLeft: "-.5rem",
-        },
-        children: ["]"],
-      }),
-    }),
+    createClosingArrayBracket(),
   ].flat();
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -220,15 +220,78 @@ function createAdditionalProperties(schema: SchemaObject) {
 // TODO: figure out how to handle array of objects
 function createItems(schema: SchemaObject) {
   if (schema.items?.properties !== undefined) {
-    return createProperties(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createProperties(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.additionalProperties !== undefined) {
-    return createAdditionalProperties(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createAdditionalProperties(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.oneOf !== undefined || schema.items?.anyOf !== undefined) {
-    return createAnyOneOf(schema.items!);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createAnyOneOf(schema.items!),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   if (schema.items?.allOf !== undefined) {
@@ -245,12 +308,29 @@ function createItems(schema: SchemaObject) {
         mergedSchemas.anyOf !== undefined) &&
       mergedSchemas.properties
     ) {
-      return create("div", {
-        children: [
-          createAnyOneOf(mergedSchemas),
-          createProperties(mergedSchemas),
-        ],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createAnyOneOf(mergedSchemas),
+        createProperties(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
 
     // Handles only anyOf/oneOf
@@ -258,16 +338,54 @@ function createItems(schema: SchemaObject) {
       mergedSchemas.oneOf !== undefined ||
       mergedSchemas.anyOf !== undefined
     ) {
-      return create("div", {
-        children: [createAnyOneOf(mergedSchemas)],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createAnyOneOf(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
 
     // Handles properties
     if (mergedSchemas.properties !== undefined) {
-      return create("div", {
-        children: [createProperties(mergedSchemas)],
-      });
+      return [
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+              paddingBottom: ".5rem",
+            },
+            children: ["Array ["],
+          }),
+        }),
+        createProperties(mergedSchemas),
+        create("li", {
+          children: create("div", {
+            style: {
+              fontSize: "var(--ifm-code-font-size)",
+              marginLeft: "-.5rem",
+            },
+            children: ["]"],
+          }),
+        }),
+      ].flat();
     }
   }
 
@@ -277,19 +395,61 @@ function createItems(schema: SchemaObject) {
     schema.items?.type === "integer" ||
     schema.items?.type === "boolean"
   ) {
-    return createNodes(schema.items);
+    return [
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+            paddingBottom: ".5rem",
+          },
+          children: ["Array ["],
+        }),
+      }),
+      createNodes(schema.items),
+      create("li", {
+        children: create("div", {
+          style: {
+            fontSize: "var(--ifm-code-font-size)",
+            marginLeft: "-.5rem",
+          },
+          children: ["]"],
+        }),
+      }),
+    ].flat();
   }
 
   // TODO: clean this up or eliminate it?
-  return Object.entries(schema.items!).map(([key, val]) =>
-    createEdges({
-      name: key,
-      schema: val,
-      required: Array.isArray(schema.required)
-        ? schema.required.includes(key)
-        : false,
-    })
-  );
+  return [
+    create("li", {
+      children: create("div", {
+        style: {
+          fontSize: "var(--ifm-code-font-size)",
+          marginLeft: "-.5rem",
+          paddingBottom: ".5rem",
+        },
+        children: ["Array ["],
+      }),
+    }),
+    Object.entries(schema.items!).map(([key, val]) =>
+      createEdges({
+        name: key,
+        schema: val,
+        required: Array.isArray(schema.required)
+          ? schema.required.includes(key)
+          : false,
+      })
+    ),
+    create("li", {
+      children: create("div", {
+        style: {
+          fontSize: "var(--ifm-code-font-size)",
+          marginLeft: "-.5rem",
+        },
+        children: ["]"],
+      }),
+    }),
+  ].flat();
 }
 
 /**
@@ -656,9 +816,12 @@ function createNodes(schema: SchemaObject): any {
   if (schema.allOf !== undefined) {
     const { mergedSchemas } = mergeAllOf(schema.allOf);
 
-    // allOf seems to always result in properties
     if (mergedSchemas.properties !== undefined) {
       nodes.push(createProperties(mergedSchemas));
+    }
+
+    if (mergedSchemas.items !== undefined) {
+      nodes.push(createItems(mergedSchemas));
     }
   }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -120,14 +120,10 @@ export function createResponseExamples(
   }
   return Object.entries(responseExamples).map(
     ([exampleName, exampleValue]: any) => {
-      const camelToSpaceName = exampleName.replace(/([A-Z])/g, " $1");
-      let finalFormattedName =
-        camelToSpaceName.charAt(0).toUpperCase() + camelToSpaceName.slice(1);
-
       if (typeof exampleValue.value === "object") {
         return create("TabItem", {
-          label: `${finalFormattedName}`,
-          value: `${finalFormattedName}`,
+          label: `${exampleName}`,
+          value: `${exampleName}`,
           children: [
             guard(exampleValue.summary, (summary) => [
               create("p", {
@@ -142,8 +138,8 @@ export function createResponseExamples(
         });
       }
       return create("TabItem", {
-        label: `${finalFormattedName}`,
-        value: `${finalFormattedName}`,
+        label: `${exampleName}`,
+        value: `${exampleName}`,
         children: [
           guard(exampleValue.summary, (summary) => [
             create("p", {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -6,10 +6,10 @@
  * ========================================================================== */
 
 import chalk from "chalk";
+import merge from "lodash/merge";
 
 import { mergeAllOf } from "../markdown/createRequestSchema";
 import { SchemaObject } from "./types";
-import merge from "lodash/merge";
 
 interface OASTypeToTypeMap {
   string: string;

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -6,10 +6,10 @@
  * ========================================================================== */
 
 import chalk from "chalk";
+import merge from "lodash/merge";
 
 import { mergeAllOf } from "../markdown/createResponseSchema";
 import { SchemaObject } from "./types";
-import merge from "lodash/merge";
 
 interface OASTypeToTypeMap {
   string: string;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -241,11 +241,11 @@ function SchemaTabsComponent(props) {
               (tabItem) => tabItem.props.value === defaultValue
             )[0],
           {
-            className: "margin-vert--md",
+            className: styles.marginVertical,
           }
         )
       ) : (
-        <div className="margin-vert--md">
+        <div className={styles.marginVertical}>
           {children.map((tabItem, i) =>
             cloneElement(tabItem, {
               key: i,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/styles.module.css
@@ -103,3 +103,8 @@
     width: 100%;
   }
 }
+
+.marginVertical {
+  margin-top: 1rem !important;
+  margin-bottom: unset !important;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -78,8 +78,12 @@
 
 .theme-api-markdown details li {
   list-style: none;
-  padding-bottom: 5px;
   padding-top: 5px;
+}
+
+.theme-api-markdown .tabs__item {
+  padding-bottom: unset;
+  padding-top: unset;
 }
 
 .theme-api-markdown details > div > div {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -249,6 +249,8 @@
   color: var(--ifm-color-success);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--python.tabs__item--active {
@@ -273,6 +275,8 @@
   color: var(--ifm-color-info);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--go.tabs__item--active {
@@ -297,6 +301,8 @@
   color: var(--ifm-color-warning);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--javascript.tabs__item--active {
@@ -321,6 +327,8 @@
   color: var(--ifm-color-danger);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--bash.tabs__item--active {
@@ -345,6 +353,8 @@
   color: var(--ifm-color-danger);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--ruby.tabs__item--active {
@@ -369,6 +379,8 @@
   color: var(--ifm-color-gray-500);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--csharp.tabs__item--active {
@@ -393,6 +405,8 @@
   color: var(--ifm-color-success);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--nodejs.tabs__item--active {
@@ -417,6 +431,8 @@
   color: var(--ifm-color-gray-500);
   padding-left: 1.4rem;
   padding-right: 1.4rem;
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
 }
 
 .code__tab--php.tabs__item--active {


### PR DESCRIPTION
## Description

Some schemas can implement more than one node type at the same level, such as `oneOf` and `properties`, or any other combination. This change introduces changes to how `createNodes` processes schemas. Previously, there was an ordered precedent applied whereby we exited after the first match. With these changes, now all node types will be collected in an array and returned together, in the order they were processed.

> Note: also includes improvements to how items/arrays are rendered

> Note: fixes formatting issues with example tab labels - basically, just leaves them as-is instead of attempting to un-camel-case and capitalize the first letter of each word

Preview: https://docusaurus-openapi-36b86--pr397-nr3rt8ms.web.app/

## Motivation and Context

Addresses issue observed in the following endpoint, whereby only the `oneOf` schema/node was processed and the `properties` were ignored: https://pan.dev/access/api/prisma-access-config/post-sse-config-v-1-address-groups/

Preview with fix: https://docusaurus-openapi-36b86--pr397-nr3rt8ms.web.app/config/post-sse-config-v-1-address-groups/

## How Has This Been Tested?

Tested with the Prisma Access Config `address-group` spec referenced above. Can be found here: https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/master/openapi-specs/access/prisma-access-config/AddressGroups.yaml

Additional testing is required to ensure no regression bugs are introduced.