### PR TITLE
[Enhancement] Add option to hide send button

### DIFF
--- a/demo/api.mustache
+++ b/demo/api.mustache
@@ -28,6 +28,9 @@ custom_edit_url: null
 {{#frontMatter.proxy}}
 proxy: {{{frontMatter.proxy}}}
 {{/frontMatter.proxy}}
+{{#frontMatter.hide_send_button}}
+hide_send_button: true
+{{/frontMatter.hide_send_button}}
 ---
 
 {{{markdown}}}

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -233,7 +233,6 @@ const config = {
             template: "api.mustache", // Customize API MDX with mustache template
             downloadUrl:
               "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
-            hideSendButton: true,
           },
           cos: {
             specPath: "examples/openapi-cos.json",

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -233,6 +233,7 @@ const config = {
             template: "api.mustache", // Customize API MDX with mustache template
             downloadUrl:
               "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
+            hideSendButton: true,
           },
           cos: {
             specPath: "examples/openapi-cos.json",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -190,6 +190,9 @@ custom_edit_url: null
 {{#frontMatter.proxy}}
 proxy: {{{frontMatter.proxy}}}
 {{/frontMatter.proxy}}
+{{#frontMatter.hide_send_button}}
+hide_send_button: true
+{{/frontMatter.hide_send_button}}
 ---
 
 {{{markdown}}}

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -221,6 +221,9 @@ function createItems(
                 .replace(/\s+$/, "")
             : "",
           ...(options?.proxy && { proxy: options.proxy }),
+          ...(options?.hideSendButton && {
+            hide_send_button: options.hideSendButton,
+          }),
         },
         api: {
           ...defaults,
@@ -338,6 +341,9 @@ function createItems(
                 .replace(/\s+$/, "")
             : "",
           ...(options?.proxy && { proxy: options.proxy }),
+          ...(options?.hideSendButton && {
+            hide_send_button: options.hideSendButton,
+          }),
         },
         api: {
           ...defaults,

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -27,6 +27,7 @@ export const OptionsSchema = Joi.object({
         outputDir: Joi.string().required(),
         template: Joi.string(),
         downloadUrl: Joi.string(),
+        hideSendButton: Joi.boolean(),
         sidebarOptions: sidebarOptions,
         version: Joi.string().when("versions", {
           is: Joi.exist(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -33,6 +33,7 @@ export interface APIOptions {
   outputDir: string;
   template?: string;
   downloadUrl?: string;
+  hideSendButton?: boolean;
   sidebarOptions?: SidebarOptions;
   version?: string;
   label?: string;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Request/index.tsx
@@ -25,7 +25,7 @@ function Request({ item }: { item: NonNullable<ApiItem> }) {
   const response = useTypedSelector((state: any) => state.response.value);
   const postman = new sdk.Request(item.postman);
   const metadata = useDoc();
-  const { proxy } = metadata.frontMatter;
+  const { proxy, hide_send_button } = metadata.frontMatter;
 
   const params = {
     path: [] as ParameterObject[],
@@ -48,7 +48,9 @@ function Request({ item }: { item: NonNullable<ApiItem> }) {
         <summary>
           <div className={`details__request-summary`}>
             <h4>Request</h4>
-            {item.servers && <Execute postman={postman} proxy={proxy} />}
+            {item.servers && !hide_send_button && (
+              <Execute postman={postman} proxy={proxy} />
+            )}
           </div>
         </summary>
         <div className={styles.optionsPanel}>


### PR DESCRIPTION
## Description

Introduces `hideSendButton` option for manually hiding `Send Request` button.

## Motivation and Context

Gives users option to disable "try it" feature.

## How Has This Been Tested?

See deploy preview.