### PR TITLE
Prepare release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.7.3 (May 5, 2023)
+
+High level enhancements
+
+- Add optional `markdownGenerators` config option ([#567](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/567))
+- Add more debug info to resolveJsonRefs ([#560](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/560))
+
+Other enhancements and bug fixes
+
+- [Bug] Add handler for oneOf properties, fix nested <li> and and avoid duplicate properties in createAnyOneOf ([#561](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/561))
+
 ## 1.7.2 (Apr 20, 2023)
 
 High level enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ High level enhancements
 
 Other enhancements and bug fixes
 
-- [Bug] Add handler for oneOf properties, fix nested <li> and and avoid duplicate properties in createAnyOneOf ([#561](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/561))
+- [Bug] Add handler for oneOf properties, fix nested `<li>` and avoid duplicate properties in createAnyOneOf ([#561](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/561))
 
 ## 1.7.2 (Apr 20, 2023)
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -26,8 +26,8 @@
     "@docusaurus/preset-classic": ">=2.0.1 <2.3.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.7.2",
-    "docusaurus-theme-openapi-docs": "^1.7.2",
+    "docusaurus-plugin-openapi-docs": "^1.7.3",
+    "docusaurus-theme-openapi-docs": "^1.7.3",
     "prism-react-renderer": "^1.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.2",
+  "version": "1.7.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -51,7 +51,7 @@
     "buffer": "^6.0.3",
     "clsx": "^1.1.1",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^1.7.2",
+    "docusaurus-plugin-openapi-docs": "^1.7.3",
     "file-saver": "^2.0.5",
     "immer": "^9.0.7",
     "lodash": "^4.17.20",


### PR DESCRIPTION
## 1.7.3 (May 5, 2023)

High level enhancements

- Add optional `markdownGenerators` config option ([#567](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/567))
- Add more debug info to resolveJsonRefs ([#560](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/560))

Other enhancements and bug fixes

- [Bug] Add handler for oneOf properties, fix nested `<li>` and avoid duplicate properties in createAnyOneOf ([#561](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/561))

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)