### PR TITLE
Prepare release v2.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.0.0-beta.0 (Mar 9, 2023)
+
+High level enhancements
+
+- Add support for Docusaurus 2.3.0 ([#471](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/471))
+- [UI Enhancement] Move MethodEndpoint from ApiDemoPanel to left doc panel ([#429](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/429))
+- [UI Enhancement] Migration to SCSS and BEM-style convention for theme components ([#450](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/450))
+- [UI Enhancement] Include status code tabs in Response card ([#476](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/476))
+
+Other enhancements and bug fixes
+
+- Split beta release into separate script/workflow ([#480](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/480))
+- Add bold, svg and ensure parity between opening/closing regex ([#479](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/479))
+- Relax if statement ([#477](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/477))
+- Add v2.0.0 branch to release workflows ([#475](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/475))
+
 ## 1.6.1 (Feb 28, 2023)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "1.6.1",
+  "version": "2.0.0-beta.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -27,8 +27,8 @@
     "@docusaurus/preset-classic": "^2.3.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.6.1",
-    "docusaurus-theme-openapi-docs": "^1.6.1",
+    "docusaurus-plugin-openapi-docs": "^2.0.0-beta.0",
+    "docusaurus-theme-openapi-docs": "^2.0.0-beta.0",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.1",
+  "version": "2.0.0-beta.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.6.1",
+  "version": "2.0.0-beta.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.6.1",
+  "version": "2.0.0-beta.0",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -51,7 +51,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.6.1",
+    "docusaurus-plugin-openapi-docs": "^2.0.0-beta.0",
     "docusaurus-plugin-sass": "^0.2.3",
     "file-saver": "^2.0.5",
     "immer": "^9.0.7",


### PR DESCRIPTION
## Description

## 2.0.0-beta.0 (Mar 9, 2023)

High level enhancements

- Add support for Docusaurus 2.3.0 ([#471](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/471))
- [UI Enhancement] Move MethodEndpoint from ApiDemoPanel to left doc panel ([#429](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/429))
- [UI Enhancement] Migration to SCSS and BEM-style convention for theme components ([#450](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/450))
- [UI Enhancement] Include status code tabs in Response card ([#476](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/476))

Other enhancements and bug fixes

- Split beta release into separate script/workflow ([#480](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/480))
- Add bold, svg and ensure parity between opening/closing regex ([#479](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/479))
- Relax if statement ([#477](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/477))
- Add v2.0.0 branch to release workflows ([#475](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/475))

