### PR TITLE
[UI Enhancement] Restyle schema property labels

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/_ParamsItem.scss
@@ -31,9 +31,22 @@
 
 .openapi-schema__type {
   opacity: 0.6;
+  padding-left: 0.3rem;
 }
 
 .openapi-schema__required {
-  font-size: var(--ifm-code-font-size);
   color: var(--openapi-required);
+  margin-left: 1%;
+  background-color: transparent;
+  font-size: 10.5px;
+}
+
+.openapi-schema__divider {
+  flex-grow: 1;
+  border-bottom: thin solid var(--ifm-toc-border-color);
+  margin: 10px;
+}
+
+.openapi-schema__container {
+  display: flex;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -37,7 +37,9 @@ function ParamsItem({
   ));
 
   const renderSchemaRequired = guard(required, () => (
-    <strong className="openapi-schema__required"> required</strong>
+    <span className="badge badge--danger openapi-schema__required">
+      required
+    </span>
   ));
 
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
@@ -118,9 +120,12 @@ function ParamsItem({
 
   return (
     <li className="openapi-params__list-item">
-      <strong>{name}</strong>
-      {renderSchemaName}
-      {renderSchemaRequired}
+      <span className="openapi-schema__container">
+        <strong>{name}</strong>
+        {renderSchemaName}
+        {required && <span class="openapi-schema__divider"></span>}
+        {renderSchemaRequired}
+      </span>
       {renderSchema}
       {renderDefaultValue}
       {renderDescription}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
@@ -31,23 +31,40 @@
 
 .openapi-schema__name {
   opacity: 0.6;
+  padding-left: 0.3rem;
 }
 
 .openapi-schema__required {
-  font-size: var(--ifm-code-font-size);
   color: var(--openapi-required);
+  margin-left: 1%;
+  background-color: transparent;
+  font-size: 10.5px;
 }
 
 .openapi-schema__deprecated {
-  font-size: var(--ifm-code-font-size);
   color: var(--openapi-deprecated);
+  margin-left: 1%;
+  background-color: transparent;
+  font-size: 10.5px;
 }
 
 .openapi-schema__nullable {
-  font-size: var(--ifm-code-font-size);
   color: var(--openapi-nullable);
+  margin-left: 1%;
+  background-color: transparent;
+  font-size: 10.5px;
 }
 
 .openapi-schema__strikethrough {
   text-decoration: line-through;
+}
+
+.openapi-schema__divider {
+  flex-grow: 1;
+  border-bottom: thin solid var(--ifm-toc-border-color);
+  margin: 10px;
+}
+
+.openapi-schema__container {
+  display: flex;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
@@ -37,15 +37,21 @@ function SchemaItem({
 
   const renderRequired = guard(
     Array.isArray(required) ? required.includes(name) : required,
-    () => <strong className="openapi-schema__required"> required</strong>
+    () => (
+      <span className="badge badge--danger openapi-schema__required">
+        required
+      </span>
+    )
   );
 
   const renderDeprecated = guard(deprecated, () => (
-    <strong className="openapi-schema__deprecated"> deprecated</strong>
+    <span className="badge badge--warning openapi-schema__deprecated">
+      deprecated
+    </span>
   ));
 
   const renderNullable = guard(nullable, () => (
-    <strong className="openapi-schema__nullable"> nullable</strong>
+    <span className="badge badge--info openapi-schema__nullable">nullable</span>
   ));
 
   const renderSchemaDescription = guard(schemaDescription, (description) => (
@@ -89,13 +95,18 @@ function SchemaItem({
 
   const schemaContent = (
     <div>
-      <strong className={deprecated && "openapi-schema__strikethrough"}>
-        {name}
-      </strong>
-      <span className="openapi-schema__name"> {schemaName}</span>
-      {renderNullable}
-      {!deprecated && renderRequired}
-      {renderDeprecated}
+      <span className="openapi-schema__container">
+        <strong className={deprecated && "openapi-schema__strikethrough"}>
+          {name}
+        </strong>
+        <span className="openapi-schema__name"> {schemaName}</span>
+        {(nullable || required || deprecated) && (
+          <span class="openapi-schema__divider"></span>
+        )}
+        {renderNullable}
+        {!deprecated && renderRequired}
+        {renderDeprecated}
+      </span>
       {renderQualifierMessage}
       {renderDefaultValue}
       {renderSchemaDescription}


### PR DESCRIPTION
## Description

Swaps property labels for badges. Also pushes badges to the far right to help balance the UI.

## Motivation and Context

Hopefully easier to read and easier to spot required, nullable, deprecated properties. Also aligns with design patterns observed in other tools.

## How Has This Been Tested?

See deploy preview