### PR TITLE
Add Callbacks Support to V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
   },
   "engines": {
     "node": ">=14"
-  }
+  },
+  "packageManager": "yarn@1.22.1"
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
@@ -1,0 +1,95 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { MediaTypeObject } from "../openapi/types";
+import { ApiItem } from "../types";
+import { createDescription } from "./createDescription";
+import { createMethodEndpoint } from "./createMethodEndpoint";
+import { createRequestBodyDetails } from "./createRequestBodyDetails";
+import { createStatusCodes } from "./createStatusCodes";
+import { create } from "./utils";
+
+interface Props {
+  callbacks: ApiItem["callbacks"];
+}
+
+interface RequestBodyProps {
+  title: string;
+  body: {
+    content?: {
+      [key: string]: MediaTypeObject;
+    };
+    description?: string;
+    required?: boolean;
+  };
+}
+
+export function createCallbacks({ callbacks }: Props) {
+  if (callbacks === undefined) {
+    return undefined;
+  }
+
+  const callbacksNames = Object.keys(callbacks);
+  if (callbacksNames.length === 0) {
+    return undefined;
+  }
+
+  return create("div", {
+    children: [
+      create("div", {
+        className: "openapi__divider",
+      }),
+      create("h2", {
+        children: "Callbacks",
+        id: "callbacks",
+      }),
+      create("OperationTabs", {
+        className: "openapi-tabs__operation",
+        children: callbacksNames.flatMap((name) => {
+          const path = Object.keys(callbacks[name])[0];
+          const methods = new Map([
+            ["delete", callbacks[name][path].delete],
+            ["get", callbacks[name][path].get],
+            ["head", callbacks[name][path].head],
+            ["options", callbacks[name][path].options],
+            ["patch", callbacks[name][path].patch],
+            ["post", callbacks[name][path].post],
+            ["put", callbacks[name][path].put],
+            ["trace", callbacks[name][path].trace],
+          ]);
+
+          return Array.from(methods).flatMap(([method, operationObject]) => {
+            if (!operationObject) return [];
+
+            const { description, requestBody, responses } = operationObject;
+
+            return [
+              create("TabItem", {
+                label: `${method.toUpperCase()} ${name}`,
+                value: `${method}-${name}`,
+                children: [
+                  createMethodEndpoint(method, path),
+                  // TODO: add `deprecation notice` when markdown support is added
+                  createDescription(description),
+                  createRequestBodyDetails({
+                    title: "Body",
+                    body: requestBody,
+                  } as RequestBodyProps),
+                  createStatusCodes({
+                    id: "callbacks-responses",
+                    label: "Callbacks Responses",
+                    responses,
+                  }),
+                ],
+              }),
+            ];
+          });
+        }),
+      }),
+    ],
+  });
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { MediaTypeObject } from "../openapi/types";
-import { ApiItem } from "../types";
 import { createDescription } from "./createDescription";
 import { createMethodEndpoint } from "./createMethodEndpoint";
 import { createRequestBodyDetails } from "./createRequestBodyDetails";
 import { createStatusCodes } from "./createStatusCodes";
 import { create } from "./utils";
+import { MediaTypeObject } from "../openapi/types";
+import { ApiItem } from "../types";
 
 interface Props {
   callbacks: ApiItem["callbacks"];

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestBodyDetails.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestBodyDetails.ts
@@ -19,6 +19,6 @@ interface Props {
   };
 }
 
-export function createRequestBodyDetails({ title, body }: Props): any {
+export function createRequestBodyDetails({ title, body }: Props) {
   return createRequestSchema({ title, body });
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createStatusCodes.ts
@@ -54,6 +54,8 @@ export default function json2xml(o: any, tab: any) {
 }
 
 interface Props {
+  id?: string;
+  label?: string;
   responses: ApiItem["responses"];
 }
 
@@ -254,7 +256,7 @@ export function createExampleFromSchema(schema: any, mimeType: string) {
   return undefined;
 }
 
-export function createStatusCodes({ responses }: Props) {
+export function createStatusCodes({ label, id, responses }: Props) {
   if (responses === undefined) {
     return undefined;
   }
@@ -269,6 +271,8 @@ export function createStatusCodes({ responses }: Props) {
       create("div", {
         children: [
           create("ApiTabs", {
+            label,
+            id,
             children: codes.map((code) => {
               const responseHeaders: any = responses[code].headers;
               return create("TabItem", {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -7,6 +7,7 @@
 
 import { createAuthentication } from "./createAuthentication";
 import { createAuthorization } from "./createAuthorization";
+import { createCallbacks } from "./createCallbacks";
 import { createContactInfo } from "./createContactInfo";
 import { createDeprecationNotice } from "./createDeprecationNotice";
 import { createDescription } from "./createDescription";
@@ -31,7 +32,7 @@ import {
 } from "../openapi/types";
 import { ApiPageMetadata, InfoPageMetadata, TagPageMetadata } from "../types";
 
-interface Props {
+interface RequestBodyProps {
   title: string;
   body: {
     content?: {
@@ -54,6 +55,7 @@ export function createApiPageMD({
     parameters,
     requestBody,
     responses,
+    callbacks,
   },
   infoPath,
   frontMatter,
@@ -68,11 +70,14 @@ export function createApiPageMD({
     `import ResponseSamples from "@theme/ResponseSamples";\n`,
     `import SchemaItem from "@theme/SchemaItem";\n`,
     `import SchemaTabs from "@theme/SchemaTabs";\n`,
+    `import OperationTabs from "@theme/OperationTabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
     createHeading(title),
     createMethodEndpoint(method, path),
     infoPath && createAuthorization(infoPath),
-    frontMatter.show_extensions && createVendorExtensions(extensions),
+    frontMatter.show_extensions
+      ? createVendorExtensions(extensions)
+      : undefined,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(description),
     createRequestHeader("Request"),
@@ -83,8 +88,9 @@ export function createApiPageMD({
     createRequestBodyDetails({
       title: "Body",
       body: requestBody,
-    } as Props),
+    } as RequestBodyProps),
     createStatusCodes({ responses }),
+    createCallbacks({ callbacks }),
   ]);
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -24,13 +24,20 @@ import useIsBrowser from "@docusaurus/useIsBrowser";
 import Heading from "@theme/Heading";
 import clsx from "clsx";
 
+export interface TabListProps extends TabProps {
+  label: string;
+  id: string;
+}
+
 function TabList({
   className,
   block,
   selectedValue,
   selectValue,
   tabValues,
-}: TabProps & ReturnType<typeof useTabs>) {
+  label = "Responses",
+  id = "responses",
+}: TabListProps & ReturnType<typeof useTabs>) {
   const tabRefs: (HTMLLIElement | null)[] = [];
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();
@@ -107,8 +114,8 @@ function TabList({
 
   return (
     <div className="openapi-tabs__response-header-section">
-      <Heading as="h2" id="responses" className="openapi-tabs__response-header">
-        Responses
+      <Heading as="h2" id={id} className="openapi-tabs__response-header">
+        {label}
       </Heading>
       <div className="openapi-tabs__response-container">
         {showTabArrows && (
@@ -148,8 +155,8 @@ function TabList({
                 parseInt(value) >= 400
                   ? "danger"
                   : parseInt(value) >= 200 && parseInt(value) < 300
-                    ? "success"
-                    : "info",
+                  ? "success"
+                  : "info",
                 {
                   active: selectedValue === value,
                 }
@@ -199,7 +206,7 @@ function TabContent({
     </div>
   );
 }
-function TabsComponent(props: TabProps): React.JSX.Element {
+function TabsComponent(props: TabListProps): React.JSX.Element {
   const tabs = useTabs(props);
   return (
     <div className="openapi-tabs__container">
@@ -208,7 +215,7 @@ function TabsComponent(props: TabProps): React.JSX.Element {
     </div>
   );
 }
-export default function ApiTabs(props: TabProps): React.JSX.Element {
+export default function ApiTabs(props: TabListProps): React.JSX.Element {
   const isBrowser = useIsBrowser();
   return (
     <TabsComponent

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -155,8 +155,8 @@ function TabList({
                 parseInt(value) >= 400
                   ? "danger"
                   : parseInt(value) >= 200 && parseInt(value) < 300
-                  ? "success"
-                  : "info",
+                    ? "success"
+                    : "info",
                 {
                   active: selectedValue === value,
                 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.openapi-tabs__operation-container {
+  display: flex;
+  align-items: center;
+  margin-top: 1rem;
+  overflow: hidden;
+}
+
+.openapi-tabs__operation-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid transparent;
+  margin-top: 0 !important;
+  margin-right: 0.5rem;
+  font-weight: var(--ifm-font-weight-bold);
+  font-size: 12px;
+  white-space: nowrap;
+  transition: 300ms;
+
+  &:hover {
+    background-color: transparent;
+    border: 1px solid var(--ifm-toc-border-color);
+  }
+
+  &.active {
+    border: 1px solid var(--ifm-tabs-color-active-border);
+    color: var(--ifm-tabs-color-active);
+  }
+
+  &:last-child {
+    margin-right: 0 !important;
+  }
+}
+
+.openapi-tabs__operation-list-container {
+  overflow-y: hidden;
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.openapi-tabs__operation-schema-container {
+  max-width: 600px;
+}
+
+@media screen and (max-width: 500px) {
+  .operationTabsTopSection {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .operationTabsContainer {
+    width: 100%;
+    margin-top: var(--ifm-spacing-vertical);
+    padding: 0;
+  }
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.js
@@ -1,0 +1,187 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React, { cloneElement, useEffect, useState, useRef } from "react";
+
+import {
+  useScrollPositionBlocker,
+  useTabs,
+} from "@docusaurus/theme-common/internal";
+import useIsBrowser from "@docusaurus/useIsBrowser";
+import clsx from "clsx";
+
+function TabList({ className, block, selectedValue, selectValue, tabValues }) {
+  const tabRefs = [];
+  const { blockElementScrollPositionUntilNextRender } =
+    useScrollPositionBlocker();
+
+  const handleTabChange = (event) => {
+    event.preventDefault();
+    const newTab = event.currentTarget;
+    const newTabIndex = tabRefs.indexOf(newTab);
+    const newTabValue = tabValues[newTabIndex].value;
+    // custom
+    if (newTabValue !== selectedValue) {
+      blockElementScrollPositionUntilNextRender(newTab);
+      selectValue(newTabValue);
+    }
+  };
+
+  const handleKeydown = (event) => {
+    let focusElement = null;
+    switch (event.key) {
+      case "Enter": {
+        handleTabChange(event);
+        break;
+      }
+      case "ArrowRight": {
+        const nextTab = tabRefs.indexOf(event.currentTarget) + 1;
+        focusElement = tabRefs[nextTab] ?? tabRefs[0];
+        break;
+      }
+      case "ArrowLeft": {
+        const prevTab = tabRefs.indexOf(event.currentTarget) - 1;
+        focusElement = tabRefs[prevTab] ?? tabRefs[tabRefs.length - 1];
+        break;
+      }
+      default:
+        break;
+    }
+    focusElement?.focus();
+  };
+
+  const tabItemListContainerRef = useRef(null);
+  const [showTabArrows, setShowTabArrows] = useState(false);
+
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (let entry of entries) {
+        if (entry.target.offsetWidth < entry.target.scrollWidth) {
+          setShowTabArrows(true);
+        } else {
+          setShowTabArrows(false);
+        }
+      }
+    });
+
+    resizeObserver.observe(tabItemListContainerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  const handleRightClick = () => {
+    tabItemListContainerRef.current.scrollLeft += 90;
+  };
+
+  const handleLeftClick = () => {
+    tabItemListContainerRef.current.scrollLeft -= 90;
+  };
+
+  return (
+    <div className="tabs__container">
+      <div className="openapi-tabs__operation-container">
+        {showTabArrows && (
+          <button
+            className={clsx("openapi-tabs__arrow", "left")}
+            onClick={handleLeftClick}
+          />
+        )}
+        <ul
+          ref={tabItemListContainerRef}
+          role="tablist"
+          aria-orientation="horizontal"
+          className={clsx(
+            "openapi-tabs__operation-list-container",
+            "tabs",
+            {
+              "tabs--block": block,
+            },
+            className
+          )}
+        >
+          {tabValues.map(({ value, label, attributes }) => {
+            return (
+              <li
+                role="tab"
+                tabIndex={selectedValue === value ? 0 : -1}
+                aria-selected={selectedValue === value}
+                key={value}
+                ref={(tabControl) => tabRefs.push(tabControl)}
+                onKeyDown={handleKeydown}
+                onFocus={handleTabChange}
+                onClick={(e) => handleTabChange(e)}
+                {...attributes}
+                className={clsx(
+                  "tabs__item",
+                  "openapi-tabs__operation-item",
+                  attributes?.className,
+                  {
+                    active: selectedValue === value,
+                  }
+                )}
+              >
+                {label ?? value}
+              </li>
+            );
+          })}
+        </ul>
+        {showTabArrows && (
+          <button
+            className={clsx("openapi-tabs__arrow", "right")}
+            onClick={handleRightClick}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+function TabContent({ lazy, children, selectedValue }) {
+  // eslint-disable-next-line no-param-reassign
+  children = Array.isArray(children) ? children : [children];
+  if (lazy) {
+    const selectedTabItem = children.find(
+      (tabItem) => tabItem.props.value === selectedValue
+    );
+    if (!selectedTabItem) {
+      // fail-safe or fail-fast? not sure what's best here
+      return null;
+    }
+    return cloneElement(selectedTabItem, { className: "margin-top--md" });
+  }
+  return (
+    <div className="margin-top--md">
+      {children.map((tabItem, i) =>
+        cloneElement(tabItem, {
+          key: i,
+          hidden: tabItem.props.value !== selectedValue,
+        })
+      )}
+    </div>
+  );
+}
+function TabsComponent(props) {
+  const tabs = useTabs(props);
+  return (
+    <div className="tabs-container">
+      <TabList {...props} {...tabs} />
+      <TabContent {...props} {...tabs} />
+    </div>
+  );
+}
+export default function OperationTabs(props) {
+  const isBrowser = useIsBrowser();
+  return (
+    <TabsComponent
+      // Remount tabs after hydration
+      // Temporary fix for https://github.com/facebook/docusaurus/issues/5653
+      key={String(isBrowser)}
+      {...props}
+    />
+  );
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.tsx
@@ -5,34 +5,54 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { cloneElement, useEffect, useState, useRef } from "react";
+import React, {
+  cloneElement,
+  useEffect,
+  useState,
+  useRef,
+  ReactElement,
+} from "react";
 
 import {
+  sanitizeTabsChildren,
+  TabProps,
   useScrollPositionBlocker,
   useTabs,
 } from "@docusaurus/theme-common/internal";
+import { TabItemProps } from "@docusaurus/theme-common/lib/utils/tabsUtils";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import clsx from "clsx";
 
-function TabList({ className, block, selectedValue, selectValue, tabValues }) {
-  const tabRefs = [];
+function TabList({
+  className,
+  block,
+  selectedValue,
+  selectValue,
+  tabValues,
+}: TabProps & ReturnType<typeof useTabs>) {
+  const tabRefs: (HTMLLIElement | null)[] = [];
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();
 
-  const handleTabChange = (event) => {
-    event.preventDefault();
+  const handleTabChange = (
+    event:
+      | React.FocusEvent<HTMLLIElement>
+      | React.MouseEvent<HTMLLIElement>
+      | React.KeyboardEvent<HTMLLIElement>
+  ) => {
     const newTab = event.currentTarget;
     const newTabIndex = tabRefs.indexOf(newTab);
     const newTabValue = tabValues[newTabIndex].value;
-    // custom
+
     if (newTabValue !== selectedValue) {
       blockElementScrollPositionUntilNextRender(newTab);
       selectValue(newTabValue);
     }
   };
 
-  const handleKeydown = (event) => {
-    let focusElement = null;
+  const handleKeydown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+    let focusElement: HTMLLIElement | null = null;
+
     switch (event.key) {
       case "Enter": {
         handleTabChange(event);
@@ -40,27 +60,28 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
       }
       case "ArrowRight": {
         const nextTab = tabRefs.indexOf(event.currentTarget) + 1;
-        focusElement = tabRefs[nextTab] ?? tabRefs[0];
+        focusElement = tabRefs[nextTab] ?? tabRefs[0]!;
         break;
       }
       case "ArrowLeft": {
         const prevTab = tabRefs.indexOf(event.currentTarget) - 1;
-        focusElement = tabRefs[prevTab] ?? tabRefs[tabRefs.length - 1];
+        focusElement = tabRefs[prevTab] ?? tabRefs[tabRefs.length - 1]!;
         break;
       }
       default:
         break;
     }
+
     focusElement?.focus();
   };
 
-  const tabItemListContainerRef = useRef(null);
-  const [showTabArrows, setShowTabArrows] = useState(false);
+  const tabItemListContainerRef = useRef<HTMLUListElement>(null);
+  const [showTabArrows, setShowTabArrows] = useState<boolean>(false);
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
+        if (entry.target.clientWidth < entry.target.scrollWidth) {
           setShowTabArrows(true);
         } else {
           setShowTabArrows(false);
@@ -68,7 +89,7 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
       }
     });
 
-    resizeObserver.observe(tabItemListContainerRef.current);
+    resizeObserver.observe(tabItemListContainerRef.current!);
 
     return () => {
       resizeObserver.disconnect();
@@ -76,11 +97,11 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
   }, []);
 
   const handleRightClick = () => {
-    tabItemListContainerRef.current.scrollLeft += 90;
+    tabItemListContainerRef.current!.scrollLeft += 90;
   };
 
   const handleLeftClick = () => {
-    tabItemListContainerRef.current.scrollLeft -= 90;
+    tabItemListContainerRef.current!.scrollLeft -= 90;
   };
 
   return (
@@ -108,6 +129,7 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
           {tabValues.map(({ value, label, attributes }) => {
             return (
               <li
+                // TODO extract TabListItem
                 role="tab"
                 tabIndex={selectedValue === value ? 0 : -1}
                 aria-selected={selectedValue === value}
@@ -120,7 +142,7 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
                 className={clsx(
                   "tabs__item",
                   "openapi-tabs__operation-item",
-                  attributes?.className,
+                  attributes?.className as string,
                   {
                     active: selectedValue === value,
                   }
@@ -141,11 +163,16 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
     </div>
   );
 }
-function TabContent({ lazy, children, selectedValue }) {
-  // eslint-disable-next-line no-param-reassign
-  children = Array.isArray(children) ? children : [children];
+function TabContent({
+  lazy,
+  children,
+  selectedValue,
+}: TabProps & ReturnType<typeof useTabs>): React.JSX.Element | null {
+  const childTabs = (Array.isArray(children) ? children : [children]).filter(
+    Boolean
+  ) as ReactElement<TabItemProps>[];
   if (lazy) {
-    const selectedTabItem = children.find(
+    const selectedTabItem = childTabs.find(
       (tabItem) => tabItem.props.value === selectedValue
     );
     if (!selectedTabItem) {
@@ -156,7 +183,7 @@ function TabContent({ lazy, children, selectedValue }) {
   }
   return (
     <div className="margin-top--md">
-      {children.map((tabItem, i) =>
+      {childTabs.map((tabItem, i) =>
         cloneElement(tabItem, {
           key: i,
           hidden: tabItem.props.value !== selectedValue,
@@ -165,7 +192,7 @@ function TabContent({ lazy, children, selectedValue }) {
     </div>
   );
 }
-function TabsComponent(props) {
+function TabsComponent(props: TabProps): React.JSX.Element {
   const tabs = useTabs(props);
   return (
     <div className="tabs-container">
@@ -174,7 +201,7 @@ function TabsComponent(props) {
     </div>
   );
 }
-export default function OperationTabs(props) {
+export default function OperationTabs(props: TabProps): React.JSX.Element {
   const isBrowser = useIsBrowser();
   return (
     <TabsComponent
@@ -182,6 +209,8 @@ export default function OperationTabs(props) {
       // Temporary fix for https://github.com/facebook/docusaurus/issues/5653
       key={String(isBrowser)}
       {...props}
-    />
+    >
+      {sanitizeTabsChildren(props.children)}
+    </TabsComponent>
   );
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -36,6 +36,7 @@
 @use "./DiscriminatorTabs/DiscriminatorTabs";
 @use "./MimeTabs/MimeTabs";
 @use "./SchemaTabs/SchemaTabs";
+@use "./OperationTabs/OperationTabs";
 /* Code Samples */
 @use "./ResponseSamples/ResponseSamples";
 /* Markdown Styling */


### PR DESCRIPTION
## Description

OpenAPI specs callbacks in endpoints were being ignored on rendering. I noticed the types were included but no code was found for rendering the callbacks. So `callbacks` included in [Petstore](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/main/demo/examples/petstore.yaml) cannot be seen at https://docusaurus-openapi.tryingpan.dev/petstore/subscribe-to-the-store-events

## Motivation and Context

Be aligned with OpenAPI 3.0 Specs: https://swagger.io/docs/specification/callbacks/

## How Has This Been Tested?
Go to petstore "Subscribe to the store events"  - http://localhost:3000/petstore/subscribe-to-the-store-events

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist


- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
