### PR TITLE
Relax if statement to allow v2.0.0 releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    if: ${{ github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

Previously, the `if` statement only allowed releases from `main` branch. This change relaxes `if` statement to allow v2.0.0 releases while still only allowing releases from `PaloAltoNetworks` org repo.