### PR TITLE
Clarify support for OpenAPI 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `docusaurus-plugin-openapi-docs` package extends the Docusaurus CLI with com
 
 Key Features:
 
-- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.x.
+- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.0.
 - **Fast:** Convert large OpenAPI specs into MDX docs in seconds. 🔥
 - **Stylish:** Based on the same [Infima styling framework](https://infima.dev/) that powers the Docusaurus UI.
 - **Capable:** Supports single, multi and _even micro_ OpenAPI specs.

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -47,7 +47,7 @@ The `docusaurus-plugin-openapi-docs` package extends the Docusaurus CLI with com
 
 Key Features:
 
-- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.x.
+- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.0.
 - **Fast:** Convert large OpenAPI specs into MDX docs in seconds. 🔥
 - **Stylish:** Based on the same [Infima styling framework](https://infima.dev/) that powers the Docusaurus UI.
 - **Capable:** Supports single, multi and _even micro_ OpenAPI specs.


### PR DESCRIPTION
## Description

Clarify that only OpenAPI 3.0 is supported so as not to imply 3.1 support.