### PR TITLE
Use `sass-loader` module as dependency

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -63,6 +63,7 @@
     "redux-devtools-extension": "^2.13.8",
     "rehype-raw": "^6.1.1",
     "sass": "^1.58.1",
+    "sass-loader": "^13.3.2",
     "webpack": "^5.61.0",
     "xml-formatter": "^2.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13712,6 +13712,13 @@ sass-loader@^10.1.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
+sass-loader@^13.3.2:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.2.tgz#460022de27aec772480f03de17f5ba88fa7e18c6"
+  integrity sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==
+  dependencies:
+    neo-async "^2.6.2"
+
 sass@^1.58.1:
   version "1.58.1"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.58.1.tgz#17ab0390076a50578ed0733f1cc45429e03405f6"


### PR DESCRIPTION
## Description

`sass-loader` was used from a sub-dependency but called directly in the module

## Motivation and Context

Fix #638 

## How Has This Been Tested?

Tested on a project that uses pnpm8 as package manager. The build passes when it used to not pass.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
