### PR TITLE
stop docusaurus support at v2.4.0

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -28,7 +28,7 @@
     "watch": "tsc --watch"
   },
   "devDependencies": {
-    "@docusaurus/types": ">=2.3.0 <2.5.0",
+    "@docusaurus/types": ">=2.3.0 <2.4.1",
     "@types/fs-extra": "^9.0.13",
     "@types/json-pointer": "^1.0.31",
     "@types/json-schema": "^7.0.9",
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
-    "@docusaurus/plugin-content-docs": ">=2.3.0 <2.5.0",
-    "@docusaurus/utils": ">=2.3.0 <2.5.0",
-    "@docusaurus/utils-validation": ">=2.3.0 <2.5.0",
+    "@docusaurus/plugin-content-docs": ">=2.3.0 <2.4.1",
+    "@docusaurus/utils": ">=2.3.0 <2.4.1",
+    "@docusaurus/utils-validation": ">=2.3.0 <2.4.1",
     "@paloaltonetworks/openapi-to-postmanv2": "3.1.0-hotfix.1",
     "@paloaltonetworks/postman-collection": "^4.1.0",
     "@redocly/openapi-core": "^1.0.0-beta.125",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -28,14 +28,14 @@
     "watch": "concurrently --names \"lib,lib-next,tsc\" --kill-others \"yarn babel:lib --watch\" \"yarn babel:lib-next --watch\" \"yarn tsc --watch\""
   },
   "devDependencies": {
-    "@docusaurus/types": ">=2.3.0 <2.5.0",
+    "@docusaurus/types": ">=2.3.0 <2.4.1",
     "@types/crypto-js": "^4.1.0",
     "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.176",
     "concurrently": "^5.2.0"
   },
   "dependencies": {
-    "@docusaurus/theme-common": ">=2.3.0 <2.5.0",
+    "@docusaurus/theme-common": ">=2.3.0 <2.4.1",
     "@hookform/error-message": "^2.0.1",
     "@paloaltonetworks/postman-code-generators": "1.1.15-patch.2",
     "@paloaltonetworks/postman-collection": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,7 +1418,7 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-docs@2.4.0", "@docusaurus/plugin-content-docs@>=2.3.0 <2.5.0":
+"@docusaurus/plugin-content-docs@2.4.0", "@docusaurus/plugin-content-docs@>=2.3.0 <2.4.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz#36e235adf902325735b873b4f535205884363728"
   integrity sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==
@@ -1569,7 +1569,7 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@2.4.0", "@docusaurus/theme-common@>=2.3.0 <2.5.0":
+"@docusaurus/theme-common@2.4.0", "@docusaurus/theme-common@>=2.3.0 <2.4.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.4.0.tgz#626096fe9552d240a2115b492c7e12099070cf2d"
   integrity sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==
@@ -1621,7 +1621,7 @@
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.4.0", "@docusaurus/types@>=2.3.0 <2.5.0":
+"@docusaurus/types@2.4.0", "@docusaurus/types@>=2.3.0 <2.4.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.4.0.tgz#f94f89a0253778b617c5d40ac6f16b17ec55ce41"
   integrity sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==
@@ -1642,7 +1642,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@docusaurus/utils-validation@2.4.0", "@docusaurus/utils-validation@>=2.3.0 <2.5.0":
+"@docusaurus/utils-validation@2.4.0", "@docusaurus/utils-validation@>=2.3.0 <2.4.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz#1ed92bfab5da321c4a4d99cad28a15627091aa90"
   integrity sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==
@@ -1653,7 +1653,7 @@
     js-yaml "^4.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/utils@2.4.0", "@docusaurus/utils@>=2.3.0 <2.5.0":
+"@docusaurus/utils@2.4.0", "@docusaurus/utils@>=2.3.0 <2.4.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.4.0.tgz#fdf0c3545819e48bb57eafc5057495fd4d50e900"
   integrity sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==


### PR DESCRIPTION
## Description

Stop Docusaurus support at v2.4.0

## Motivation and Context

Docusaurus v2.4.1+ introduced breaking changes to v2.0.0 plugin. Will revisit after v2 stable is released.