### PR TITLE
Add more debug info to resolveJsonRefs

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -101,7 +101,19 @@ async function resolveJsonRefs(specUrlOrObject: object | string) {
     });
     return schema as OpenApiObject;
   } catch (err: any) {
-    console.error(chalk.yellow(err.errors[0]?.message ?? err));
+    let errorMsg = "";
+
+    if (err.errors[0] !== undefined) {
+      const error = err.errors[0];
+      errorMsg = JSON.stringify({
+        footprint: error.footprint,
+        message: error.message,
+      });
+    } else {
+      errorMsg = err;
+    }
+
+    console.error(chalk.yellow(errorMsg));
     return;
   }
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -105,10 +105,7 @@ async function resolveJsonRefs(specUrlOrObject: object | string) {
 
     if (err.errors[0] !== undefined) {
       const error = err.errors[0];
-      errorMsg = JSON.stringify({
-        footprint: error.footprint,
-        message: error.message,
-      });
+      errorMsg = `Error: [${error.message}] with footprint [${error.footprint}]`;
     } else {
       errorMsg = err;
     }


### PR DESCRIPTION
## Description

Add footprint formation when resolving references fails

## Motivation and Context

I opened an issue (https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/559) because I received an error that looked like there was something wrong in the plugin, but it turned out to be a typo in my project somewhere. Adding the footprint allows developers to see where in the spec something failed.

Below message was reported which didn't help me too much.

```js
Could not find resolver for "g:/[somepath...]/ApiCommons.yml%22"
SyntaxError: Unexpected token u in JSON at position 0
WARNING: the following OpenAPI spec returned undefined: G:/[somepath...]/Api.yml
```

## How Has This Been Tested?

Built the plugin and referenced it in my project, caused it to fail and that resulted in a better error that helps me find out where the error is.

```js
Error: [Could not find resolver for "g:/[somepath...]/SimplyPluralApiDocs/node_modules/@apidevtools/json-schema-ref-parser/dist/SimplyPluralApiCommons.yml'"] with footprint [paths,/v1/chat/category/:id,get,parameters,0,description+g:/[somepath...]/SimplyPluralApiDocs/node_modules/@apidevtools/json-schema-ref-parser/dist/+EUNMATCHEDRESOLVER+Could not find resolver for "g:/[somepath...]/SimplyPluralApiDocs/node_modules/@apidevtools/json-schema-ref-parser/dist/SimplyPluralApiCommons.yml'"]
SyntaxError: Unexpected token u in JSON at position 0
WARNING: the following OpenAPI spec returned undefined: G:\[somepath...]\SimplyPluralApiDocs\SimplyPluralApi.yml
```

Note: I replaced my root path with "[somepath...]"

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
