### PR TITLE
Convert title heading from h2 to h1 for better a11y

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -225,7 +225,7 @@ const config = {
             },
           },
           petstore: {
-            specPath: "examples/petstore",
+            specPath: "examples/petstore.yaml",
             proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -225,8 +225,7 @@ const config = {
             },
           },
           petstore: {
-            specPath:
-              "https://raw.githubusercontent.com/benlei/docusaurus-openapi-docs-failed-to-gen/master/examples/petstore.yaml",
+            specPath: "examples/petstore",
             proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { create, guard } from "./utils";
+import { create } from "./utils";
 
 export function createHeading(heading: string) {
   return [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
@@ -1,0 +1,18 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { create, guard } from "./utils";
+
+export function createHeading(heading: string) {
+  return [
+    create("h1", {
+      className: "openapi__heading",
+      children: `${heading}`,
+    }),
+    `\n\n`,
+  ];
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -95,7 +95,7 @@ export function createInfoPageMD({
 
     createVersionBadge(version),
     createDownload(downloadUrl),
-    `# ${title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")}\n\n`,
+    createHeading(title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")),
     createLogo(logo, darkLogo),
     createDescription(description),
     createAuthentication(securitySchemes as unknown as SecuritySchemeObject),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -17,6 +17,7 @@ import { createContactInfo } from "./createContactInfo";
 import { createDeprecationNotice } from "./createDeprecationNotice";
 import { createDescription } from "./createDescription";
 import { createDownload } from "./createDownload";
+import { createHeading } from "./createHeading";
 import { createLicense } from "./createLicense";
 import { createLogo } from "./createLogo";
 import { createParamsDetails } from "./createParamsDetails";
@@ -57,7 +58,7 @@ export function createApiPageMD({
     `import SchemaTabs from "@theme/SchemaTabs";\n`,
     `import DiscriminatorTabs from "@theme/DiscriminatorTabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
-    `## ${title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")}\n\n`,
+    createHeading(title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")),
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(description),
     createParamsDetails({ parameters, type: "path" }),

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -483,5 +483,5 @@
 }
 
 .openapi__heading {
-  font-size: 30.4px;
+  font-size: var(--ifm-h1-font-size);
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -476,6 +476,12 @@
   white-space: pre !important;
 }
 
+/* Begin BEM-style CSS styles */
+
 .openapi__logo {
   width: 250px;
+}
+
+.openapi__heading {
+  font-size: 30.4px;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -485,7 +485,7 @@
 .openapi__heading {
   font-size: var(--ifm-h1-font-size);
 }
- 
+
 /* Method Endpoint Styles */
 .openapi__method-endpoint {
   max-width: 100%;


### PR DESCRIPTION
## Description

See #419 for background

> Also introduces `openpai__heading` style.