### PR TITLE
Prepare release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.6.0 (Feb 24, 2023)
+
+High level enhancements
+
+- Add support for security vendor extensions ([#457](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/457))
+- [Enhancement] Add option to hide send button ([#456](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/456))
+- Lock supported docusaurus versions ([#449](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/449))
+- Handle missing params/header schema ([#446](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/446))
+- Apply docusaurus.io styles to demo ([#443](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/443))
+- [FR] Added support for summary and description for param schema examples ([#406](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/406))
+
+Other enhancements and bug fixes
+
+- Avoid falling back to MOD label when rendering oneOf/anyOf and title not defined ([#455](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/455))
+- Expand support for nullable objects and default to any for empty/unknown schemas ([#452](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/452))
+- Fix security schemes ([#444](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/444))
+- [bug] Use toString() utility to always convert example to string ([#442](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/442))
+- Improve handling of non-string default values ([#436](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/436))
+- Remove trailing slash in outputDir option if present ([#435](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/435))
+- Fix: date-time examples should include time ([#427](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/427))
+- Fix logo/darkLogo and colorMode synching ([#426](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/426))
+- fix: fix logic that determines if an object property is required in response ([#424](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/424))
+- Implement NodePolyfillPlugin in theme webpack config ([#422](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/422))
+- revert `max-width` and `max-height` on code blocks in code tabs ([#417](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/417))
+- Update sidebars.md ([#413](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/413))
+- Clarify support for OpenAPI 3.0 ([#420](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/420))
+- Add support for java and expand language variants ([#404](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/404))
+
 ## 1.5.2 (Feb 2, 2023)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -27,8 +27,8 @@
     "@docusaurus/preset-classic": ">=2.0.1 <2.3.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.5.2",
-    "docusaurus-theme-openapi-docs": "^1.5.2",
+    "docusaurus-plugin-openapi-docs": "^1.6.0",
+    "docusaurus-theme-openapi-docs": "^1.6.0",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.2",
+  "version": "1.6.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -51,7 +51,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.5.2",
+    "docusaurus-plugin-openapi-docs": "^1.6.0",
     "file-saver": "^2.0.5",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",


### PR DESCRIPTION
## Description

### v1.6.0 (Feb 24, 2023)

High level enhancements

- Add support for security vendor extensions ([#457](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/457))
- [Enhancement] Add option to hide send button ([#456](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/456))
- Lock supported docusaurus versions ([#449](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/449))
- Handle missing params/header schema ([#446](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/446))
- Apply docusaurus.io styles to demo ([#443](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/443))
- [FR] Added support for summary and description for param schema examples ([#406](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/406))

Other enhancements and bug fixes

- Avoid falling back to MOD label when rendering oneOf/anyOf and title not defined ([#455](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/455))
- Expand support for nullable objects and default to any for empty/unknown schemas ([#452](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/452))
- Fix security schemes ([#444](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/444))
- [bug] Use toString() utility to always convert example to string ([#442](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/442))
- Improve handling of non-string default values ([#436](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/436))
- Remove trailing slash in outputDir option if present ([#435](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/435))
- Fix: date-time examples should include time ([#427](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/427))
- Fix logo/darkLogo and colorMode synching ([#426](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/426))
- fix: fix logic that determines if an object property is required in response ([#424](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/424))
- Implement NodePolyfillPlugin in theme webpack config ([#422](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/422))
- revert `max-width` and `max-height` on code blocks in code tabs ([#417](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/417))
- Update sidebars.md ([#413](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/413))
- Clarify support for OpenAPI 3.0 ([#420](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/420))
- Add support for java and expand language variants ([#404](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/404))