### PR TITLE
Handle missing params/header schema

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -223,7 +223,8 @@ const config = {
             },
           },
           petstore: {
-            specPath: "examples/petstore.yaml",
+            specPath:
+              "https://raw.githubusercontent.com/benlei/docusaurus-openapi-docs-failed-to-gen/master/examples/petstore.yaml",
             proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -62,46 +62,45 @@ function createResponseHeaders(responseHeaders: any) {
     create("ul", {
       style: { marginLeft: "1rem" },
       children: [
-        Object.entries(responseHeaders).map(([headerName, headerObj]) => {
-          const {
-            description,
-            schema: { type },
-            example,
-          }: any = headerObj;
+        Object.entries(responseHeaders).map(
+          ([headerName, headerObj]: [any, any]) => {
+            const { description, example }: any = headerObj;
+            const type = headerObj.schema?.type ?? "any";
 
-          return create("li", {
-            className: "schemaItem",
-            children: [
-              createDetailsSummary({
-                children: [
-                  create("strong", { children: headerName }),
-                  guard(type, () => [
-                    create("span", {
-                      style: { opacity: "0.6" },
-                      children: ` ${type}`,
-                    }),
-                  ]),
-                ],
-              }),
-              create("div", {
-                children: [
-                  guard(description, (description) =>
-                    create("div", {
-                      style: {
-                        marginTop: ".5rem",
-                        marginBottom: ".5rem",
-                      },
-                      children: [
-                        guard(example, () => `Example: ${example}`),
-                        createDescription(description),
-                      ],
-                    })
-                  ),
-                ],
-              }),
-            ],
-          });
-        }),
+            return create("li", {
+              className: "schemaItem",
+              children: [
+                createDetailsSummary({
+                  children: [
+                    create("strong", { children: headerName }),
+                    guard(type, () => [
+                      create("span", {
+                        style: { opacity: "0.6" },
+                        children: ` ${type}`,
+                      }),
+                    ]),
+                  ],
+                }),
+                create("div", {
+                  children: [
+                    guard(description, (description) =>
+                      create("div", {
+                        style: {
+                          marginTop: ".5rem",
+                          marginBottom: ".5rem",
+                        },
+                        children: [
+                          guard(example, () => `Example: ${example}`),
+                          createDescription(description),
+                        ],
+                      })
+                    ),
+                  ],
+                }),
+              ],
+            });
+          }
+        ),
       ],
     })
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -30,6 +30,10 @@ import styles from "./styles.module.css";
 function ParamsItem({
   param: { description, example, examples, name, required, schema },
 }) {
+  if (!schema || !schema?.type) {
+    schema = { type: "any" };
+  }
+
   const renderSchemaName = guard(schema, (schema) => (
     <span className={styles.schemaName}> {getSchemaName(schema)}</span>
   ));


### PR DESCRIPTION
## Description

Addresses #430 

Not so much a bug as it is an enhancement or opinionated approach to supporting missing `schema` or `schema.type` definitions.

> I did a bit more research and came across this thread: https://github.com/OAI/OpenAPI-Specification/issues/1657
  After skimming through some of the responses/opinions, I think there's a strong case/consensus around interpreting no 
  schema.type as "any" - or, basically leaving it up to the tooling to decide how to handle those cases.