### PR TITLE
[Bug] Fix double scrollbars

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -280,9 +280,7 @@ function Curl({ postman, codeSamples }: Props) {
               }
               attributes={{ className: `code__tab--${lang.logoClass}` }}
             >
-              <CodeBlock language={lang.highlight} className={styles.codeBlock}>
-                {codeText}
-              </CodeBlock>
+              <CodeBlock language={lang.highlight}>{codeText}</CodeBlock>
             </CodeTab>
           );
         })}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/styles.module.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/styles.module.css
@@ -82,8 +82,3 @@
   background: var(--ifm-menu-color-background-active);
   color: var(--ifm-menu-color-active);
 }
-
-.codeBlock code {
-  max-width: revert;
-  max-height: revert;
-}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Response/index.tsx
@@ -62,7 +62,10 @@ function Response() {
           </button>
         </div>
       </summary>
-      <CodeBlock language={response.startsWith("<") ? `xml` : `json`}>
+      <CodeBlock
+        language={response.startsWith("<") ? `xml` : `json`}
+        className="openapi-demo__code-block"
+      >
         {prettyResponse || "No Response"}
       </CodeBlock>
     </details>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -155,14 +155,6 @@
   margin-right: 1rem;
 }
 
-/* Code block */
-
-.theme-api-markdown code {
-  max-width: 600px;
-  max-height: 500px;
-  overflow: auto;
-}
-
 /* Version button */
 
 .version-button div {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.css
@@ -475,3 +475,8 @@
 div:has(> ul.openapi-tabs__security-schemes) {
   max-width: 100%;
 }
+
+.openapi-demo__code-block code {
+  max-height: 500px;
+  overflow: auto;
+}


### PR DESCRIPTION
## Description

See #496 for background. Essentially, this change removes redundant styles that are the likely cause of the "double scrollbars" reported by users.

## Motivation and Context

Only one set of x/y scrollbars should be visible. Having more than one set is a poor UI/UX.