### PR TITLE
Prepare release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.6.1 (Feb 28, 2023)
+
+High level enhancements
+
+- Add support for rendering additionalProperties schemas ([#465](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/465))
+- Add response status class name to response tab item ([#461](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/461))
+- Update usage docs ([#463](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/463))
+- Allow "none" option for categoryLinkSource ([#462](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/462))
+- Add code, thead and tbody to greaterThan regex ([#459](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/459))
+
+Other enhancements and bug fixes
+
+- Eval guard value as double not ([#468](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/468))
+- Remove code tab test styling ([#469](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/469))
+
 ## 1.6.0 (Feb 24, 2023)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -27,8 +27,8 @@
     "@docusaurus/preset-classic": ">=2.0.1 <2.3.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.6.0",
-    "docusaurus-theme-openapi-docs": "^1.6.0",
+    "docusaurus-plugin-openapi-docs": "^1.6.1",
+    "docusaurus-theme-openapi-docs": "^1.6.1",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -51,7 +51,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.6.0",
+    "docusaurus-plugin-openapi-docs": "^1.6.1",
     "file-saver": "^2.0.5",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",


### PR DESCRIPTION
## Description

## 1.6.1 (Feb 28, 2023)

High level enhancements

- Add support for rendering additionalProperties schemas ([#465](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/465))
- Add response status class name to response tab item ([#461](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/461))
- Update usage docs ([#463](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/463))
- Allow "none" option for categoryLinkSource ([#462](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/462))

Other enhancements and bug fixes

- Eval guard value as double not ([#468](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/468))
- Add code, thead and tbody to greaterThan regex ([#459](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/459))