### PR TITLE
MDX v2 support

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -209,12 +209,10 @@ custom_edit_url: null
 
 {{{markdown}}}
 
-\`\`\`mdx-code-block
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 <DocCardList items={useCurrentSidebarCategory().items}/>
-\`\`\`
       `;
 
       const tagMdTemplate = `---
@@ -226,12 +224,10 @@ custom_edit_url: null
 
 {{{markdown}}}
 
-\`\`\`mdx-code-block
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 
 <DocCardList items={useCurrentSidebarCategory().items}/>
-\`\`\`
       `;
 
       loadedApi.map(async (item) => {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
@@ -35,15 +35,19 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
             create("td", {
               children: [
                 guard(tokenUrl, () =>
-                  create("p", { children: `Token URL: ${tokenUrl}` })
+                  create("p", {
+                    children: `Token URL: [${tokenUrl}](${tokenUrl})`,
+                  })
                 ),
                 guard(authorizationUrl, () =>
                   create("p", {
-                    children: `Authorization URL: ${authorizationUrl}`,
+                    children: `Authorization URL: [${authorizationUrl}](${authorizationUrl})`,
                   })
                 ),
                 guard(refreshUrl, () =>
-                  create("p", { children: `Refresh URL: ${refreshUrl}` })
+                  create("p", {
+                    children: `Refresh URL: [${refreshUrl}](${refreshUrl})`,
+                  })
                 ),
                 create("span", { children: "Scopes:" }),
                 create("ul", {
@@ -129,7 +133,9 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
                     create("tr", {
                       children: [
                         create("th", { children: "OpenID Connect URL:" }),
-                        create("td", { children: openIdConnectUrl }),
+                        create("td", {
+                          children: `[${openIdConnectUrl}](${openIdConnectUrl})`,
+                        }),
                       ],
                     })
                   ),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -30,14 +30,14 @@ export function createContactInfo(contact: ContactObject) {
           guard(name, () => `${name}: `),
           guard(email, () =>
             create("span", {
-              children: `\nmailto:${email}\n`,
+              children: `${email}`,
             })
           ),
         ],
       }),
       guard(url, () =>
         create("span", {
-          children: [`\nURL: [${url}](${url})\n`],
+          children: [`URL: [${url}](${url})`],
         })
       ),
     ],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -29,16 +29,15 @@ export function createContactInfo(contact: ContactObject) {
         children: [
           guard(name, () => `${name}: `),
           guard(email, () =>
-            create("a", {
-              href: `mailto:${email}`,
-              children: `${email}`,
+            create("span", {
+              children: `\nmailto:${email}\n`,
             })
           ),
         ],
       }),
       guard(url, () =>
         create("span", {
-          children: [`URL: [${url}](${url})`],
+          children: [`\nURL: [${url}](${url})\n`],
         })
       ),
     ],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -26,14 +26,7 @@ export function createContactInfo(contact: ContactObject) {
         children: "Contact",
       }),
       create("span", {
-        children: [
-          guard(name, () => `${name}: `),
-          guard(email, () =>
-            create("span", {
-              children: `${email}`,
-            })
-          ),
-        ],
+        children: [guard(name, () => `${name}: [${email}](mailto:${email})`)],
       }),
       guard(url, () =>
         create("span", {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -39,11 +39,7 @@ export function createContactInfo(contact: ContactObject) {
       guard(url, () =>
         create("span", {
           children: [
-            "URL: ",
-            create("a", {
-              href: `${url}`,
-              children: `${url}`,
-            }),
+            `URL: [${url}](${url})`,
           ],
         })
       ),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createContactInfo.ts
@@ -38,9 +38,7 @@ export function createContactInfo(contact: ContactObject) {
       }),
       guard(url, () =>
         create("span", {
-          children: [
-            `URL: [${url}](${url})`,
-          ],
+          children: [`URL: [${url}](${url})`],
         })
       ),
     ],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createLicense.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createLicense.ts
@@ -24,9 +24,8 @@ export function createLicense(license: LicenseObject) {
         children: "License",
       }),
       guard(url, () =>
-        create("a", {
-          href: url,
-          children: name ?? url,
+        create("span", {
+          children: `[${name ?? url}](${url})`,
         })
       ),
     ],

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createTermsOfService.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createTermsOfService.ts
@@ -21,9 +21,8 @@ export function createTermsOfService(termsOfService: string | undefined) {
         },
         children: "Terms of Service",
       }),
-      create("a", {
-        href: `${termsOfService}`,
-        children: termsOfService,
+      create("span", {
+        children: `[${termsOfService}](${termsOfService})`,
       }),
     ],
   });

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -17,7 +17,7 @@ export function create(tag: string, props: Props): string {
     propString += ` ${key}={${JSON.stringify(value)}}`;
   }
 
-  return `<${tag}${propString}>${render(children)}</${tag}>`;
+  return `\n<${tag}${propString}>${render(children)}</${tag}>\n`;
 }
 
 export function guard<T>(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
1. Changed the `a` tag in the `createContactInfo` markdown function to follow the markdown link syntax of `[text](url)`.
2. Removed the `mdx-code-block` code blocks in the markdown templates for the `generateApiDocs` function.
3. Added a new line before and after every tag in the `create` markdown util function.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I am upgrading my Docusaurus site to use MDX v2 and [Code Hike](https://codehike.org/) and ran into several errors associated with the changes that this PR makes. 

1. Without adding a new line before and after every tag in the `create` function, I get an error like this when spinning up the development server:

```zsh
# Lots of these errors
Expected a closing tag for `<div>` (16:686-16:691) before the end of `paragraph`

# And then lots of these errors
[webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/Users/janessa.garrow/dev/openapi-docusaurus/node_modules/babel-loader/lib/index.js??ruleSet[1].rules[8].use[0]!/Users/janessa.garrow/dev/openapi-docusaurus/node_modules/docusaurus-mdx-loader-v2/lib/index.js??ruleSet[1].rules[8].use[1]!/Users/janessa.garrow/dev/openapi-docusaurus/node_modules/@docusaurus/plugin-content-docs/lib/markdown/index.js??ruleSet[1].rules[8].use[2]!/Users/janessa.garrow/dev/openapi-docusaurus/docs/platform-api/aggregate-member.api.mdx': No serializer registered for VFileMessage
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> webpack/lib/ModuleBuildError -> VFileMessage
```

2. After updating the `create` markdown util to add a new line in between the tags, I ran into this error:

```zsh
Error: Unknown language: mdx-code-block
```

Since the blocks flagged with `mdx-code-block` are just importing other components and using the JSX in the generated MDX files, I removed the code block syntax entirely and the components rendered as expected.

3. Finally, after making the above 2 changes, I get an error with the `a` tag in the contact info:

```zsh
Expected a closing tag for `</a>` (54:1-54:7) before the end of `paragraph`
```

Changing that `a` tag to use markdown link syntax resolved the error.


<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
