### PR TITLE
Add support for `anyOf` keyword

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -37,7 +37,7 @@ info:
     Petstore offers two forms of authentication:
       - API Key
       - OAuth2
-      
+
     OAuth2 - an open protocol to allow secure authorization in a simple
     and standard method from web, mobile and desktop applications.
 
@@ -1124,7 +1124,7 @@ components:
         id:
           $ref: "#/components/schemas/Id"
         pet:
-          oneOf:
+          anyOf:
             - $ref: "#/components/schemas/Pet"
             - $ref: "#/components/schemas/Tag"
         username:

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -520,13 +520,15 @@ function createDetailsNode(
   });
 }
 
-function createOneOfProperty(
+function createOneOfOrAnyOfProperty(
   name: string,
   schemaName: string,
   schema: SchemaObject,
   required: string[] | boolean,
   nullable: boolean | unknown
 ): any {
+  const type = schema.oneOf ? "oneOf" : "anyOf";
+  const children = schema[type] || [];
   return create("SchemaItem", {
     collapsible: true,
     className: "schemaItem",
@@ -590,10 +592,10 @@ function createOneOfProperty(
             children: [
               create("span", {
                 className: "badge badge--info",
-                children: "oneOf",
+                children: type,
               }),
               create("SchemaTabs", {
-                children: schema["oneOf"]!.map((property, index) => {
+                children: children.map((property, index) => {
                   const label = property.type ?? `MOD${index + 1}`;
                   return create("TabItem", {
                     label: label,
@@ -689,7 +691,7 @@ function createEdges({
   }
 
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
-    return createOneOfProperty(
+    return createOneOfOrAnyOfProperty(
       name,
       schemaName,
       schema,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -526,13 +526,15 @@ function createDetailsNode(
   });
 }
 
-function createOneOfProperty(
+function createOneOfOrAnyOfProperty(
   name: string,
   schemaName: string,
   schema: SchemaObject,
   required: string[] | boolean,
   nullable: boolean | unknown
 ): any {
+  const type = schema.oneOf ? "oneOf" : "anyOf";
+  const children = schema[type] || [];
   return create("SchemaItem", {
     collapsible: true,
     className: "schemaItem",
@@ -596,10 +598,10 @@ function createOneOfProperty(
             children: [
               create("span", {
                 className: "badge badge--info",
-                children: "oneOf",
+                children: type,
               }),
               create("SchemaTabs", {
-                children: schema["oneOf"]!.map((property, index) => {
+                children: children.map((property, index) => {
                   const label = property.type ?? `MOD${index + 1}`;
                   return create("TabItem", {
                     label: label,
@@ -695,7 +697,7 @@ function createEdges({
   }
 
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
-    return createOneOfProperty(
+    return createOneOfOrAnyOfProperty(
       name,
       schemaName,
       schema,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Add support for `anyOf` sub-schemas.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When #561 was merged to add support for `oneOf` properties, it looks like it was also intended to support `anyOf` sub-schemas as well, but there was no `anyOf` keyword in the example schemas, so it was merged with a bug.
The `createOneOfProperty` function is called if a schema has either `anyOf` or `oneOf` properties, but the function also assumes that it should read `schema.oneOf`.

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/3e8d8ccd9f7294154b04af7031865d792366c176/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts#L602

This leads to exceptions when passed a schema with `anyOf`.

Example Error:
```
[ERROR] TypeError: Cannot read properties of undefined (reading 'map')
    at createOneOfProperty (docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:503:59)
    at createEdges (docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:569:16)
    at docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:110:16
    at Array.map (<anonymous>)
    at createProperties (docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:109:46)
    at createNodes (docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:640:24)
    at docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:774:67
    at Array.map (<anonymous>)
    at createResponseSchema (docusaurus-plugin-openapi-docs/lib/markdown/createResponseSchema.js:710:33)
    at docusaurus-plugin-openapi-docs/lib/markdown/createStatusCodes.js:290:91
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I replaced a `oneOf` keyword in the example petstore schema with `anyOf`, then tested by building the demo website and viewing it.

If you'd prefer that we alter a different portion of the schema, or if you prefer that a new property be added, that would be fine.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

| **Before** | **After |
| --- | --- |
| <img width="766" alt="Screen Shot 2023-05-15 at 4 26 36 PM" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/706922/1032287c-2065-4719-b859-76e1cda122bb"> | <img width="786" alt="Screen Shot 2023-05-15 at 4 25 40 PM" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/706922/f1b38cf4-c31a-4e82-801d-f7927e422d4c"> |


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly. (I don't think any doc updates are appropriate)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate. (I don't see any tests, if I missed them, let me know, and I'll be happy to write one)
- [ ] All new and existing tests passed. (again, I don't see any tests)
