### PR TITLE
Adds compression support to frontmatter api prop

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -7,6 +7,7 @@
 
 import fs from "fs";
 import path from "path";
+import zlib from "zlib";
 
 import type { LoadContext, Plugin } from "@docusaurus/types";
 import { Globby, posixPath } from "@docusaurus/utils";
@@ -18,7 +19,6 @@ import { readOpenapiFiles, processOpenapiFiles } from "./openapi";
 import { OptionsSchema } from "./options";
 import generateSidebarSlice from "./sidebars";
 import type { PluginOptions, LoadedContent, APIOptions } from "./types";
-import zlib from "zlib";
 
 export function isURL(str: string): boolean {
   return /^(https?:)\/\//m.test(str);

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -18,6 +18,7 @@ import { readOpenapiFiles, processOpenapiFiles } from "./openapi";
 import { OptionsSchema } from "./options";
 import generateSidebarSlice from "./sidebars";
 import type { PluginOptions, LoadedContent, APIOptions } from "./types";
+import zlib from "zlib";
 
 export function isURL(str: string): boolean {
   return /^(https?:)\/\//m.test(str);
@@ -264,7 +265,16 @@ import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
             : tagPageGenerator(item);
         item.markdown = markdown;
         if (item.type === "api") {
-          item.json = JSON.stringify(item.api);
+          // opportunity to compress JSON
+          // const serialize = (o: any) => {
+          //   return zlib.deflateSync(JSON.stringify(o)).toString("base64");
+          // };
+          // const deserialize = (s: any) => {
+          //   return zlib.inflateSync(Buffer.from(s, "base64")).toString();
+          // };
+          item.json = zlib
+            .deflateSync(JSON.stringify(item.api))
+            .toString("base64");
           let infoBasePath = `${outputDir}/${item.infoId}`;
           if (docRouteBasePath) {
             infoBasePath = `${docRouteBasePath}/${outputDir

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -50,9 +50,12 @@ export default function ApiItem(props: Props): JSX.Element {
   const { info_path: infoPath } = frontMatter as DocFrontMatter;
   let { api } = frontMatter as ApiFrontMatter;
   // decompress and parse
-  api = JSON.parse(
-    zlib.inflateSync(Buffer.from(api as any, "base64")).toString()
-  );
+  if (api) {
+    api = JSON.parse(
+      zlib.inflateSync(Buffer.from(api as any, "base64")).toString()
+    );
+  }
+
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import zlib from "zlib";
+
 import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
@@ -27,7 +29,6 @@ import type {
   ThemeConfig,
 } from "docusaurus-theme-openapi-docs/src/types";
 import { Provider } from "react-redux";
-import zlib from "zlib";
 
 import { createStoreWithoutState, createStoreWithState } from "./store";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -27,6 +27,7 @@ import type {
   ThemeConfig,
 } from "docusaurus-theme-openapi-docs/src/types";
 import { Provider } from "react-redux";
+import zlib from "zlib";
 
 import { createStoreWithoutState, createStoreWithState } from "./store";
 
@@ -47,7 +48,11 @@ export default function ApiItem(props: Props): JSX.Element {
   const MDXComponent = props.content;
   const { frontMatter } = MDXComponent;
   const { info_path: infoPath } = frontMatter as DocFrontMatter;
-  const { api } = frontMatter as ApiFrontMatter;
+  let { api } = frontMatter as ApiFrontMatter;
+  // decompress and parse
+  api = JSON.parse(
+    zlib.inflateSync(Buffer.from(api as any, "base64")).toString()
+  );
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;


### PR DESCRIPTION
## Description

As the OpenAPI spec size increases we run the risk of exceeding the max string length allowed for `server.bundle.js`. This change uses `zlib` to compress the `api` frontmatter prop in order to reduce the overall size of this string.