### PR TITLE
[Bug] Patch webpack sass loader

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -35,8 +35,8 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
         module: {
           rules: [
             {
-              test: /styles.scss$/,
-              include: path.resolve(__dirname, "theme", "styles.scss"),
+              test: /\.s[ca]ss$/,
+              include: path.resolve(__dirname, "..", "lib", "theme"),
               use: [
                 ...getStyleLoaders(isServer, {}),
                 {


### PR DESCRIPTION
## Description

Point `test` and `include` to `lib` directory which appears to be where webpack searches for `styles.scss`. 

