### PR TITLE
[Cleanup] Optimize theme typescript build 

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -24,11 +24,8 @@
   "types": "src/theme-openapi.d.ts",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc --noEmit && yarn babel:lib && yarn babel:lib-next && yarn format:lib-next",
-    "watch": "concurrently --names \"lib,lib-next,tsc\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\" \"yarn tsc --watch\"",
-    "babel:lib": "cross-env BABEL_ENV=lib babel src -d lib --extensions \".tsx,.ts\" --ignore \"**/*.d.ts\" --copy-files",
-    "babel:lib-next": "cross-env BABEL_ENV=lib-next babel src -d lib-next --extensions \".tsx,.ts\" --ignore \"**/*.d.ts\" --copy-files",
-    "format:lib-next": "prettier --config ../../.prettierrc.json --write \"lib-next/**/*.{js,ts,jsx,tsc}\""
+    "build": "tsc --build && node ../../scripts/copyUntypedFiles.mjs && prettier --config ../../.prettierrc.json --write \"lib/theme/**/*.js\"",
+    "watch": "concurrently --names \"lib,lib-next,tsc\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\" \"yarn tsc --watch\""
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.3.0",

--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -16,12 +16,16 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
     name: "docusaurus-theme-openapi",
 
     getClientModules() {
-      const modules = [require.resolve("./theme/styles.scss")];
+      const modules = [
+        require.resolve(
+          path.join(__dirname, "..", "lib", "theme", "styles.scss")
+        ),
+      ];
       return modules;
     },
 
     getThemePath() {
-      return path.join(__dirname, "..", "lib-next", "theme");
+      return path.join(__dirname, "..", "lib", "theme");
     },
 
     getTypeScriptThemePath() {

--- a/packages/docusaurus-theme-openapi-docs/tsconfig.json
+++ b/packages/docusaurus-theme-openapi-docs/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2019"],
-    "module": "esnext",
-    "noEmit": true,
+    "lib": ["ESNext", "DOM"],
+    "rootDir": "src",
+    "module": "CommonJS",
+    "target": "ESNext",
+    "noEmit": false,
+    "outDir": "lib",
     "jsx": "react"
   },
   "include": ["src"]

--- a/scripts/copyUntypedFiles.mjs
+++ b/scripts/copyUntypedFiles.mjs
@@ -1,0 +1,36 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import fs from "fs-extra";
+import path from "path";
+import chokidar from "chokidar";
+
+const srcDir = path.join(process.cwd(), "src");
+const libDir = path.join(process.cwd(), "lib");
+
+const ignoredPattern = /(?:__tests__|\.tsx?$)/;
+
+async function copy() {
+  await fs.copy(srcDir, libDir, {
+    filter(testedPath) {
+      return !ignoredPattern.test(testedPath);
+    },
+  });
+}
+
+if (process.argv.includes("--watch")) {
+  const watcher = chokidar.watch(srcDir, {
+    ignored: ignoredPattern,
+    ignoreInitial: true,
+    persistent: true,
+  });
+  ["add", "change", "unlink", "addDir", "unlinkDir"].forEach((event) =>
+    watcher.on(event, copy)
+  );
+} else {
+  await copy();
+}


### PR DESCRIPTION
## Description

Previously, our theme `tsc` build step used babel to transpile to both esm and cjs. With node 16+ this step is unnecessary. Furthermore, emitting to both `lib` and `lib-next` can sometimes lead to unexpected behavior at runtime.

## Motivation and Context

From docusaurus maintainer:

> Also latest Docusaurus is on Node 16.14 with ESM support, you may not need 2 theme outputs (esm+cjs) now. We removed cjs recently from the classic theme 

> I mean you don't need to compile the theme in esm + cjs, like we used to
"babel:lib": "cross-env BABEL_ENV=lib babel src -d lib --extensions ".tsx,.ts" --ignore "/*.d.ts" --copy-files",
    "babel:lib-next": "cross-env BABEL_ENV=lib-next babel src -d lib-next --extensions ".tsx,.ts" --ignore "/*.d.ts" --copy-files",

## How Has This Been Tested?

Tested locally. Deploy preview will test prod deployment. Further testing will be needed using standalone docusaurus site.