### PR TITLE
[Enhancement] Add support for rendering vendor extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `template`       | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                  |
 | `downloadUrl`    | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                             |
 | `hideSendButton` | `boolean` | `null`  | _Optional:_ If set to `true`, hides the "Send API Request" button in API demo panel                                         |
+| `showExtensions` | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation-level vendor-extensions in description.                                     |
 | `sidebarOptions` | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                            |
 | `version`        | `string`  | `null`  | _Optional:_ Version assigned to single or micro-spec API specified in `specPath`.                                           |
 | `label`          | `string`  | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                              |

--- a/demo/api.mustache
+++ b/demo/api.mustache
@@ -31,6 +31,9 @@ proxy: {{{frontMatter.proxy}}}
 {{#frontMatter.hide_send_button}}
 hide_send_button: true
 {{/frontMatter.hide_send_button}}
+{{#frontMatter.show_extensions}}
+show_extensions: true
+{{/frontMatter.show_extensions}}
 ---
 
 {{{markdown}}}

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -305,6 +305,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `template`       | `string` | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                  |
 | `downloadUrl`    | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                             |
 | `hideSendButton` | `boolean`| `null`  | _Optional:_ If set to `true`, hides the "Send API Request" button in API demo panel.                                        |
+| `showExtensions` | `boolean`| `null`  | _Optional:_ If set to `true`, renders operation-level vendor-extensions in description.                                    |
 | `sidebarOptions` | `object` | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                            |
 | `version`        | `string` | `null`  | _Optional:_ Version assigned to single or micro-spec API specified in `specPath`.                                           |
 | `label`          | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                              |

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -125,6 +125,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `template`       | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                  |
 | `downloadUrl`    | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                             |
 | `hideSendButton` | `boolean` | `null`  | _Optional:_ If set to `true`, hides the "Send API Request" button in API demo panel                                         |
+| `showExtensions` | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation-level vendor-extensions in description.                                     |
 | `sidebarOptions` | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                            |
 | `version`        | `string`  | `null`  | _Optional:_ Version assigned to single or micro-spec API specified in `specPath`.                                           |
 | `label`          | `string`  | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                              |

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -193,6 +193,9 @@ proxy: {{{frontMatter.proxy}}}
 {{#frontMatter.hide_send_button}}
 hide_send_button: true
 {{/frontMatter.hide_send_button}}
+{{#frontMatter.show_extensions}}
+show_extensions: true
+{{/frontMatter.show_extensions}}
 ---
 
 {{{markdown}}}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createVendorExtensions.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createVendorExtensions.ts
@@ -1,0 +1,22 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+export function createVendorExtensions(extensions: any) {
+  if (!extensions || typeof extensions !== "object") {
+    return undefined;
+  }
+  const rows: Array<string> = [];
+  extensions.map((extension: any) => {
+    const extensionRow = () => {
+      return `${extension.key}: ${JSON.stringify(extension.value)}`;
+    };
+    rows.push(extensionRow());
+  });
+  return `\n\n\`\`\`
+${rows.join("\n")}
+\`\`\`\n\n`;
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createVendorExtensions.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createVendorExtensions.ts
@@ -14,7 +14,7 @@ export function createVendorExtensions(extensions: any) {
     const extensionRow = () => {
       return `${extension.key}: ${JSON.stringify(extension.value)}`;
     };
-    rows.push(extensionRow());
+    return rows.push(extensionRow());
   });
   return `\n\n\`\`\`
 ${rows.join("\n")}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -23,6 +23,7 @@ import { createParamsDetails } from "./createParamsDetails";
 import { createRequestBodyDetails } from "./createRequestBodyDetails";
 import { createStatusCodes } from "./createStatusCodes";
 import { createTermsOfService } from "./createTermsOfService";
+import { createVendorExtensions } from "./createVendorExtensions";
 import { createVersionBadge } from "./createVersionBadge";
 import { greaterThan, lessThan, render } from "./utils";
 
@@ -43,10 +44,12 @@ export function createApiPageMD({
     deprecated,
     "x-deprecated-description": deprecatedDescription,
     description,
+    extensions,
     parameters,
     requestBody,
     responses,
   },
+  frontMatter,
 }: ApiPageMetadata) {
   return render([
     `import ApiTabs from "@theme/ApiTabs";\n`,
@@ -58,6 +61,7 @@ export function createApiPageMD({
     `import DiscriminatorTabs from "@theme/DiscriminatorTabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
     `## ${title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")}\n\n`,
+    frontMatter.show_extensions && createVendorExtensions(extensions),
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(description),
     createParamsDetails({ parameters, type: "path" }),

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -144,6 +144,13 @@ function createItems(
         ? kebabCase(operationObject.operationId)
         : kebabCase(operationObject.summary);
 
+      const extensions = [];
+      for (const [key, value] of Object.entries(operationObject)) {
+        if (key.startsWith("x-")) {
+          extensions.push({ key, value });
+        }
+      }
+
       const servers =
         operationObject.servers ?? pathObject.servers ?? openapiData.servers;
 
@@ -224,9 +231,13 @@ function createItems(
           ...(options?.hideSendButton && {
             hide_send_button: options.hideSendButton,
           }),
+          ...(options?.showExtensions && {
+            show_extensions: options.showExtensions,
+          }),
         },
         api: {
           ...defaults,
+          ...(extensions.length > 0 && { extensions: extensions }),
           tags: operationObject.tags,
           method,
           path,
@@ -264,6 +275,13 @@ function createItems(
         ? kebabCase(operationObject.operationId)
         : kebabCase(operationObject.summary);
 
+      const extensions = [];
+      for (const [key, value] of Object.entries(operationObject)) {
+        if (key.startsWith("x-")) {
+          extensions.push({ key, value });
+        }
+      }
+
       const servers =
         operationObject.servers ?? pathObject.servers ?? openapiData.servers;
 
@@ -344,9 +362,13 @@ function createItems(
           ...(options?.hideSendButton && {
             hide_send_button: options.hideSendButton,
           }),
+          ...(options?.showExtensions && {
+            show_extensions: options.showExtensions,
+          }),
         },
         api: {
           ...defaults,
+          ...(extensions.length > 0 && { extensions: extensions }),
           tags: operationObject.tags,
           method,
           path,

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -145,8 +145,10 @@ function createItems(
         : kebabCase(operationObject.summary);
 
       const extensions = [];
+      const commonExtensions = ["x-codeSamples"];
+
       for (const [key, value] of Object.entries(operationObject)) {
-        if (key.startsWith("x-")) {
+        if (key.startsWith("x-") && !commonExtensions.includes(key)) {
           extensions.push({ key, value });
         }
       }
@@ -276,8 +278,10 @@ function createItems(
         : kebabCase(operationObject.summary);
 
       const extensions = [];
+      const commonExtensions = ["x-codeSamples"];
+
       for (const [key, value] of Object.entries(operationObject)) {
-        if (key.startsWith("x-")) {
+        if (key.startsWith("x-") && !commonExtensions.includes(key)) {
           extensions.push({ key, value });
         }
       }

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -29,6 +29,7 @@ export const OptionsSchema = Joi.object({
         template: Joi.string(),
         downloadUrl: Joi.string(),
         hideSendButton: Joi.boolean(),
+        showExtensions: Joi.boolean(),
         sidebarOptions: sidebarOptions,
         version: Joi.string().when("versions", {
           is: Joi.exist(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -34,6 +34,7 @@ export interface APIOptions {
   template?: string;
   downloadUrl?: string;
   hideSendButton?: boolean;
+  showExtensions?: boolean;
   sidebarOptions?: SidebarOptions;
   version?: string;
   label?: string;
@@ -103,6 +104,7 @@ export interface ApiItem extends OperationObject {
   postman?: Request;
   proxy?: string;
   info: InfoObject;
+  extensions?: object;
 }
 
 export interface InfoPageMetadata extends ApiMetadataBase {


### PR DESCRIPTION
## Description

Adds support for rendering arbitrary vendor extensions at the operation level.

## Motivation and Context

Previously, we were displaying extensions for some of our product APIs:

![image](https://user-images.githubusercontent.com/9343811/228900257-ad49583a-cb4c-4b63-b644-557a93ecfd61.png)

## How Has This Been Tested?

Tested with the CWPP OpenAPI spec.