### PR TITLE
[UI Enhancement] Move authorization card to ApiItem

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -243,13 +243,6 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
             item.downloadUrl = downloadUrl;
           }
         }
-        const markdown =
-          item.type === "api"
-            ? createApiPageMD(item)
-            : item.type === "info"
-            ? createInfoPageMD(item)
-            : createTagPageMD(item);
-        item.markdown = markdown;
         if (item.type === "api") {
           item.json = JSON.stringify(item.api);
           let infoBasePath = `${outputDir}/${item.infoId}`;
@@ -260,6 +253,13 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
           }
           if (item.infoId) item.infoPath = infoBasePath;
         }
+        const markdown =
+          item.type === "api"
+            ? createApiPageMD(item)
+            : item.type === "info"
+            ? createInfoPageMD(item)
+            : createTagPageMD(item);
+        item.markdown = markdown;
 
         const view = render(mdTemplate, item);
         const utils = render(infoMdTemplate, item);

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthorization.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthorization.ts
@@ -1,0 +1,13 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { create } from "./utils";
+
+export function createAuthorization(infoPath: string) {
+  if (!infoPath) return undefined;
+  return [create("SecuritySchemes", { infoPath: infoPath }), "\n\n"];
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -27,6 +27,7 @@ import { createStatusCodes } from "./createStatusCodes";
 import { createTermsOfService } from "./createTermsOfService";
 import { createVendorExtensions } from "./createVendorExtensions";
 import { createVersionBadge } from "./createVersionBadge";
+import { createAuthorization } from "./createAuthorization";
 import { greaterThan, lessThan, render } from "./utils";
 
 interface Props {
@@ -53,12 +54,14 @@ export function createApiPageMD({
     requestBody,
     responses,
   },
+  infoPath,
   frontMatter,
 }: ApiPageMetadata) {
   return render([
     `import ApiTabs from "@theme/ApiTabs";\n`,
     `import DiscriminatorTabs from "@theme/DiscriminatorTabs";\n`,
     `import MethodEndpoint from "@theme/ApiDemoPanel/MethodEndpoint";\n`,
+    `import SecuritySchemes from "@theme/ApiDemoPanel/SecuritySchemes";\n`,
     `import MimeTabs from "@theme/MimeTabs";\n`,
     `import ParamsItem from "@theme/ParamsItem";\n`,
     `import ResponseSamples from "@theme/ResponseSamples";\n`,
@@ -68,6 +71,7 @@ export function createApiPageMD({
     createHeading(title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")),
     createMethodEndpoint(method, path),
     `## ${title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")}\n\n`,
+    infoPath && createAuthorization(infoPath),
     frontMatter.show_extensions && createVendorExtensions(extensions),
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(description),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../openapi/types";
 import { ApiPageMetadata, InfoPageMetadata, TagPageMetadata } from "../types";
 import { createAuthentication } from "./createAuthentication";
+import { createAuthorization } from "./createAuthorization";
 import { createContactInfo } from "./createContactInfo";
 import { createDeprecationNotice } from "./createDeprecationNotice";
 import { createDescription } from "./createDescription";
@@ -27,7 +28,6 @@ import { createStatusCodes } from "./createStatusCodes";
 import { createTermsOfService } from "./createTermsOfService";
 import { createVendorExtensions } from "./createVendorExtensions";
 import { createVersionBadge } from "./createVersionBadge";
-import { createAuthorization } from "./createAuthorization";
 import { greaterThan, lessThan, render } from "./utils";
 
 interface Props {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/SecuritySchemes/index.tsx
@@ -23,9 +23,11 @@ function SecuritySchemes(props: any) {
 
   const selectedAuth = options[selected];
   return (
-    <details className="openapi-demo__details" open={false}>
-      <summary className="openapi-demo__summary-container">
-        <h4 className="openapi-demo__summary-header">Authorization</h4>
+    <details className="openapi-security__details" open={false}>
+      <summary className="openapi-security__summary-container">
+        <h4 className="openapi-demo__summary-header">
+          Authorization: {selectedAuth[0].name ?? selectedAuth[0].type}
+        </h4>
       </summary>
       {selectedAuth.map((auth: any) => {
         const isHttp = auth.type === "http";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -11,7 +11,6 @@ import sdk from "@paloaltonetworks/postman-collection";
 import Curl from "@theme/ApiDemoPanel/Curl";
 import Request from "@theme/ApiDemoPanel/Request";
 import Response from "@theme/ApiDemoPanel/Response";
-import SecuritySchemes from "@theme/ApiDemoPanel/SecuritySchemes";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 function ApiDemoPanel({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -25,7 +25,6 @@ function ApiDemoPanel({
 
   return (
     <div>
-      <SecuritySchemes infoPath={infoPath} />
       <Request item={item} />
       <Response />
       <Curl

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
@@ -38,3 +38,28 @@
 details summary::-webkit-details-marker {
   display: none;
 }
+
+.openapi-security__details {
+  margin-bottom: 1rem;
+  background-color: transparent;
+  color: var(--ifm-font-color-base);
+  padding: unset;
+  border: thin solid var(--ifm-toc-border-color);
+  border-radius: var(--ifm-pre-border-radius);
+  box-shadow: unset !important;
+  --docusaurus-details-decoration-color: var(--ifm-font-color-base) !important;
+}
+
+.openapi-security__details pre {
+  margin-bottom: unset;
+}
+
+.openapi-security__summary-container {
+  padding: 1rem;
+  list-style-type: none;
+  border-bottom: thin solid var(--ifm-toc-border-color);
+
+  &:hover {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
## Description

This change moves the `Authorization` card from the demo/explorer panel over to ApiItem.

> A good post-cleanup step would be to cleanup the component naming. For example, we use "security schemes" and "authorization" and "security" interchangeably but perhaps there's a more intuitive/accurate naming we can apply to these componens.

## Motivation and Context

The contents of Authorization are align more with reference documentation as opposed to anything demo/explorer specific. In other words, the content is read-only and has no bearing on the final API request that gets sent from browser. Therefore, it makes sense to move it under the reference docs column. The added benefit is that the API demo/explorer panel will be less crowded.

## How Has This Been Tested?

See deploy preview