### PR TITLE
allow for custom code example tabs

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/CodeTabs/index.tsx
@@ -46,6 +46,7 @@ export interface Props {
   }[];
   readonly groupId?: string;
   readonly className?: string;
+  readonly mergedLangs?: Language[];
   readonly action?: any;
 }
 
@@ -57,6 +58,7 @@ function TabsComponent(props: Props): JSX.Element {
     values: valuesProp,
     groupId,
     className,
+    mergedLangs,
     action,
   } = props;
   const children = React.Children.map(props.children, (child) => {
@@ -133,7 +135,8 @@ function TabsComponent(props: Props): JSX.Element {
       blockElementScrollPositionUntilNextRender(newTab);
       setSelectedValue(newTabValue);
       if (action) {
-        const newLanguage = languageSet.filter(
+        const langs = mergedLangs ? mergedLangs : languageSet;
+        const newLanguage = langs.filter(
           (lang: Language) => lang.language === newTabValue
         );
         action(newLanguage[0]);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -277,7 +277,7 @@ function Curl({ postman, codeSamples }: Props) {
 
   return (
     <>
-      <CodeTabs groupId="code-samples" action={setLanguage}>
+      <CodeTabs groupId="code-samples" mergedLangs={mergedLangs} action={setLanguage}>
         {mergedLangs.map((lang) => {
           return (
             <CodeTab

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiDemoPanel/Curl/index.tsx
@@ -277,7 +277,11 @@ function Curl({ postman, codeSamples }: Props) {
 
   return (
     <>
-      <CodeTabs groupId="code-samples" mergedLangs={mergedLangs} action={setLanguage}>
+      <CodeTabs
+        groupId="code-samples"
+        mergedLangs={mergedLangs}
+        action={setLanguage}
+      >
         {mergedLangs.map((lang) => {
           return (
             <CodeTab


### PR DESCRIPTION
## Description

There seems to be some support for an `x-code-samples` property to display custom code samples. However, when doing this, the `CodeTabs` component is only aware of the default auto-generated samples. So when you click on a tab for a custom code sample, the component can't find the Language and bombs.

It's not clear to me that the `x-code-samples` property is intended to be fully supported. I can't find any documentation about support or a working example, so it's unclear to me if there are tests that should be added/updated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When using `x-code-samples`, clicking on a tab for a custom code sample, the component can't find the Language and bombs.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
This was tested manually using an openAPI spec with and without the `x-code-samples` property.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x]  I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
