### PR TITLE
[Bug] Narrow SASS loader rules to avoid conflicts with docusaurus-plugin-sass

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -30,7 +30,6 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
 
     configureWebpack(_, isServer, utils) {
       const { getStyleLoaders } = utils;
-      console.log(path.resolve(__dirname, "theme/styles.scss"));
       return {
         plugins: [new NodePolyfillPlugin()],
         module: {

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -36,27 +36,9 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
         module: {
           rules: [
             {
-              test: /\.s[ca]ss$/,
+              test: /\styles.scss$/,
+              include: path.resolve(__dirname, "..", "src", "theme"),
               oneOf: [
-                {
-                  test: /\.module\.s[ca]ss$/,
-                  use: [
-                    ...getStyleLoaders(isServer, {
-                      modules: {
-                        localIdentName: isProd
-                          ? `[local]_[hash:base64:4]`
-                          : `[local]_[path][name]`,
-                        exportOnlyLocals: isServer,
-                      },
-                      importLoaders: 2,
-                      sourceMap: !isProd,
-                    }),
-                    {
-                      loader: require.resolve("sass-loader"),
-                      options: {},
-                    },
-                  ],
-                },
                 {
                   use: [
                     ...getStyleLoaders(isServer, {}),

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -35,7 +35,7 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
         module: {
           rules: [
             {
-              test: /\styles.scss$/,
+              test: /styles.scss$/,
               include: path.resolve(__dirname, "..", "src", "theme"),
               oneOf: [
                 {

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -36,16 +36,12 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
           rules: [
             {
               test: /styles.scss$/,
-              include: path.resolve(__dirname, "theme/styles.scss"),
-              oneOf: [
+              include: path.resolve(__dirname, "theme", "styles.scss"),
+              use: [
+                ...getStyleLoaders(isServer, {}),
                 {
-                  use: [
-                    ...getStyleLoaders(isServer, {}),
-                    {
-                      loader: require.resolve("sass-loader"),
-                      options: {},
-                    },
-                  ],
+                  loader: require.resolve("sass-loader"),
+                  options: {},
                 },
               ],
             },

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -30,7 +30,6 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
 
     configureWebpack(_, isServer, utils) {
       const { getStyleLoaders } = utils;
-      const isProd = process.env.NODE_ENV === "production";
       return {
         plugins: [new NodePolyfillPlugin()],
         module: {

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -30,13 +30,14 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
 
     configureWebpack(_, isServer, utils) {
       const { getStyleLoaders } = utils;
+      console.log(path.resolve(__dirname, "theme/styles.scss"));
       return {
         plugins: [new NodePolyfillPlugin()],
         module: {
           rules: [
             {
               test: /styles.scss$/,
-              include: path.resolve(__dirname, "..", "src", "theme"),
+              include: path.resolve(__dirname, "theme/styles.scss"),
               oneOf: [
                 {
                   use: [


### PR DESCRIPTION
## Description

Our SASS loader rules in our webpack config appear to be too broad which could lead to conflicts/issues with `docusaurus-plugin-sass`. This PR attempts to solve for this by refining/narrowing the loader rules such that we specifically test and load only the `styles.scss` included in `docusaurus-theme-openapi-docs`. 

## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/discussions/488#discussioncomment-5404790 for additional context

## How Has This Been Tested?

Deploy preview will test that the rule functions as expected. Additional testing with standalone site is required to confirm our theme can work alongside `docusaurus-plugin-sass` without issues.