### PR TITLE
[FR] Added support for summary and description for param schema examples

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -88,27 +88,26 @@ function ParamsItem({
   const renderExamples = guard(examples, (examples) => {
     const exampleEntries = Object.entries(examples);
     return (
-      <SchemaTabs>
-        {exampleEntries.map(([exampleName, exampleProperties]) => (
-          <TabItem
-            className={styles.paramsItemExamplesContainer}
-            value={exampleName}
-            label={exampleName}
-          >
-            {exampleProperties.summary && <p>{exampleProperties.summary}</p>}
-            {exampleProperties.description && (
+      <>
+        <strong>Examples:</strong>
+        <SchemaTabs>
+          {exampleEntries.map(([exampleName, exampleProperties]) => (
+            <TabItem value={exampleName} label={exampleName}>
+              {exampleProperties.summary && <p>{exampleProperties.summary}</p>}
+              {exampleProperties.description && (
+                <p>
+                  <strong>Description: </strong>
+                  <span>{exampleProperties.description}</span>
+                </p>
+              )}
               <p>
-                <strong>Description: </strong>
-                <span>{exampleProperties.description}</span>
+                <strong>Example: </strong>
+                <code>{exampleProperties.value}</code>
               </p>
-            )}
-            <p>
-              <strong>Example: </strong>
-              <code>{exampleProperties.value}</code>
-            </p>
-          </TabItem>
-        ))}
-      </SchemaTabs>
+            </TabItem>
+          ))}
+        </SchemaTabs>
+      </>
     );
   });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -17,6 +17,8 @@ import {
 } from "docusaurus-theme-openapi-docs/lib/markdown/schema";
 /* eslint-disable import/no-extraneous-dependencies*/
 import { guard } from "docusaurus-theme-openapi-docs/lib/markdown/utils";
+import SchemaTabs from "@theme/SchemaTabs";
+import TabItem from "@theme/TabItem";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 
@@ -77,20 +79,40 @@ function ParamsItem({
   );
 
   const renderExample = guard(example, (example) => (
-    <div>{`Example: ${example}`}</div>
+    <>
+      <strong>Example: </strong>
+      {example}
+    </>
   ));
 
   const renderExamples = guard(examples, (examples) => {
     const exampleEntries = Object.entries(examples);
     return (
-      <>
-        {exampleEntries.map(([k, v]) => (
-          <div>{`Example (${k}): ${v.value}`}</div>
+      <SchemaTabs>
+        {exampleEntries.map(([exampleName, exampleProperties]) => (
+          <TabItem
+            className={styles.paramsItemExamplesContainer}
+            value={exampleName}
+            label={exampleName}
+          >
+            {exampleProperties.summary && <p>{exampleProperties.summary}</p>}
+            {exampleProperties.description && (
+              <p>
+                <strong>Description: </strong>
+                <span>{exampleProperties.description}</span>
+              </p>
+            )}
+            <p>
+              <strong>Example: </strong>
+              <code>{exampleProperties.value}</code>
+            </p>
+          </TabItem>
         ))}
-      </>
+      </SchemaTabs>
     );
   });
 
+  console.log(example, examples);
   return (
     <li className={styles.paramsItem}>
       <strong>{name}</strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -8,6 +8,8 @@
 import React from "react";
 
 import CodeBlock from "@theme/CodeBlock";
+import SchemaTabs from "@theme/SchemaTabs";
+import TabItem from "@theme/TabItem";
 /* eslint-disable import/no-extraneous-dependencies*/
 import { createDescription } from "docusaurus-theme-openapi-docs/lib/markdown/createDescription";
 /* eslint-disable import/no-extraneous-dependencies*/
@@ -17,8 +19,6 @@ import {
 } from "docusaurus-theme-openapi-docs/lib/markdown/schema";
 /* eslint-disable import/no-extraneous-dependencies*/
 import { guard } from "docusaurus-theme-openapi-docs/lib/markdown/utils";
-import SchemaTabs from "@theme/SchemaTabs";
-import TabItem from "@theme/TabItem";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 
@@ -112,7 +112,6 @@ function ParamsItem({
     );
   });
 
-  console.log(example, examples);
   return (
     <li className={styles.paramsItem}>
       <strong>{name}</strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/styles.module.css
@@ -14,10 +14,6 @@
   background-color: var(--ifm-menu-color-background-active);
 }
 
-.paramsItemExamplesContainer {
-  padding-bottom: 1rem;
-}
-
 .schemaName {
   opacity: 0.6;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/styles.module.css
@@ -14,6 +14,10 @@
   background-color: var(--ifm-menu-color-background-active);
 }
 
+.paramsItemExamplesContainer {
+  padding-bottom: 1rem;
+}
+
 .schemaName {
   opacity: 0.6;
 }


### PR DESCRIPTION
## Description

This PR introduces support for rendering `summary` and `description` for param schemas that contain multiple examples. In addition, users are now able to tab through the provided examples in order to minimize any UI bloating.

## Motivation and Context

See #398 for context

## How Has This Been Tested?

Tested with https://gist.github.com/paulo-raca/c82e211f6b4218003fef2f957488b319#file-openapi-json
- Ensure build works as expected 
- CSS changes are only applied to `ParamsItem` that contained multiple examples

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/48506502/217336874-09fe15c9-ed05-4155-9c3b-9d13b9838208.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
