### PR TITLE
Use SCHEMA_TYPE to distinguish request/response to support readOnly/writeOnly properties

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -90,7 +90,7 @@ export function createRequestSchema({ title, body, ...rest }: Props) {
                 }),
                 create("ul", {
                   style: { marginLeft: "1rem" },
-                  children: createNodes(firstBody),
+                  children: createNodes(firstBody, "request"),
                 }),
               ],
             }),
@@ -161,7 +161,7 @@ export function createRequestSchema({ title, body, ...rest }: Props) {
               }),
               create("ul", {
                 style: { marginLeft: "1rem" },
-                children: createNodes(firstBody),
+                children: createNodes(firstBody, "request"),
               }),
             ],
           }),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -118,7 +118,7 @@ export function createResponseSchema({ title, body, ...rest }: Props) {
                           }),
                           create("ul", {
                             style: { marginLeft: "1rem" },
-                            children: createNodes(firstBody!),
+                            children: createNodes(firstBody!, "response"),
                           }),
                         ],
                       }),

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -48,7 +48,7 @@ describe("createNodes", () => {
       },
     };
     expect(
-      createNodes(schema).map((md: any) =>
+      createNodes(schema, "request").map((md: any) =>
         prettier.format(md, { parser: "babel" })
       )
     ).toMatchSnapshot();


### PR DESCRIPTION
## Description

When schema functions were collapsed into `createSchema` in #582 maintaining support for `readOnly` and `writeOnly` properties was overlooked. This PR adds a `SCHEMA_TYPE` prop to `createNodes` so that we can distinguish between "request" vs "response" schemas in order to handle `readOnly` and `writeOnly` appropriately.

## Motivation and Context

See #664 

## How Has This Been Tested?

Tested with petstore API. See deploy preview for live example.