### PR TITLE
[bug] Add sass loader to theme webpack config

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -199,7 +199,6 @@ const config = {
     }),
 
   plugins: [
-    "docusaurus-plugin-sass",
     [
       "docusaurus-plugin-openapi-docs",
       {

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -28,9 +28,48 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
       return path.resolve(__dirname, "..", "src", "theme");
     },
 
-    configureWebpack() {
+    configureWebpack(_, isServer, utils) {
+      const { getStyleLoaders } = utils;
+      const isProd = process.env.NODE_ENV === "production";
       return {
         plugins: [new NodePolyfillPlugin()],
+        module: {
+          rules: [
+            {
+              test: /\.s[ca]ss$/,
+              oneOf: [
+                {
+                  test: /\.module\.s[ca]ss$/,
+                  use: [
+                    ...getStyleLoaders(isServer, {
+                      modules: {
+                        localIdentName: isProd
+                          ? `[local]_[hash:base64:4]`
+                          : `[local]_[path][name]`,
+                        exportOnlyLocals: isServer,
+                      },
+                      importLoaders: 2,
+                      sourceMap: !isProd,
+                    }),
+                    {
+                      loader: require.resolve("sass-loader"),
+                      options: {},
+                    },
+                  ],
+                },
+                {
+                  use: [
+                    ...getStyleLoaders(isServer, {}),
+                    {
+                      loader: require.resolve("sass-loader"),
+                      options: {},
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       };
     },
   };


### PR DESCRIPTION
## Description

Extends theme webpack config to include loader for SASS/SCSS.

## Motivation and Context

The following error was observed when the `docusaurus-plugin-sass` was not defined under `plugins`.

<img width="1819" alt="Screenshot 2023-03-10 at 7 41 54 AM" src="https://user-images.githubusercontent.com/9343811/224322007-9559ee8d-e810-4f59-b780-2079e81a8328.png">

With this change, users should no longer be required to add `docusaurus-plugin-sass` plugin to `docusaurus.config.js`.

## How Has This Been Tested?

Tested with the demo site.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
