### PR TITLE
Allow charset support for application/json

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -171,7 +171,18 @@ function createItems(
       }
 
       let jsonRequestBodyExample;
-      const body = operationObject.requestBody?.content?.["application/json"];
+      const content = operationObject.requestBody?.content;
+      let body;
+      for (let key in content) {
+        if (
+          key.toLowerCase() === "application/json" ||
+          key.toLowerCase() === "application/json; charset=utf-8"
+        ) {
+          body = content[key];
+          break;
+        }
+      }
+
       if (body?.schema) {
         jsonRequestBodyExample = sampleRequestFromSchema(body.schema);
       }
@@ -304,7 +315,18 @@ function createItems(
       }
 
       let jsonRequestBodyExample;
-      const body = operationObject.requestBody?.content?.["application/json"];
+      const content = operationObject.requestBody?.content;
+      let body;
+      for (let key in content) {
+        if (
+          key.toLowerCase() === "application/json" ||
+          key.toLowerCase() === "application/json; charset=utf-8"
+        ) {
+          body = content[key];
+          break;
+        }
+      }
+
       if (body?.schema) {
         jsonRequestBodyExample = sampleRequestFromSchema(body.schema);
       }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -114,7 +114,6 @@ function Body({
       </FormItem>
     );
   }
-
   if (
     (contentType === "multipart/form-data" ||
       contentType === "application/x-www-form-urlencoded") &&
@@ -221,7 +220,10 @@ function Body({
   let exampleBody;
   let examplesBodies = [] as any;
 
-  if (contentType === "application/json" || contentType.endsWith("+json")) {
+  if (
+    contentType.includes("application/json") ||
+    contentType.endsWith("+json")
+  ) {
     if (jsonRequestBodyExample) {
       defaultBody = JSON.stringify(jsonRequestBodyExample, null, 2);
     }


### PR DESCRIPTION
## Description

See https://github.com/PaloAltoNetworks/pan.dev/issues/512 for background.

Tested with AdoptionAdvisor API spec: https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/115152a5f4bc8c5cdb646a4f373ee5529088087d/openapi-specs/cspm/AdoptionAdvisor.json