### PR TITLE
Hide details marker

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
@@ -33,3 +33,8 @@
 .openapi-markdown__details p {
   margin-bottom: 0;
 }
+
+/* Hide defaul details marker by default */
+details summary::-webkit-details-marker {
+  display: none;
+}


### PR DESCRIPTION
## Description

Hides default details marker

## Motivation and Context

Plan is to replace default marker with custom chevron that is more similar to the one used in theme-classic