### PR TITLE
Remove double scrollbars on codeblocks in code tabs

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -280,7 +280,9 @@ function Curl({ postman, codeSamples }: Props) {
               }
               attributes={{ className: `code__tab--${lang.logoClass}` }}
             >
-              <CodeBlock language={lang.highlight}>{codeText}</CodeBlock>
+              <CodeBlock language={lang.highlight} className={styles.codeBlock}>
+                {codeText}
+              </CodeBlock>
             </CodeTab>
           );
         })}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/styles.module.css
@@ -82,3 +82,8 @@
   background: var(--ifm-menu-color-background-active);
   color: var(--ifm-menu-color-active);
 }
+
+.codeBlock code {
+  max-width: revert;
+  max-height: revert;
+}


### PR DESCRIPTION
## Description

Removes the double scroll bars by reverting `max-height` and `max-width` defined [here](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/767cb952ac9dbcd9ad48e15f362eb79754b080f6/packages/docusaurus-theme-openapi-docs/src/theme/styles.css#L160-L164). It may make more sense to remove that top-level style, but without knowing where it applies, this option fixes the issue and is less intrusive.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #416 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in Chrome, Firefox, and Safari on Mac

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
