### PR TITLE
Add missing security schemes component

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
@@ -112,6 +112,10 @@
   }
 }
 
+.openapi-security__summary-container {
+  background: var(--ifm-pre-background);
+}
+
 // Prevent auto zoom on mobile iOS devices when focusing on input elmenents
 @media screen and (-webkit-min-device-pixel-ratio: 0) and (max-device-width: 1024px) {
   .prism-code,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
@@ -13,6 +13,8 @@ import Request from "@theme/ApiExplorer/Request";
 import Response from "@theme/ApiExplorer/Response";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
+import SecuritySchemes from "./SecuritySchemes";
+
 function ApiExplorer({
   item,
   infoPath,
@@ -24,6 +26,7 @@ function ApiExplorer({
 
   return (
     <>
+      <SecuritySchemes infoPath={infoPath} />
       {item.method !== "event" && (
         <CodeSnippets
           postman={postman}


### PR DESCRIPTION
## Description

See #672 for background

Somehow, the SecuritySchemes component was left out during the migration. Adding it back.