### PR TITLE
Fix demo panel for `FormData` request type

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -152,11 +152,14 @@ async function makeRequest(
         break;
       }
       case "formdata": {
+        // The Content-Type header will be set automatically based on the type of body.
+        myHeaders.delete("Content-Type");
+
         myBody = new FormData();
-        if (Array.isArray(body.formdata)) {
-          for (const data of body.formdata) {
-            if (data.key && data.value) {
-              myBody.append(data.key, data.value);
+        if (Array.isArray(request.body.formdata.members)) {
+          for (const data of request.body.formdata.members) {
+            if (data.key && data.value.content) {
+              myBody.append(data.key, data.value.content);
             }
           }
         }


### PR DESCRIPTION
## Description

See #618 

The current implementation doesn't support the FormData request well - at least sending binary files doesn't work at all.

There are 2 main problems:
1. The request body is initially serialized to JSON
1. The request Content-Type header is set manually instead of letting `fetch` to set it automatically based on the content. `fetch` should also set the correct boundary separator (eg `multipart/form-data; boundary=---...`). 

## Motivation and Context

See #618 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
