### PR TITLE
[UI Enhancement] Move CodeTabs above Request

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
@@ -1,8 +1,8 @@
 :root {
   --bash-background-color: transparent;
   --bash-border-radius: none;
-  --code-tab-logo-width: 26px;
-  --code-tab-logo-height: 26px;
+  --code-tab-logo-width: 24px;
+  --code-tab-logo-height: 24px;
 }
 
 [data-theme="dark"] {
@@ -11,7 +11,8 @@
 }
 
 .openapi-tabs__code-list-container {
-  display: table-row-group;
+  display: flex;
+  justify-content: space-between;
 }
 
 .openapi-demo__code-block code {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
@@ -13,6 +13,11 @@
 .openapi-tabs__code-list-container {
   display: flex;
   justify-content: start;
+  padding-bottom: 0.6rem;
+}
+
+.openapi-tabs__code-content {
+  margin-top: unset !important;
 }
 
 .openapi-demo__code-block code {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/_CodeTabs.scss
@@ -12,7 +12,7 @@
 
 .openapi-tabs__code-list-container {
   display: flex;
-  justify-content: space-between;
+  justify-content: start;
 }
 
 .openapi-demo__code-block code {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.js
@@ -122,7 +122,7 @@ function TabContent({ lazy, children, selectedValue }) {
     return cloneElement(selectedTabItem, { className: "margin-top--md" });
   }
   return (
-    <div className="margin-top--md">
+    <div className="margin-top--md openapi-tabs__code-content">
       {children.map((tabItem, i) =>
         cloneElement(tabItem, {
           key: i,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -23,14 +23,14 @@ function ApiDemoPanel({
   const postman = new sdk.Request(item.postman);
 
   return (
-    <div>
+    <>
       <Curl
         postman={postman}
         codeSamples={(item as any)["x-code-samples"] ?? []}
       />
       <Request item={item} />
       <Response />
-    </div>
+    </>
   );
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/index.tsx
@@ -24,12 +24,12 @@ function ApiDemoPanel({
 
   return (
     <div>
-      <Request item={item} />
-      <Response />
       <Curl
         postman={postman}
         codeSamples={(item as any)["x-code-samples"] ?? []}
       />
+      <Request item={item} />
+      <Response />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Moves the CodeTabs section above the Request section. Also brought back a pattern that @blindaa121 implemented before for spacing the tabs.

## Motivation and Context

Analytics indicates that CodeTabs see much more usage compared to the "Send API Request" feature so it might make more sense to make it more easily accessible to users. Additionally, after reviewing a number of other API doc tools, this appears to be the most common pattern/layout.

## How Has This Been Tested?

See deploy preview