### PR TITLE
Use negative look behind to exclude colon delimited path segments

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -469,8 +469,7 @@ function bindCollectionToApiItems(
     const method = item.request.method.toLowerCase();
     const path = item.request.url
       .getPath({ unresolved: true }) // unresolved returns "/:variableName" instead of "/<type>"
-      .replace(/:([a-z0-9-_]+)/gi, "{$1}"); // replace "/:variableName" with "/{variableName}"
-
+      .replace(/(?<![a-z0-9-_]+):([a-z0-9-_]+)/gi, "{$1}"); // replace "/:variableName" with "/{variableName}"
     const apiItem = items.find((item) => {
       if (item.type === "info" || item.type === "tag") {
         return false;


### PR DESCRIPTION
## Description

This PR adds a negative look behind to exclude colon delimited path segments from regex match intended to replace with docusaurus compatible code markdown.

## Motivation and Context

The original regex pattern matched on all semi-colon prefixed segments, regardless if they were intended as path variables, e.g. `https://api.sase.paloaltonetworks.com/sse/config/v1/config-versions/candidate:push`

## How Has This Been Tested?

Tested with the following OpenAPI spec:

https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/master/openapi-specs/access/prisma-access-config/ConfigurationManagement.yaml

## Screenshots (if appropriate)

![Screenshot 2023-11-27 at 9 57 14 AM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/9343811/726ca578-c9a9-46e0-b7c1-30a4e6cf9ea6)
