### PR TITLE
Reuse `createAnyOneOf` while creating a property

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,11 +71,12 @@ module.exports = {
   },
   overrides: [
     {
-      files: ["**/scripts/**", "cypress/**"],
+      files: ["**/scripts/**", "cypress/**", "**/*.test.ts"],
       rules: {
         "import/no-extraneous-dependencies": [
           "warn",
           {
+            packageDir: [__dirname, "."],
             devDependencies: true,
             optionalDependencies: false,
             peerDependencies: true,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createNodes should create readable MODs for oneOf primitive properties 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <strong>oneOfProperty</strong>
+      <span style={{ opacity: \\"0.6\\" }}> object</span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}></div>
+    <div>
+      <span className={\\"badge badge--info\\"}>oneOf</span>
+      <SchemaTabs>
+        <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+          <SchemaItem
+            collapsible={false}
+            name={\\"noseLength\\"}
+            required={true}
+            schemaName={\\"number\\"}
+            qualifierMessage={undefined}
+            schema={{ type: \\"number\\" }}
+          ></SchemaItem>
+        </TabItem>
+        <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+          <li>
+            <div
+              style={{
+                fontSize: \\"var(--ifm-code-font-size)\\",
+                opacity: \\"0.6\\",
+                marginLeft: \\"-.5rem\\",
+                paddingBottom: \\".5rem\\",
+              }}
+            >
+              Array [
+            </div>
+          </li>
+          <div
+            style={{
+              marginTop: \\".5rem\\",
+              marginBottom: \\".5rem\\",
+              marginLeft: \\"1rem\\",
+            }}
+          >
+            string
+          </div>
+          <li>
+            <div
+              style={{
+                fontSize: \\"var(--ifm-code-font-size)\\",
+                opacity: \\"0.6\\",
+                marginLeft: \\"-.5rem\\",
+              }}
+            >
+              ]
+            </div>
+          </li>
+        </TabItem>
+        <TabItem label={\\"MOD3\\"} value={\\"2-item-properties\\"}>
+          <div
+            style={{
+              marginTop: \\".5rem\\",
+              marginBottom: \\".5rem\\",
+              marginLeft: \\"1rem\\",
+            }}
+          >
+            boolean
+          </div>
+        </TabItem>
+        <TabItem label={\\"MOD4\\"} value={\\"3-item-properties\\"}>
+          <div
+            style={{
+              marginTop: \\".5rem\\",
+              marginBottom: \\".5rem\\",
+              marginLeft: \\"1rem\\",
+            }}
+          >
+            number
+          </div>
+        </TabItem>
+        <TabItem label={\\"MOD5\\"} value={\\"4-item-properties\\"}>
+          <div
+            style={{
+              marginTop: \\".5rem\\",
+              marginBottom: \\".5rem\\",
+              marginLeft: \\"1rem\\",
+            }}
+          >
+            string
+          </div>
+        </TabItem>
+      </SchemaTabs>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -1,0 +1,56 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import * as prettier from "prettier";
+
+import { SchemaObject } from "../openapi/types";
+import { createNodes } from "./createSchema";
+
+describe("createNodes", () => {
+  it("should create readable MODs for oneOf primitive properties", () => {
+    const schema: SchemaObject = {
+      type: "object",
+      properties: {
+        oneOfProperty: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                noseLength: {
+                  type: "number",
+                },
+              },
+              required: ["noseLength"],
+              description: "Clown's nose length",
+            },
+            {
+              type: "array",
+              items: {
+                type: "string",
+              },
+              description: "Array of strings",
+            },
+            {
+              type: "boolean",
+            },
+            {
+              type: "number",
+            },
+            {
+              type: "string",
+            },
+          ],
+        },
+      },
+    };
+    expect(
+      createNodes(schema).map((md: any) =>
+        prettier.format(md, { parser: "babel" })
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -430,8 +430,6 @@ function createAnyOneOfProperty(
   required: string[] | boolean,
   nullable: boolean | unknown
 ): any {
-  const type = schema.oneOf ? "oneOf" : "anyOf";
-  const children = schema[type] || [];
   return create("SchemaItem", {
     collapsible: true,
     className: "schemaItem",
@@ -492,39 +490,7 @@ function createAnyOneOfProperty(
               ),
             ],
           }),
-          create("div", {
-            children: [
-              create("span", {
-                className: "badge badge--info",
-                children: type,
-              }),
-              create("SchemaTabs", {
-                children: children.map((property, index) => {
-                  const label = property.title ?? `MOD${index + 1}`;
-                  if (property.properties) {
-                    return create("TabItem", {
-                      label: label,
-                      value: `${index}-property`,
-                      children: [createNodes(property)],
-                    });
-                  }
-                  return create("TabItem", {
-                    label: label,
-                    value: `${index}-property`,
-                    children: [
-                      create("p", { children: label }),
-                      guard(schema.description, (description) =>
-                        create("div", {
-                          style: { marginTop: ".5rem", marginBottom: ".5rem" },
-                          children: createDescription(description),
-                        })
-                      ),
-                    ],
-                  });
-                }),
-              }),
-            ],
-          }),
+          createAnyOneOf(schema),
         ],
       }),
     ],

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -7,6 +7,7 @@
 
 import path from "path";
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { posixPath } from "@docusaurus/utils";
 
 import { readOpenapiFiles } from ".";


### PR DESCRIPTION
## Description

`createAnyOneOfProperty` has an incomplete implementation and doesn't display all possible types at the moment, but only 'object' type. Reusing `createAnyOneOf` helps with making it display all possible mods.

## Motivation and Context

A bug in `createAnyOneOfProperty` prevents from seeing all mods and shows `MOD1`, `MOD2`, etc for primitive types and arrays.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the snapshot of the before and after:
https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/commit/55a26858333f83b109868c931d63a55ec58b50d7

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
