### PR TITLE
Format JSX with newlines and indentation

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -6,7 +6,7 @@ Array [
   <details style={{}} className={\\"openapi-markdown__details\\"}>
     <summary style={{}}>
       <strong>oneOfProperty</strong>
-      <span style={{ opacity: \\"0.6\\" }}> object</span>
+      <span style={{ opacity: \\"0.6\\" }}>object</span>
     </summary>
     <div style={{ marginLeft: \\"1rem\\" }}></div>
     <div>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -14,10 +14,13 @@ export function create(tag: string, props: Props): string {
 
   let propString = "";
   for (const [key, value] of Object.entries(rest)) {
-    propString += ` ${key}={${JSON.stringify(value)}}`;
+    propString += `\n  ${key}={${JSON.stringify(value)}}`;
   }
+  propString += propString ? "\n" : "";
 
-  return `<${tag}${propString}>${render(children)}</${tag}>`;
+  let indentedChildren = render(children).replace(/^/gm, "  ");
+  indentedChildren += indentedChildren ? "\n" : "";
+  return `<${tag}${propString}>\n${indentedChildren}</${tag}>`;
 }
 
 export function guard<T>(


### PR DESCRIPTION
## Description

This modifies how generated JSX is formatted such that it includes newlines and indentation. Previously, much of the content would be on a single line. Here's an example of the new output:

```tsx
<MimeTabs className={'openapi-tabs__mime'}>
  <TabItem label={'application/json'} value={'application/json-schema'}>
    <details
      style={{}}
      className={'openapi-markdown__details mime'}
      data-collapsed={false}
      open={true}
    >
      <summary style={{}} className={'openapi-markdown__details-summary-mime'}>
        <h3 className={'openapi-markdown__details-summary-header-body'}>Body</h3>
        <strong className={'openapi-schema__required'}>required</strong>
      </summary>
      <div style={{ textAlign: 'left', marginLeft: '1rem' }}></div>
      <ul style={{ marginLeft: '1rem' }}>
        <SchemaItem
          collapsible={false}
          name={'username'}
          required={true}
          schemaName={'Username'}
          qualifierMessage={undefined}
          schema={{ title: 'Username', type: 'string' }}
        ></SchemaItem>
        <SchemaItem
          collapsible={false}
          name={'password'}
          required={true}
          schemaName={'Password'}
          qualifierMessage={undefined}
          schema={{ title: 'Password', type: 'string' }}
        ></SchemaItem>
      </ul>
    </details>
  </TabItem>
</MimeTabs>
```

## Motivation and Context

There are two motivations:

1. It's easier to read the generated MDX, and diffs are also much cleaner and easier to read when regenerating docs.
2. The new formatting is compatible with `@mdx-js/react` v1 and v2. The previous formatting was only compatible with v1, and is one of the blockers to `docusaurus` v3 compatibility. See #591 for an open issue.

## How Has This Been Tested?

I've tested this manually with my own API documentation.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
