### PR TITLE
[Bug] Improve support for additional properties, cleanup nested <li>, support SchemaItem children

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -53,7 +53,7 @@ export function mergeAllOf(allOf: SchemaObject[]) {
  */
 function createAnyOneOf(schema: SchemaObject): any {
   const type = schema.oneOf ? "oneOf" : "anyOf";
-  return create("li", {
+  return create("div", {
     children: [
       create("span", {
         className: "badge badge--info",
@@ -68,14 +68,17 @@ function createAnyOneOf(schema: SchemaObject): any {
 
           if (anyOneSchema.properties !== undefined) {
             anyOneChildren.push(createProperties(anyOneSchema));
+            delete anyOneSchema.properties;
           }
 
           if (anyOneSchema.allOf !== undefined) {
             anyOneChildren.push(createNodes(anyOneSchema));
+            delete anyOneSchema.allOf;
           }
 
           if (anyOneSchema.items !== undefined) {
             anyOneChildren.push(createItems(anyOneSchema));
+            delete anyOneSchema.items;
           }
 
           if (
@@ -159,6 +162,18 @@ function createAdditionalProperties(schema: SchemaObject) {
   // }
   const additionalProperties = schema.additionalProperties;
   const type: string | unknown = additionalProperties?.type;
+  // Handle free-form objects
+  if (String(additionalProperties) === "true" && schema.type === "object") {
+    return create("SchemaItem", {
+      name: "property name*",
+      required: false,
+      schemaName: "any",
+      qualifierMessage: getQualifierMessage(schema.additionalProperties),
+      schema: schema,
+      collapsible: false,
+      discriminator: false,
+    });
+  }
   if (
     (type === "object" || type === "array") &&
     (additionalProperties?.properties ||
@@ -168,12 +183,12 @@ function createAdditionalProperties(schema: SchemaObject) {
       additionalProperties?.oneOf ||
       additionalProperties?.anyOf)
   ) {
-    const title = additionalProperties.title;
-    const schemaName = title ? `object (${title})` : "object";
+    const title = additionalProperties.title as string;
+    const schemaName = getSchemaName(additionalProperties);
     const required = schema.required ?? false;
     return createDetailsNode(
       "property name*",
-      schemaName,
+      title ?? schemaName,
       additionalProperties,
       required,
       schema.nullable
@@ -191,51 +206,30 @@ function createAdditionalProperties(schema: SchemaObject) {
       schema.additionalProperties?.additionalProperties;
     if (additionalProperties !== undefined) {
       const type = schema.additionalProperties?.additionalProperties?.type;
-      const format = schema.additionalProperties?.additionalProperties?.format;
-      return create("li", {
-        children: create("div", {
-          children: [
-            create("code", { children: `property name*` }),
-            guard(type, (type) =>
-              create("span", {
-                style: { opacity: "0.6" },
-                children: ` ${type}`,
-              })
-            ),
-            guard(format, (format) =>
-              create("span", {
-                style: { opacity: "0.6" },
-                children: ` (${format})`,
-              })
-            ),
-            guard(getQualifierMessage(schema.additionalProperties), (message) =>
-              create("div", {
-                style: { marginTop: "var(--ifm-table-cell-padding)" },
-                children: createDescription(message),
-              })
-            ),
-          ],
-        }),
+      const schemaName = getSchemaName(
+        schema.additionalProperties?.additionalProperties!
+      );
+      return create("SchemaItem", {
+        name: "property name*",
+        required: false,
+        schemaName: schemaName ?? type,
+        qualifierMessage:
+          schema.additionalProperties ??
+          getQualifierMessage(schema.additionalProperties),
+        schema: schema,
+        collapsible: false,
+        discriminator: false,
       });
     }
-    return create("li", {
-      children: create("div", {
-        children: [
-          create("code", { children: `property name*` }),
-          guard(type, (type) =>
-            create("span", {
-              style: { opacity: "0.6" },
-              children: ` ${type}`,
-            })
-          ),
-          guard(getQualifierMessage(schema.additionalProperties), (message) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(message),
-            })
-          ),
-        ],
-      }),
+    const schemaName = getSchemaName(schema.additionalProperties!);
+    return create("SchemaItem", {
+      name: "property name*",
+      required: false,
+      schemaName: schemaName,
+      qualifierMessage: getQualifierMessage(schema),
+      schema: schema.additionalProperties,
+      collapsible: false,
+      discriminator: false,
     });
   }
   return Object.entries(schema.additionalProperties!).map(([key, val]) =>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -58,14 +58,13 @@ export function mergeAllOf(allOf: SchemaObject[]) {
  */
 function createAnyOneOf(schema: SchemaObject): any {
   const type = schema.oneOf ? "oneOf" : "anyOf";
-  return create("li", {
+  return create("div", {
     children: [
       create("span", {
         className: "badge badge--info",
         children: type,
       }),
       create("SchemaTabs", {
-        className: "openapi-tabs__schema",
         children: schema[type]!.map((anyOneSchema, index) => {
           const label = anyOneSchema.title
             ? anyOneSchema.title
@@ -74,14 +73,17 @@ function createAnyOneOf(schema: SchemaObject): any {
 
           if (anyOneSchema.properties !== undefined) {
             anyOneChildren.push(createProperties(anyOneSchema));
+            delete anyOneSchema.properties;
           }
 
           if (anyOneSchema.allOf !== undefined) {
             anyOneChildren.push(createNodes(anyOneSchema));
+            delete anyOneSchema.allOf;
           }
 
           if (anyOneSchema.items !== undefined) {
             anyOneChildren.push(createItems(anyOneSchema));
+            delete anyOneSchema.items;
           }
 
           if (
@@ -92,7 +94,6 @@ function createAnyOneOf(schema: SchemaObject): any {
           ) {
             anyOneChildren.push(createNodes(anyOneSchema));
           }
-
           if (anyOneChildren.length) {
             if (schema.type === "array") {
               return create("TabItem", {
@@ -110,7 +111,7 @@ function createAnyOneOf(schema: SchemaObject): any {
             return create("TabItem", {
               label: label,
               value: `${index}-item-properties`,
-              children: anyOneChildren,
+              children: anyOneChildren.filter(Boolean).flat(),
             });
           }
 
@@ -166,6 +167,18 @@ function createAdditionalProperties(schema: SchemaObject) {
   // }
   const additionalProperties = schema.additionalProperties;
   const type: string | unknown = additionalProperties?.type;
+  // Handle free-form objects
+  if (String(additionalProperties) === "true" && schema.type === "object") {
+    return create("SchemaItem", {
+      name: "property name*",
+      required: false,
+      schemaName: "any",
+      qualifierMessage: getQualifierMessage(schema.additionalProperties),
+      schema: schema,
+      collapsible: false,
+      discriminator: false,
+    });
+  }
   if (
     (type === "object" || type === "array") &&
     (additionalProperties?.properties ||
@@ -175,12 +188,12 @@ function createAdditionalProperties(schema: SchemaObject) {
       additionalProperties?.oneOf ||
       additionalProperties?.anyOf)
   ) {
-    const title = additionalProperties.title;
-    const schemaName = title ? `object (${title})` : "object";
+    const title = additionalProperties.title as string;
+    const schemaName = getSchemaName(additionalProperties);
     const required = schema.required ?? false;
     return createDetailsNode(
       "property name*",
-      schemaName,
+      title ?? schemaName,
       additionalProperties,
       required,
       schema.nullable
@@ -198,51 +211,30 @@ function createAdditionalProperties(schema: SchemaObject) {
       schema.additionalProperties?.additionalProperties;
     if (additionalProperties !== undefined) {
       const type = schema.additionalProperties?.additionalProperties?.type;
-      const format = schema.additionalProperties?.additionalProperties?.format;
-      return create("li", {
-        children: create("div", {
-          children: [
-            create("code", { children: `property name*` }),
-            guard(type, (type) =>
-              create("span", {
-                style: { opacity: "0.6" },
-                children: ` ${type}`,
-              })
-            ),
-            guard(format, (format) =>
-              create("span", {
-                style: { opacity: "0.6" },
-                children: ` (${format})`,
-              })
-            ),
-            guard(getQualifierMessage(schema.additionalProperties), (message) =>
-              create("div", {
-                style: { marginTop: "var(--ifm-table-cell-padding)" },
-                children: createDescription(message),
-              })
-            ),
-          ],
-        }),
+      const schemaName = getSchemaName(
+        schema.additionalProperties?.additionalProperties!
+      );
+      return create("SchemaItem", {
+        name: "property name*",
+        required: false,
+        schemaName: schemaName ?? type,
+        qualifierMessage:
+          schema.additionalProperties ??
+          getQualifierMessage(schema.additionalProperties),
+        schema: schema,
+        collapsible: false,
+        discriminator: false,
       });
     }
-    return create("li", {
-      children: create("div", {
-        children: [
-          create("code", { children: `property name*` }),
-          guard(type, (type) =>
-            create("span", {
-              style: { opacity: "0.6" },
-              children: ` ${type}`,
-            })
-          ),
-          guard(getQualifierMessage(schema.additionalProperties), (message) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(message),
-            })
-          ),
-        ],
-      }),
+    const schemaName = getSchemaName(schema.additionalProperties!);
+    return create("SchemaItem", {
+      name: "property name*",
+      required: false,
+      schemaName: schemaName,
+      qualifierMessage: getQualifierMessage(schema),
+      schema: schema.additionalProperties,
+      collapsible: false,
+      discriminator: false,
     });
   }
   return Object.entries(schema.additionalProperties!).map(([key, val]) =>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -119,7 +119,7 @@ function ParamsItem({
   });
 
   return (
-    <li className="openapi-params__list-item">
+    <div className="openapi-params__list-item">
       <span className="openapi-schema__container">
         <strong>{name}</strong>
         {renderSchemaName}
@@ -131,7 +131,7 @@ function ParamsItem({
       {renderDescription}
       {renderExample}
       {renderExamples}
-    </li>
+    </div>
   );
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
@@ -110,13 +110,14 @@ function SchemaItem({
       {renderQualifierMessage}
       {renderDefaultValue}
       {renderSchemaDescription}
+      {collapsibleSchemaContent ?? collapsibleSchemaContent}
     </div>
   );
 
   return (
-    <li className="openapi-schema__list-item">
+    <div className="openapi-schema__list-item">
       {collapsible ? collapsibleSchemaContent : schemaContent}
-    </li>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

Ports fixes from the v1 branch that help improve handling of discriminators, additional properties, and introduces ability to pass children to SchemaItem component.

## Motivation and Context

Maintain parity with v1.

## How Has This Been Tested?

Tested with Resoto and Petstore APIs but we should apply more rigor to ensure no regressions.

## Observations

Noticed a small formatting issue between `oneOf` badge and tabs. If it's not already fixed in #557 we should look into ways to polish it.

![Screenshot 2023-05-02 at 11 18 26 AM](https://user-images.githubusercontent.com/9343811/235710257-18f1fb9b-fe90-43d3-80f7-02964a6aa87c.png)
