### PR TITLE
fix: guard only undefined and empty strings

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -996,6 +996,7 @@ components:
               description: Average amount of honey produced per day in ounces
               example: 3.14
               multipleOf: .01
+              default: 0
           required:
             - honeyPerDay
     Id:

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
@@ -1,0 +1,48 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { guard } from "./utils";
+
+describe("guard", () => {
+  it("should guard empty strings", () => {
+    const actual = guard("", (_) => {
+      throw new Error("Should not be called");
+    });
+    expect(actual).toBe("");
+  });
+
+  it("should guard undefined", () => {
+    const actual = guard(undefined, (value) => {
+      throw new Error("Should not be called");
+    });
+    expect(actual).toBe("");
+  });
+
+  it("should not guard strings", () => {
+    const actual = guard("hello", (value) => value);
+    expect(actual).toBe("hello");
+  });
+
+  it("should not guard numbers", () => {
+    const actual = guard(1, (value) => `${value}`);
+    expect(actual).toBe("1");
+  });
+
+  it("should not guard numbers equals to 0", () => {
+    const actual = guard(0, (value) => `${value}`);
+    expect(actual).toBe("0");
+  });
+
+  it("should not guard false booleans", () => {
+    const actual = guard(false, (value) => `${value}`);
+    expect(actual).toBe("false");
+  });
+  it("should not guard true booleans", () => {
+    const actual = guard(true, (value) => `${value}`);
+    expect(actual).toBe("true");
+  });
+});

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
@@ -24,11 +24,11 @@ export function guard<T>(
   value: T | undefined | string,
   cb: (value: T) => Children
 ): string {
-  if (!!value) {
-    const children = cb(value as T);
-    return render(children);
+  if (value === undefined || value === "") {
+    return "";
   }
-  return "";
+  const children = cb(value as T);
+  return render(children);
 }
 
 export function render(children: Children): string {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.js
@@ -79,14 +79,11 @@ function SchemaItem({
     </div>
   ));
 
-  const renderDefaultValue = guard(
-    typeof defaultValue === "boolean" ? defaultValue.toString() : defaultValue,
-    (value) => (
-      <div className="">
-        <ReactMarkdown children={`**Default value:** \`${value}\``} />
-      </div>
-    )
-  );
+  const renderDefaultValue = guard(defaultValue, (value) => (
+    <div className="">
+      <ReactMarkdown children={`**Default value:** \`${value}\``} />
+    </div>
+  ));
 
   const schemaContent = (
     <div>


### PR DESCRIPTION
## Description

Fixed the guard to allow anything not undefined or empty to avoid issues with boolean and 0 numbers.

## Motivation and Context

Fix #724.

## How Has This Been Tested?

* Added unit tests for the utils file
* Updated the demo project with a default value at 0 to see the impact. See screenshot for before and after changes.

## Screenshots

Before the fix:
<img width="676" alt="image" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/5982268/f83818b2-9041-476f-b63e-2cb579d8d2c9">

After the fix:
<img width="670" alt="image" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/5982268/3737ec63-554d-4729-84ba-c34dcada61e2">

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
