### PR TITLE
Lock supported docusaurus versions

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -21,10 +21,10 @@
     "re-gen": "yarn clean-all && yarn gen-all"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.1",
-    "@docusaurus/plugin-google-gtag": "^2.0.1",
-    "@docusaurus/plugin-pwa": "^2.0.1",
-    "@docusaurus/preset-classic": "^2.0.1",
+    "@docusaurus/core": ">=2.0.1 <2.3.0",
+    "@docusaurus/plugin-google-gtag": ">=2.0.1 <2.3.0",
+    "@docusaurus/plugin-pwa": ">=2.0.1 <2.3.0",
+    "@docusaurus/preset-classic": ">=2.0.1 <2.3.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "docusaurus-plugin-openapi-docs": "^1.5.2",

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -28,8 +28,8 @@
     "watch": "tsc --watch"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.1",
-    "@docusaurus/types": "^2.0.1",
+    "@docusaurus/module-type-aliases": ">=2.0.1 <2.3.0",
+    "@docusaurus/types": ">=2.0.1 <2.3.0",
     "@types/fs-extra": "^9.0.13",
     "@types/js-yaml": "^4.0.5",
     "@types/json-pointer": "^1.0.31",
@@ -40,10 +40,10 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
-    "@docusaurus/mdx-loader": "^2.0.1",
-    "@docusaurus/plugin-content-docs": "^2.0.1",
-    "@docusaurus/utils": "^2.0.1",
-    "@docusaurus/utils-validation": "^2.0.1",
+    "@docusaurus/mdx-loader": ">=2.0.1 <2.3.0",
+    "@docusaurus/plugin-content-docs": ">=2.0.1 <2.3.0",
+    "@docusaurus/utils": ">=2.0.1 <2.3.0",
+    "@docusaurus/utils-validation": ">=2.0.1 <2.3.0",
     "@paloaltonetworks/openapi-to-postmanv2": "3.1.0-hotfix.1",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@redocly/openapi-core": "^1.0.0-beta.103",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -31,8 +31,8 @@
     "format:lib-next": "prettier --config ../../.prettierrc.json --write \"lib-next/**/*.{js,ts,jsx,tsc}\""
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.1",
-    "@docusaurus/types": "^2.0.1",
+    "@docusaurus/module-type-aliases": ">=2.0.1 <2.3.0",
+    "@docusaurus/types": ">=2.0.1 <2.3.0",
     "@types/concurrently": "^6.3.0",
     "@types/crypto-js": "^4.1.0",
     "@types/file-saver": "^2.0.5",
@@ -43,7 +43,7 @@
     "concurrently": "^5.2.0"
   },
   "dependencies": {
-    "@docusaurus/theme-common": "^2.0.1",
+    "@docusaurus/theme-common": ">=2.0.1 <2.3.0",
     "@mdx-js/react": "^1.6.21",
     "@paloaltonetworks/postman-code-generators": "^1.1.15",
     "@paloaltonetworks/postman-collection": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,7 +1304,7 @@
     "@docsearch/css" "3.3.0"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.2.0", "@docusaurus/core@^2.0.1":
+"@docusaurus/core@2.2.0", "@docusaurus/core@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.2.0.tgz#64c9ee31502c23b93c869f8188f73afaf5fd4867"
   integrity sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==
@@ -1399,7 +1399,7 @@
     chalk "^4.1.2"
     tslib "^2.4.0"
 
-"@docusaurus/mdx-loader@2.2.0", "@docusaurus/mdx-loader@^2.0.1":
+"@docusaurus/mdx-loader@2.2.0", "@docusaurus/mdx-loader@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz#fd558f429e5d9403d284bd4214e54d9768b041a0"
   integrity sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==
@@ -1422,7 +1422,7 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
-"@docusaurus/module-type-aliases@2.2.0", "@docusaurus/module-type-aliases@^2.0.1":
+"@docusaurus/module-type-aliases@2.2.0", "@docusaurus/module-type-aliases@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz#1e23e54a1bbb6fde1961e4fa395b1b69f4803ba5"
   integrity sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==
@@ -1458,7 +1458,7 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-docs@2.2.0", "@docusaurus/plugin-content-docs@^2.0.1":
+"@docusaurus/plugin-content-docs@2.2.0", "@docusaurus/plugin-content-docs@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz#0fcb85226fcdb80dc1e2d4a36ef442a650dcc84d"
   integrity sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==
@@ -1516,7 +1516,7 @@
     "@docusaurus/utils-validation" "2.2.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-gtag@2.2.0", "@docusaurus/plugin-google-gtag@^2.0.1":
+"@docusaurus/plugin-google-gtag@2.2.0", "@docusaurus/plugin-google-gtag@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz#7b086d169ac5fe9a88aca10ab0fd2bf00c6c6b12"
   integrity sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==
@@ -1526,7 +1526,7 @@
     "@docusaurus/utils-validation" "2.2.0"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-pwa@^2.0.1":
+"@docusaurus/plugin-pwa@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-pwa/-/plugin-pwa-2.2.0.tgz#2aca00d268efbca8f3cf1c3e260b801e6f7f8af5"
   integrity sha512-j1ldskYXkKYmWB6V1I0Lv2o9EUhSdGI6pCo0RFGaLijJKLlA9R+F5j+0kWvoyirXM7LRGknkXYYkc50i25R5Sw==
@@ -1565,7 +1565,7 @@
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@^2.0.1":
+"@docusaurus/preset-classic@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz#bece5a043eeb74430f7c6c7510000b9c43669eb7"
   integrity sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==
@@ -1622,7 +1622,7 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@2.2.0", "@docusaurus/theme-common@^2.0.1":
+"@docusaurus/theme-common@2.2.0", "@docusaurus/theme-common@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.2.0.tgz#2303498d80448aafdd588b597ce9d6f4cfa930e4"
   integrity sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==
@@ -1672,7 +1672,7 @@
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.2.0", "@docusaurus/types@^2.0.1":
+"@docusaurus/types@2.2.0", "@docusaurus/types@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.2.0.tgz#02c577a4041ab7d058a3c214ccb13647e21a9857"
   integrity sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==
@@ -1693,7 +1693,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@docusaurus/utils-validation@2.2.0", "@docusaurus/utils-validation@^2.0.1":
+"@docusaurus/utils-validation@2.2.0", "@docusaurus/utils-validation@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz#04d4d103137ad0145883971d3aa497f4a1315f25"
   integrity sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==
@@ -1704,7 +1704,7 @@
     js-yaml "^4.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/utils@2.2.0", "@docusaurus/utils@^2.0.1":
+"@docusaurus/utils@2.2.0", "@docusaurus/utils@>=2.0.1 <2.3.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.2.0.tgz#3d6f9b7a69168d5c92d371bf21c556a4f50d1da6"
   integrity sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==


### PR DESCRIPTION
## Description

Locking compatible Docusaurus versions.

## Motivation and Context

Docusaurus 2.3.0 introduced breaking changes that will not be supported in the `docusaurus-openapi-docs` 1.x.x release train. Instead, support for 2.3.0 will be introduced in the upcoming `docusaurus-openapi-docs` v2.0.0.

## How Has This Been Tested?

After merging, the plan is to test the canary release against a template and vanilla Docusaurus project.