### PR TITLE
Conditional display of header Request

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -81,7 +81,7 @@ export function createApiPageMD({
       : undefined,
     createDeprecationNotice({ deprecated, description: deprecatedDescription }),
     createDescription(description),
-    createRequestHeader("Request"),
+    requestBody || parameters ? createRequestHeader("Request") : undefined,
     createParamsDetails({ parameters, type: "path" }),
     createParamsDetails({ parameters, type: "query" }),
     createParamsDetails({ parameters, type: "header" }),


### PR DESCRIPTION
## Description
The change avoids including the single header "Request" when no request body or parameters exist.

## Motivation and Context
When a request is without relevant request information (e.g., requestBody, or parameters), the header "Request" is still applied to the markdown. This is inconvenient because there is no reason to have a header without content.

## How Has This Been Tested?
It has been tested by running the demo project and verifying that the header does not exist when no requestBody or parameters are present. It's also verified that the header is present when these exist.

Additonally executed normal tests (yarn test).

## Screenshots (if appropriate)

Before applying the change, the single header Request is present:

<img width="1603" alt="Skjermbilde 2024-02-03 kl  01 04 15" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/18611032/9ad6e94f-343d-495b-a1d2-c16eea9f5b77">

After applying this change, the same page does not display single header Request:

<img width="1603" alt="Skjermbilde 2024-02-03 kl  01 05 36" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/18611032/cd9d07b5-7592-4506-8201-0700d1b9cf73">

## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist
- [] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes if appropriate.
- [] All new and existing tests passed.

Comments:
- I see no need to update the documentation. 
- See no need to add additional tests.
- Normal tests were successful, but Cypress failed. Is it expected?