### PR TITLE
[Bug] Use SchemaItem to render leaf discriminator properties/nodes

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -819,36 +819,26 @@ function createNodes(schema: SchemaObject): any {
 
   // primitive
   if (schema.type !== undefined) {
-    return create("li", {
-      children: create("div", {
-        children: [
-          create("strong", { children: schema.type }),
-          guard(schema.format, (format) =>
-            create("span", {
-              style: { opacity: "0.6" },
-              children: ` ${format}`,
-            })
-          ),
-          guard(getQualifierMessage(schema), (message) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(message),
-            })
-          ),
-          guard(schema.description, (description) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(description),
-            })
-          ),
-        ],
-      }),
+    return create("SchemaItem", {
+      collapsible: false,
+      name: schema.type,
+      required: false,
+      schemaName: schema.format,
+      qualifierMessage: getQualifierMessage(schema),
+      schema: schema,
     });
   }
 
   // Unknown node/schema type should return undefined
   // So far, haven't seen this hit in testing
-  return "any";
+  return create("SchemaItem", {
+    collapsible: false,
+    name: "any",
+    required: false,
+    schemaName: schema.format,
+    qualifierMessage: getQualifierMessage(schema),
+    schema: schema,
+  });
 }
 
 interface Props {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -826,36 +826,26 @@ function createNodes(schema: SchemaObject): any {
 
   // primitive
   if (schema.type !== undefined) {
-    return create("li", {
-      children: create("div", {
-        children: [
-          create("strong", { children: schema.type }),
-          guard(schema.format, (format) =>
-            create("span", {
-              style: { opacity: "0.6" },
-              children: ` ${format}`,
-            })
-          ),
-          guard(getQualifierMessage(schema), (message) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(message),
-            })
-          ),
-          guard(schema.description, (description) =>
-            create("div", {
-              style: { marginTop: "var(--ifm-table-cell-padding)" },
-              children: createDescription(description),
-            })
-          ),
-        ],
-      }),
+    return create("SchemaItem", {
+      collapsible: false,
+      name: schema.type,
+      required: false,
+      schemaName: schema.format,
+      qualifierMessage: getQualifierMessage(schema),
+      schema: schema,
     });
   }
 
   // Unknown node/schema type should return undefined
   // So far, haven't seen this hit in testing
-  return "any";
+  return create("SchemaItem", {
+    collapsible: false,
+    name: "any",
+    required: false,
+    schemaName: schema.format,
+    qualifierMessage: getQualifierMessage(schema),
+    schema: schema,
+  });
 }
 
 interface Props {


### PR DESCRIPTION
## Description

See [this thread](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/555#issuecomment-1537045129) for background.

> Note: it's best to test using one of the Resoto specs