### PR TITLE
update compability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ yarn add docusaurus-theme-openapi-docs
 | Docusaurus OpenAPI Docs | Docusaurus       |
 | ----------------------- | ---------------- |
 | 1.x.x                   | `>=2.0.1 <2.3.0` |
-| 2.x.x (beta)            | `>=2.3.0`        |
+| 2.x.x (beta)            | `>=2.3.0 <2.4.1` |
 
 ## Configuring `docusaurus.config.js` (Plugin and theme usage)
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -81,7 +81,7 @@ yarn add docusaurus-theme-openapi-docs
 | Docusaurus OpenAPI Docs | Docusaurus       |
 | ----------------------- | ---------------- |
 | 1.x.x                   | `>=2.0.1 <2.3.0` |
-| 2.x.x (beta)            | `>=2.3.0`        |
+| 2.x.x (beta)            | `>=2.3.0 <2.4.1` |
 
 ## Configuration
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -22,7 +22,7 @@ The `docusaurus-plugin-openapi-docs` package extends the Docusaurus CLI with com
 
 Key Features:
 
-- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.x.
+- **Compatible:** Works with Swagger 2.0 and OpenAPI 3.0.
 - **Fast:** Convert large OpenAPI specs into MDX docs in seconds. 🔥
 - **Stylish:** Based on the same [Infima styling framework](https://infima.dev/) that powers the Docusaurus UI.
 - **Capable:** Supports single, multi and _even micro_ OpenAPI specs.
@@ -40,6 +40,13 @@ Theme:
 ```bash
 yarn add docusaurus-theme-openapi-docs
 ```
+
+## Compatibility Matrix
+
+| Docusaurus OpenAPI Docs | Docusaurus       |
+| ----------------------- | ---------------- |
+| 1.x.x                   | `>=2.0.1 <2.3.0` |
+| 2.x.x (beta)            | `>=2.3.0 <2.4.1` |
 
 ## Configuring `docusaurus.config.js` (Plugin and theme usage)
 


### PR DESCRIPTION
## Description

- update compatibility matrix
- update plugin README

> Note: v2.0.0 is not compatible with Docusaurus >=2.4.1