### PR TITLE
Add optional `markdownGenerators` config option

### DIFF
--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -297,20 +297,21 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `config` can be configured with the following options:
 
-| Name             | Type     | Default | Description                                                                                                                 |
-| ---------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `specPath`       | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files. |
-| `ouputDir`       | `string` | `null`  | Desired output path for generated MDX files.                                                                                |
-| `proxy`          | `string` | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser.                                     |                                                                               
-| `template`       | `string` | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                  |
-| `downloadUrl`    | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                             |
-| `hideSendButton` | `boolean`| `null`  | _Optional:_ If set to `true`, hides the "Send API Request" button in API demo panel.                                        |
-| `showExtensions` | `boolean`| `null`  | _Optional:_ If set to `true`, renders operation-level vendor-extensions in description.                                    |
-| `sidebarOptions` | `object` | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                            |
-| `version`        | `string` | `null`  | _Optional:_ Version assigned to single or micro-spec API specified in `specPath`.                                           |
-| `label`          | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                              |
-| `baseUrl`        | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                           |
-| `versions`       | `object` | `null`  | _Optional:_ Set of options for versioning configuration. See below for a list of supported options.                         |
+| Name                 | Type     | Default | Description                                                                                                                              |
+| -------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `specPath`           | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.              |
+| `ouputDir`           | `string` | `null`  | Desired output path for generated MDX files.                                                                                             |
+| `proxy`              | `string` | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser.                                                  |                                                                               
+| `template`           | `string` | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                               |
+| `downloadUrl`        | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                          |
+| `hideSendButton`     | `boolean`| `null`  | _Optional:_ If set to `true`, hides the "Send API Request" button in API demo panel.                                                     |
+| `showExtensions`     | `boolean`| `null`  | _Optional:_ If set to `true`, renders operation-level vendor-extensions in description.                                                  |
+| `sidebarOptions`     | `object` | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                         |
+| `version`            | `string` | `null`  | _Optional:_ Version assigned to single or micro-spec API specified in `specPath`.                                                        |
+| `label`              | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                                           |
+| `baseUrl`            | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                                        |
+| `versions`           | `object` | `null`  | _Optional:_ Set of options for versioning configuration. See below for a list of supported options.                                      |
+| `markdownGenerators` | `object` | `null`  | _Optional:_ Customize MDX content with a set of options for markdown generator configuration. See below for a list of supported options. |
 
 ### sidebarOptions
 
@@ -342,6 +343,22 @@ You may optionally configure a `sidebarOptions`. In doing so, an individual `sid
 
 :::info NOTE
 All versions will automatically inherit `sidebarOptions` from the parent/base config.
+:::
+
+### markdownGenerators
+
+`markdownGenerators` can be configured with the following options:
+
+| Name                 | Type      | Default | Description                                                                                                                    |
+| ------------------ | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------|
+| `createApiPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for API pages.<br/><br/>**Function type:** `(pageData: ApiPageMetadata) => string`   |
+| `createInfoPageMD` | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for info pages.<br/><br/>**Function type:** `(pageData: InfoPageMetadata) => string` |
+| `createTagPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for tag pages.<br/><br/>**Function type:** `(pageData: TagPageMetadata) => string`   |
+
+:::info NOTE
+If a config option is not provided, its default markdown generator will be used. 
+
+This config option is intended for advanced users who wish to highly customize the markdown content and layout of generated pages.
 :::
 
 ## Installing from Template

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -91,8 +91,14 @@ export default function pluginOpenAPIDocs(
   let docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
 
   async function generateApiDocs(options: APIOptions, pluginId: any) {
-    let { specPath, outputDir, template, downloadUrl, sidebarOptions } =
-      options;
+    let {
+      specPath,
+      outputDir,
+      template,
+      markdownGenerators,
+      downloadUrl,
+      sidebarOptions,
+    } = options;
 
     // Remove trailing slash before proceeding
     outputDir = outputDir.replace(/\/$/, "");
@@ -237,6 +243,13 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
 \`\`\`
       `;
 
+      const apiPageGenerator =
+        markdownGenerators?.createApiPageMD ?? createApiPageMD;
+      const infoPageGenerator =
+        markdownGenerators?.createInfoPageMD ?? createInfoPageMD;
+      const tagPageGenerator =
+        markdownGenerators?.createTagPageMD ?? createTagPageMD;
+
       loadedApi.map(async (item) => {
         if (item.type === "info") {
           if (downloadUrl && isURL(downloadUrl)) {
@@ -245,10 +258,10 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
         }
         const markdown =
           item.type === "api"
-            ? createApiPageMD(item)
+            ? apiPageGenerator(item)
             : item.type === "info"
-            ? createInfoPageMD(item)
-            : createTagPageMD(item);
+            ? infoPageGenerator(item)
+            : tagPageGenerator(item);
         item.markdown = markdown;
         if (item.type === "api") {
           item.json = JSON.stringify(item.api);

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -16,6 +16,12 @@ const sidebarOptions = Joi.object({
   sidebarCollapsed: Joi.boolean(),
 });
 
+const markdownGenerators = Joi.object({
+  createApiPageMD: Joi.function(),
+  createInfoPageMD: Joi.function(),
+  createTagPageMD: Joi.function(),
+});
+
 export const OptionsSchema = Joi.object({
   id: Joi.string().required(),
   docsPluginId: Joi.string().required(),
@@ -31,6 +37,7 @@ export const OptionsSchema = Joi.object({
         hideSendButton: Joi.boolean(),
         showExtensions: Joi.boolean(),
         sidebarOptions: sidebarOptions,
+        markdownGenerators: markdownGenerators,
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -43,6 +43,13 @@ export interface APIOptions {
     [key: string]: APIVersionOptions;
   };
   proxy?: string;
+  markdownGenerators?: MarkdownGenerator;
+}
+
+export interface MarkdownGenerator {
+  createApiPageMD?: (pageData: ApiPageMetadata) => string;
+  createInfoPageMD?: (pageData: InfoPageMetadata) => string;
+  createTagPageMD?: (pageData: TagPageMetadata) => string;
 }
 
 export interface SidebarOptions {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds an optional `markdownGenerators` config option to the `docusaurus-plugin-openapi-docs` plugin, allowing the user to optionally provide their own `createApiPageMD`, `createInfoPageMD`, or `createTagPageMD` functions. If not provided, the plugin defaults to the existing functions of the same name.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change allows for a high level of customization for layout and styling. While the `template` config option exists, it doesn't allow for large layout changes since the `markdown` available for the template is already generated by the `createApiPageMD`, `createInfoPageMD`, and `createTagPageMD` functions.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I installed a fresh Docusaurus site with this update, passing in the different config options for `markdownGenerators` that return strings with different content or layouts than the defaults. Excluding any of these options successfully falls back to the original behavior.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
