### PR TITLE
[FR] Add class to response tabs to differentiate success/error

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.js
@@ -188,12 +188,12 @@ function ApiTabsComponent(props) {
             )}
           >
             {values.map(({ value, label, attributes }) => {
-              const responseTabDotStyle =
+              const responseStatusStyle =
                 parseInt(value) >= 400
-                  ? styles.responseTabDotDanger
+                  ? styles.responseStatusDanger
                   : parseInt(value) >= 200 && parseInt(value) < 300
-                  ? styles.responseTabDotSuccess
-                  : styles.responseTabDotInfo;
+                  ? styles.responseStatusSuccess
+                  : styles.responseStatusInfo;
 
               return (
                 <li
@@ -210,14 +210,13 @@ function ApiTabsComponent(props) {
                     "tabs__item",
                     styles.tabItem,
                     attributes?.className,
+                    responseStatusStyle,
                     {
-                      [styles.responseTabActive]: selectedValue === value,
+                      [styles.active]: selectedValue === value,
                     }
                   )}
                 >
-                  <div
-                    className={clsx(styles.responseTabDot, responseTabDotStyle)}
-                  />
+                  <div className={styles.responseTabDot} />
                   {label ?? value}
                 </li>
               );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/styles.module.css
@@ -18,13 +18,36 @@
   font-weight: var(--ifm-font-weight-normal);
 }
 
-.tabItem:not(.responseTabActive) {
+.responseStatusSuccess {
+  border: none;
+  color: var(--ifm-color-success);
+}
+
+.responseStatusSuccess.active {
+  background-color: var(--ifm-color-success);
+  color: white;
+}
+
+.responseStatusDanger {
+  border: none;
+  color: var(--ifm-color-danger);
+}
+
+.responseStatusDanger.active {
+  background-color: var(--ifm-color-danger);
+  color: white;
+}
+
+.responseTabDot {
+  display: none;
+}
+
+.tabItem:not(.active) {
   opacity: 0.65;
 }
 
 .tabItem:hover {
   opacity: 1;
-  background-color: var(--ifm-color-emphasis-100);
 }
 
 .tabItem:last-child {
@@ -66,19 +89,19 @@
   border-radius: 50%;
 }
 
-.responseTabDotSuccess {
+.responseStatusSuccess > .responseTabDot {
   background-color: var(--ifm-color-success);
 }
 
-.responseTabDotDanger {
+.responseStatusDanger > .responseTabDot {
   background-color: var(--ifm-color-danger);
 }
 
-.responseTabDotInfo {
+.responseStatusInfo > .responseTabDot {
   background-color: var(--ifm-color-info);
 }
 
-.responseTabActive {
+.active {
   background-color: var(--ifm-color-emphasis-100);
 }
 


### PR DESCRIPTION
## Description

Addresses #460 

This PR consists of added support for styling response tabs based on the status code. Previously, the `responseTabDotStyle` was scoped to response tab dots, but has now been renamed and moved to the parent element to allow styling of the base response tab item.

## How Has This Been Tested?

Tested with Petstore API and styled tabs based on the `responseStatusStyle`

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/48506502/221682102-ae73b2a3-e1ed-4065-bde9-48cbbcc9b147.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
