### PR TITLE
Clarify OAS versions support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `docusaurus-plugin-openapi-docs` package extends the Docusaurus CLI with com
 
 Key Features:
 
-- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.0.
+- **Compatible:** Works with Swagger 2.0, OpenAPI 3.0, and OpenAPI 3.1.
 - **Fast:** Convert large OpenAPI specs into MDX docs in seconds. 🔥
 - **Stylish:** Based on the same [Infima styling framework](https://infima.dev/) that powers the Docusaurus UI.
 - **Capable:** Supports single, multi and _even micro_ OpenAPI specs.

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -47,7 +47,7 @@ The `docusaurus-plugin-openapi-docs` package extends the Docusaurus CLI with com
 
 Key Features:
 
-- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.0.
+- **Compatible:** Works with Swagger 2.0, OpenAPI 3.0, and OpenAPI 3.1.
 - **Fast:** Convert large OpenAPI specs into MDX docs in seconds. 🔥
 - **Stylish:** Based on the same [Infima styling framework](https://infima.dev/) that powers the Docusaurus UI.
 - **Capable:** Supports single, multi and _even micro_ OpenAPI specs.


### PR DESCRIPTION
## Description
Hello there! I was wondering whether your plugin supports OAS 3.1 documents. Thank you!
<!--- Describe your changes in detail -->

## Motivation and Context
I believe OAS 3.1.0 support is relevant and it's probably a good idea to have that mentioned in the README.md file, in case it is supported by now.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
For the moment, I can see in `node_modules/@redocly/openapi-core/lib/oas-types.js` that 3.1 is accepted, however I'd like to know whether there's actual support, or it's just treating 3.1 docs the same way it treats 3.0 docs.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
- New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
