### PR TITLE
Update bash/curl logo and refactor how logo width/height are defined

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
@@ -14,6 +14,10 @@
   display: table-row-group;
 }
 
+.openapi-demo__code-block code {
+  max-height: 500px;
+}
+
 .openapi-tabs__code-item {
   margin-top: 0 !important;
   margin-right: 0.5rem;
@@ -45,11 +49,6 @@
   }
 }
 
-.language-python {
-  max-height: 500px;
-  overflow: auto;
-}
-
 .openapi-tabs__code-item--go {
   color: var(--ifm-color-info);
 
@@ -67,11 +66,6 @@
   }
 }
 
-.language-go {
-  max-height: 500px;
-  overflow: auto;
-}
-
 .openapi-tabs__code-item--javascript {
   color: var(--ifm-color-warning);
 
@@ -87,11 +81,6 @@
     border-bottom-color: var(--ifm-color-warning);
     background-color: var(--ifm-color-emphasis-100);
   }
-}
-
-.language-javascript {
-  max-height: 500px;
-  overflow: auto;
 }
 
 .openapi-tabs__code-item--bash {
@@ -113,11 +102,6 @@
   }
 }
 
-.language-bash {
-  max-height: 500px;
-  overflow: auto;
-}
-
 .openapi-tabs__code-item--ruby {
   color: var(--ifm-color-danger);
 
@@ -133,11 +117,6 @@
     border-bottom-color: var(--ifm-color-danger);
     background-color: var(--ifm-color-emphasis-100);
   }
-}
-
-.language-ruby {
-  max-height: 500px;
-  overflow: auto;
 }
 
 .openapi-tabs__code-item--csharp {
@@ -157,11 +136,6 @@
   }
 }
 
-.language-csharp {
-  max-height: 500px;
-  overflow: auto;
-}
-
 .openapi-tabs__code-item--nodejs {
   color: var(--ifm-color-success);
 
@@ -177,11 +151,6 @@
     border-bottom-color: var(--ifm-color-success);
     background-color: var(--ifm-color-emphasis-100);
   }
-}
-
-.language-nodejs {
-  max-height: 500px;
-  overflow: auto;
 }
 
 .openapi-tabs__code-item--php {
@@ -201,11 +170,6 @@
   }
 }
 
-.language-php {
-  max-height: 500px;
-  overflow: auto;
-}
-
 .openapi-tabs__code-item--java {
   color: var(--ifm-color-warning);
 
@@ -221,11 +185,6 @@
     border-bottom-color: var(--ifm-color-warning);
     background-color: var(--ifm-color-emphasis-100);
   }
-}
-
-.language-powershell {
-  max-height: 500px;
-  overflow: auto;
 }
 
 .openapi-tabs__code-item--powershell {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
@@ -1,3 +1,15 @@
+:root {
+  --bash-background-color: transparent;
+  --bash-border-radius: none;
+  --code-tab-logo-width: 26px;
+  --code-tab-logo-height: 26px;
+}
+
+[data-theme="dark"] {
+  --bash-background-color: lightgrey;
+  --bash-border-radius: 20px;
+}
+
 .openapi-tabs__code-list-container {
   display: table-row-group;
 }
@@ -21,8 +33,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg");
     margin-block: auto;
   }
@@ -43,8 +55,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/go/go-original-wordmark.svg");
     margin-block: auto;
   }
@@ -65,8 +77,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg");
     margin-block: auto;
   }
@@ -87,10 +99,12 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
-    background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg");
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
+    background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/bash/bash-plain.svg");
     margin-block: auto;
+    background-color: var(--bash-background-color);
+    border-radius: var(--bash-border-radius);
   }
 
   &.active {
@@ -109,8 +123,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/ruby/ruby-plain.svg");
     margin-block: auto;
   }
@@ -131,8 +145,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg");
     margin-block: auto;
   }
@@ -153,8 +167,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg");
     margin-block: auto;
   }
@@ -175,8 +189,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg");
     margin-block: auto;
   }
@@ -197,8 +211,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/java/java-original.svg");
     margin-block: auto;
   }
@@ -219,8 +233,8 @@
 
   &::after {
     content: "";
-    width: 28px;
-    height: 28px;
+    width: var(--code-tab-logo-width);
+    height: var(--code-tab-logo-height);
     background: url("https://raw.githubusercontent.com/devicons/devicon/master/icons/windows8/windows8-original.svg");
     margin-block: auto;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -116,8 +116,3 @@
 .openapi__heading {
   font-size: var(--ifm-h1-font-size);
 }
-
-.openapi-demo__code-block code {
-  max-height: 500px;
-  overflow: auto;
-}


### PR DESCRIPTION
## Description

* Replace Linux with BASH logo for cURL code tab
* Reduce size of code tab logos
* Implement variables for defining logo width/height