### PR TITLE
fix: markdown pages heading creation

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
@@ -167,11 +167,16 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
 
   return create("div", {
     children: [
-      create("h2", {
-        children: "Authentication",
-        id: "authentication",
-        style: { marginBottom: "1rem" },
-      }),
+      create(
+        "Heading",
+        {
+          children: "Authentication",
+          id: "authentication",
+          as: "h2",
+          className: "openapi-tabs__heading",
+        },
+        { inline: true }
+      ),
       create("SchemaTabs", {
         className: "openapi-tabs__security-schemes",
         children: Object.entries(securitySchemes).map(

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
@@ -43,10 +43,16 @@ export function createCallbacks({ callbacks }: Props) {
       create("div", {
         className: "openapi__divider",
       }),
-      create("h2", {
-        children: "Callbacks",
-        id: "callbacks",
-      }),
+      create(
+        "Heading",
+        {
+          children: "Callbacks",
+          id: "callbacks",
+          as: "h2",
+          className: "openapi-tabs__heading",
+        },
+        { inline: true }
+      ),
       create("OperationTabs", {
         className: "openapi-tabs__operation",
         children: callbacksNames.flatMap((name) => {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createHeading.ts
@@ -9,10 +9,15 @@ import { clean, create } from "./utils";
 
 export function createHeading(heading: string) {
   return [
-    create("h1", {
-      className: "openapi__heading",
-      children: clean(heading),
-    }),
+    create(
+      "Heading",
+      {
+        children: clean(heading),
+        as: "h1",
+        className: "openapi__heading",
+      },
+      { inline: true }
+    ),
     `\n\n`,
   ];
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestHeader.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestHeader.ts
@@ -5,6 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import { create } from "./utils";
+
 export function createRequestHeader(header: string) {
-  return `## ${header}\n\n`;
+  return [
+    create(
+      "Heading",
+      {
+        children: header,
+        id: header.replace(" ", "-").toLowerCase(),
+        as: "h2",
+        className: "openapi-tabs__heading",
+      },
+      { inline: true }
+    ),
+    `\n\n`,
+  ];
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -71,6 +71,7 @@ export function createApiPageMD({
     `import SchemaItem from "@theme/SchemaItem";\n`,
     `import SchemaTabs from "@theme/SchemaTabs";\n`,
     `import Markdown from "@theme/Markdown";\n`,
+    `import Heading from "@theme/Heading";\n`,
     `import OperationTabs from "@theme/OperationTabs";\n`,
     `import TabItem from "@theme/TabItem";\n\n`,
     createHeading(title),
@@ -111,6 +112,7 @@ export function createInfoPageMD({
 }: InfoPageMetadata) {
   return render([
     `import ApiLogo from "@theme/ApiLogo";\n`,
+    `import Heading from "@theme/Heading";\n`,
     `import SchemaTabs from "@theme/SchemaTabs";\n`,
     `import TabItem from "@theme/TabItem";\n`,
     `import Export from "@theme/ApiExplorer/Export";\n\n`,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -9,16 +9,27 @@ export type Children = string | undefined | (string | string[] | undefined)[];
 
 export type Props = Record<string, any> & { children?: Children };
 
-export function create(tag: string, props: Props): string {
+export type Options = { inline?: boolean };
+
+export function create(
+  tag: string,
+  props: Props,
+  options: Options = {}
+): string {
   const { children, ...rest } = props;
 
   let propString = "";
   for (const [key, value] of Object.entries(rest)) {
     propString += `\n  ${key}={${JSON.stringify(value)}}`;
   }
-  propString += propString ? "\n" : "";
-
   let indentedChildren = render(children).replace(/^/gm, "  ");
+
+  if (options.inline) {
+    propString += `\n  children={${JSON.stringify(children)}}`;
+    indentedChildren = "";
+  }
+
+  propString += propString ? "\n" : "";
   indentedChildren += indentedChildren ? "\n" : "";
   return `<${tag}${propString}>\n${indentedChildren}</${tag}>`;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
@@ -9,6 +9,12 @@
   margin-bottom: var(--ifm-leading);
 }
 
+.openapi-tabs__response-header {
+  &.openapi-tabs__heading {
+    margin-bottom: 0;
+  }
+}
+
 .openapi-tabs__response-code-item {
   border: 1px solid transparent;
   margin-top: 0 !important;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
@@ -9,10 +9,6 @@
   margin-bottom: var(--ifm-leading);
 }
 
-.openapi-tabs__response-header {
-  margin-bottom: 0;
-}
-
 .openapi-tabs__response-code-item {
   border: 1px solid transparent;
   margin-top: 0 !important;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -114,7 +114,7 @@ function TabList({
 
   return (
     <div className="openapi-tabs__response-header-section">
-      <Heading as="h2" id={id} className="openapi-tabs__response-header">
+      <Heading as="h2" id={id} className="openapi-tabs__heading">
         {label}
       </Heading>
       <div className="openapi-tabs__response-container">

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -114,7 +114,11 @@ function TabList({
 
   return (
     <div className="openapi-tabs__response-header-section">
-      <Heading as="h2" id={id} className="openapi-tabs__heading">
+      <Heading
+        as="h2"
+        id={id}
+        className="openapi-tabs__heading openapi-tabs__response-header"
+      >
         {label}
       </Heading>
       <div className="openapi-tabs__response-container">

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
@@ -12,6 +12,10 @@
   overflow: hidden;
 }
 
+.openapi-tabs__operation-header {
+  margin-bottom: 0;
+}
+
 .openapi-tabs__operation-item {
   display: flex;
   align-items: center;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
@@ -8,7 +8,6 @@
 .openapi-tabs__operation-container {
   display: flex;
   align-items: center;
-  margin-top: 1rem;
   overflow: hidden;
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/_SchemaTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/_SchemaTabs.scss
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-.openapi-tabs__schema-container {
-  margin-top: 1rem;
-}
-
 .openapi-tabs__schema-item {
   display: flex;
   align-items: center;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -159,3 +159,7 @@
 .openapi-left-panel__container {
   border-right: thin solid var(--ifm-toc-border-color);
 }
+
+.openapi-tabs__heading {
+  margin-bottom: 0;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -161,5 +161,5 @@
 }
 
 .openapi-tabs__heading {
-  margin-bottom: 0;
+  margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Description

Normalize `@theme/Heading` component usage

## Motivation and Context

Due to headings creation using html elements, some headings didn't have classnames or had different classnames across the markdown pages. This was preventing or making more difficult to customize styles when using this library

## How Has This Been Tested?

Check the following pages Headings H1 and H2:
- Go to /petstore/swagger-petstore-yaml and check `Swagger Petstore YAML`, `Authentication`
- Go to /petstore/subscribe-to-the-store-events and check `Request`, `Responses`, `Callbacks`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
