### PR TITLE
Improve support for handling multipart form data

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -230,7 +230,7 @@ const config = {
           petstore: {
             specPath:
               "https://raw.githubusercontent.com/APIs-guru/openapi-directory/780ef441b8d6134229c8b8ef75eb3ec8a0218e7f/APIs/pdfblocks.com/1.5.0/openapi.yaml",
-            // proxy: "https://crossorigin.me",
+            proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {
               groupPathsBy: "tag",

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -228,8 +228,7 @@ const config = {
             },
           },
           petstore: {
-            specPath:
-              "https://raw.githubusercontent.com/APIs-guru/openapi-directory/780ef441b8d6134229c8b8ef75eb3ec8a0218e7f/APIs/pdfblocks.com/1.5.0/openapi.yaml",
+            specPath: "examples/petstore.yaml",
             proxy: "https://cors.pan.dev",
             outputDir: "docs/petstore",
             sidebarOptions: {

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -228,8 +228,9 @@ const config = {
             },
           },
           petstore: {
-            specPath: "examples/petstore.yaml",
-            proxy: "https://cors.pan.dev",
+            specPath:
+              "https://raw.githubusercontent.com/APIs-guru/openapi-directory/780ef441b8d6134229c8b8ef75eb3ec8a0218e7f/APIs/pdfblocks.com/1.5.0/openapi.yaml",
+            // proxy: "https://crossorigin.me",
             outputDir: "docs/petstore",
             sidebarOptions: {
               groupPathsBy: "tag",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -161,6 +161,10 @@ async function makeRequest(
             if (data.key && data.value.content) {
               myBody.append(data.key, data.value.content);
             }
+            // handle generic key-value payload
+            if (data.key && typeof data.value === "string") {
+              myBody.append(data.key, data.value);
+            }
           }
         }
         break;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -195,6 +195,8 @@ async function makeRequest(
 
   return await fetchWithtimeout(finalUrl, requestOptions).then(
     (response: any) => {
+      const contentType = response.headers.get("content-type");
+      console.log(contentType);
       return response;
     }
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -193,13 +193,62 @@ async function makeRequest(
     finalUrl = normalizedProxy + request.url.toString();
   }
 
-  return await fetchWithtimeout(finalUrl, requestOptions).then(
-    (response: any) => {
-      const contentType = response.headers.get("content-type");
-      console.log(contentType);
-      return response;
+  return fetchWithtimeout(finalUrl, requestOptions).then((response: any) => {
+    const contentType = response.headers.get("content-type");
+    let fileExtension = "";
+
+    if (contentType) {
+      if (contentType.includes("application/pdf")) {
+        fileExtension = ".pdf";
+      } else if (contentType.includes("image/jpeg")) {
+        fileExtension = ".jpg";
+      } else if (contentType.includes("image/png")) {
+        fileExtension = ".png";
+      } else if (contentType.includes("image/gif")) {
+        fileExtension = ".gif";
+      } else if (contentType.includes("image/webp")) {
+        fileExtension = ".webp";
+      } else if (contentType.includes("video/mpeg")) {
+        fileExtension = ".mpeg";
+      } else if (contentType.includes("video/mp4")) {
+        fileExtension = ".mp4";
+      } else if (contentType.includes("audio/mpeg")) {
+        fileExtension = ".mp3";
+      } else if (contentType.includes("audio/ogg")) {
+        fileExtension = ".ogg";
+      } else if (contentType.includes("application/octet-stream")) {
+        fileExtension = ".bin";
+      } else if (contentType.includes("application/zip")) {
+        fileExtension = ".zip";
+      }
+
+      if (fileExtension) {
+        return response.blob().then((blob: any) => {
+          const url = window.URL.createObjectURL(blob);
+
+          const link = document.createElement("a");
+          link.href = url;
+          // Now the file name includes the extension
+          link.setAttribute("download", `file${fileExtension}`);
+
+          // These two lines are necessary to make the link click in Firefox
+          link.style.display = "none";
+          document.body.appendChild(link);
+
+          link.click();
+
+          // After link is clicked, it's safe to remove it.
+          setTimeout(() => document.body.removeChild(link), 0);
+
+          return response;
+        });
+      } else {
+        return response;
+      }
     }
-  );
+
+    return response;
+  });
 }
 
 export default makeRequest;


### PR DESCRIPTION
## Description

Improves support for handling multi-part form data in `makeRequest` module. Previously, payloads that included a file/blob excluded other form data. Additionally, blob content returned by API was simply rendered in raw format in the response card.

With these changes, media content types will now be auto-downloaded to file.ext, where ext is the appropriate file extension for that type.