### PR TITLE
Add support for rendering additionalProperties schemas

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -160,7 +160,7 @@ function createAdditionalProperties(schema: SchemaObject) {
   const additionalProperties = schema.additionalProperties;
   const type: string | unknown = additionalProperties?.type;
   if (
-    type === "object" &&
+    (type === "object" || type === "array") &&
     (additionalProperties?.properties ||
       additionalProperties?.items ||
       additionalProperties?.allOf ||

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -34,7 +34,7 @@ export function mergeAllOf(allOf: SchemaObject[]) {
         return true;
       },
     },
-    ignoreAdditionalProperties: true,
+    ignoreAdditionalProperties: false,
   });
 
   const required = allOf.reduce((acc, cur) => {
@@ -157,6 +157,19 @@ function createAdditionalProperties(schema: SchemaObject) {
   //   },
   //   type: 'array'
   // }
+  const type: string | unknown = schema.additionalProperties?.type;
+  if (type === "object" && schema.additionalProperties) {
+    const title = schema.additionalProperties.title;
+    const schemaName = title ? `object (${title})` : "object";
+    const required = schema.required ?? false;
+    return createDetailsNode(
+      "property name*",
+      schemaName,
+      schema.additionalProperties,
+      required,
+      schema.nullable
+    );
+  }
 
   if (
     (schema.additionalProperties?.type as string) === "string" ||
@@ -165,7 +178,6 @@ function createAdditionalProperties(schema: SchemaObject) {
     (schema.additionalProperties?.type as string) === "integer" ||
     (schema.additionalProperties?.type as string) === "number"
   ) {
-    const type = schema.additionalProperties?.type;
     const additionalProperties =
       schema.additionalProperties?.additionalProperties;
     if (additionalProperties !== undefined) {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -157,15 +157,24 @@ function createAdditionalProperties(schema: SchemaObject) {
   //   },
   //   type: 'array'
   // }
-  const type: string | unknown = schema.additionalProperties?.type;
-  if (type === "object" && schema.additionalProperties) {
-    const title = schema.additionalProperties.title;
+  const additionalProperties = schema.additionalProperties;
+  const type: string | unknown = additionalProperties?.type;
+  if (
+    type === "object" &&
+    (additionalProperties?.properties ||
+      additionalProperties?.items ||
+      additionalProperties?.allOf ||
+      additionalProperties?.additionalProperties ||
+      additionalProperties?.oneOf ||
+      additionalProperties?.anyOf)
+  ) {
+    const title = additionalProperties.title;
     const schemaName = title ? `object (${title})` : "object";
     const required = schema.required ?? false;
     return createDetailsNode(
       "property name*",
       schemaName,
-      schema.additionalProperties,
+      additionalProperties,
       required,
       schema.nullable
     );

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -166,7 +166,7 @@ function createAdditionalProperties(schema: SchemaObject) {
   const additionalProperties = schema.additionalProperties;
   const type: string | unknown = additionalProperties?.type;
   if (
-    type === "object" &&
+    (type === "object" || type === "array") &&
     (additionalProperties?.properties ||
       additionalProperties?.items ||
       additionalProperties?.allOf ||

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -163,15 +163,24 @@ function createAdditionalProperties(schema: SchemaObject) {
   //   },
   //   type: 'array'
   // }
-  const type: string | unknown = schema.additionalProperties?.type;
-  if (type === "object" && schema.additionalProperties) {
-    const title = schema.additionalProperties.title;
+  const additionalProperties = schema.additionalProperties;
+  const type: string | unknown = additionalProperties?.type;
+  if (
+    type === "object" &&
+    (additionalProperties?.properties ||
+      additionalProperties?.items ||
+      additionalProperties?.allOf ||
+      additionalProperties?.additionalProperties ||
+      additionalProperties?.oneOf ||
+      additionalProperties?.anyOf)
+  ) {
+    const title = additionalProperties.title;
     const schemaName = title ? `object (${title})` : "object";
     const required = schema.required ?? false;
     return createDetailsNode(
       "property name*",
       schemaName,
-      schema.additionalProperties,
+      additionalProperties,
       required,
       schema.nullable
     );

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -163,6 +163,19 @@ function createAdditionalProperties(schema: SchemaObject) {
   //   },
   //   type: 'array'
   // }
+  const type: string | unknown = schema.additionalProperties?.type;
+  if (type === "object" && schema.additionalProperties) {
+    const title = schema.additionalProperties.title;
+    const schemaName = title ? `object (${title})` : "object";
+    const required = schema.required ?? false;
+    return createDetailsNode(
+      "property name*",
+      schemaName,
+      schema.additionalProperties,
+      required,
+      schema.nullable
+    );
+  }
 
   if (
     (schema.additionalProperties?.type as string) === "string" ||
@@ -171,7 +184,6 @@ function createAdditionalProperties(schema: SchemaObject) {
     (schema.additionalProperties?.type as string) === "integer" ||
     (schema.additionalProperties?.type as string) === "number"
   ) {
-    const type = schema.additionalProperties?.type;
     const additionalProperties =
       schema.additionalProperties?.additionalProperties;
     if (additionalProperties !== undefined) {


### PR DESCRIPTION
## Description

Previously, the plugin was only handling `additionalProperties` with no schema/properties defined, i.e. only a `type`. This change introduces support for rendering `additionalProperties` schemas, e.g. `properties`, `items`, etc., when present.

> Note: generated schema samples for additionalProperties is not supported but will be covered/added in a future PR

## Motivation and Context

Expanded support for `additionalProperties`.

## How Has This Been Tested?

Tested with CSPM Anomalies API spec.

## Screenshots (if appropriate)

<img width="805" alt="Screenshot 2023-02-28 at 4 22 06 PM" src="https://user-images.githubusercontent.com/9343811/221983127-985e5476-4b7d-4ee3-b01c-e0f9e5c6b540.png">

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
