### PR TITLE
[UI Enhancement] Restyle tree lines

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
@@ -75,7 +75,7 @@
   position: relative;
   margin: 0 !important;
   padding: 5px 0 5px 0 !important;
-  border-left: thin solid var(--ifm-toc-border-color) !important;
+  border-left: thin solid var(--openapi-tree-line-color) !important;
 }
 
 @media screen and (max-width: 500px) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
@@ -75,7 +75,7 @@
   position: relative;
   margin: 0 !important;
   padding: 5px 0 5px 0 !important;
-  border-left: thin solid var(--ifm-color-gray-500) !important;
+  border-left: thin solid var(--ifm-toc-border-color) !important;
 }
 
 @media screen and (max-width: 500px) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
@@ -2,7 +2,6 @@
 
 .openapi-markdown__details {
   margin: unset !important;
-  max-width: 600px;
   background-color: transparent;
   color: var(--ifm-font-color-base);
   padding: unset;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
@@ -2,7 +2,7 @@
   margin: 0 0 0 1rem !important;
   position: relative;
   padding-left: 1rem;
-  border-left: thin solid var(--ifm-color-gray-500) !important;
+  border-left: thin solid var(--ifm-toc-border-color) !important;
   margin-top: unset !important;
 
   // Horizonal line styling for param attributes
@@ -15,7 +15,7 @@
     height: 0.5rem;
     /* vertical position of line */
     vertical-align: top;
-    border-bottom: thin solid var(--ifm-color-gray-500);
+    border-bottom: thin solid var(--ifm-toc-border-color);
     content: "";
     display: inline-block;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
@@ -2,7 +2,7 @@
   margin: 0 0 0 1rem !important;
   position: relative;
   padding-left: 1rem;
-  border-left: thin solid var(--ifm-toc-border-color) !important;
+  border-left: thin solid var(--openapi-tree-line-color) !important;
   margin-top: unset !important;
 
   // Horizonal line styling for param attributes
@@ -15,7 +15,7 @@
     height: 0.5rem;
     /* vertical position of line */
     vertical-align: top;
-    border-bottom: thin solid var(--ifm-toc-border-color);
+    border-bottom: thin solid var(--openapi-tree-line-color);
     content: "";
     display: inline-block;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
@@ -3,7 +3,7 @@
   position: relative;
   margin: 0 !important;
   padding: 5px 0 5px 1rem;
-  border-left: thin solid var(--ifm-color-gray-500) !important;
+  border-left: thin solid var(--ifm-toc-border-color) !important;
 
   // Horizontal line styling for schema properties
   &::before {
@@ -15,7 +15,7 @@
     height: 0.5rem;
     /* vertical position of line */
     vertical-align: top;
-    border-bottom: thin solid var(--ifm-color-gray-500);
+    border-bottom: thin solid var(--ifm-toc-border-color);
     content: "";
     display: inline-block;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
@@ -3,7 +3,7 @@
   position: relative;
   margin: 0 !important;
   padding: 5px 0 5px 1rem;
-  border-left: thin solid var(--ifm-toc-border-color) !important;
+  border-left: thin solid var(--openapi-tree-line-color) !important;
 
   // Horizontal line styling for schema properties
   &::before {
@@ -15,7 +15,7 @@
     height: 0.5rem;
     /* vertical position of line */
     vertical-align: top;
-    border-bottom: thin solid var(--ifm-toc-border-color);
+    border-bottom: thin solid var(--openapi-tree-line-color);
     content: "";
     display: inline-block;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -43,6 +43,7 @@
   --openapi-card-border-radius: var(--ifm-pre-border-radius);
   --openapi-input-border: var(--ifm-color-primary);
   --openapi-input-background: var(--openapi-card-background-color);
+  --openapi-tree-line-color: var(--ifm-toc-border-color);
 }
 
 [data-theme="dark"] {


### PR DESCRIPTION
## Description

Re-colors tree lines with `--ifm-toc-border-color` and allows details schema/params/discriminator items to be full width

## Motivation and Context

Improve UI/UX

## How Has This Been Tested?

See preview