### PR TITLE
[UI Enhancement] Restyle details markers with caret

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Markdown/Details/_Details.scss
@@ -10,6 +10,19 @@
   --docusaurus-details-decoration-color: var(--ifm-font-color-base) !important;
 }
 
+.openapi-markdown__details > summary::before {
+  content: "";
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>')
+    50% / 1.2rem 1.2rem;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
+  height: 0.75rem;
+  transform: rotate(90deg) !important;
+  width: 0.75rem;
+  transition: transform var(--ifm-transition-fast) linear !important;
+  border: none !important;
+  transform-origin: unset !important;
+}
+
 .openapi-markdown__details ul {
   padding-left: 0;
   font-size: 14px;
@@ -18,6 +31,10 @@
 .openapi-markdown__details li {
   list-style: none;
   padding-top: 5px;
+}
+
+.theme-api-markdown details[data-collapsed="false"] > summary::before {
+  transform: rotate(180deg) !important;
 }
 
 .theme-api-markdown .tabs__item {


### PR DESCRIPTION
## Description

Replaces the details marker with a more appropriate caret symbol. Should only apply to details in the reference/ApiItem column.

## Motivation and Context

Cleaner, more consistent style

## How Has This Been Tested?

See deploy preview