### PR TITLE
fix: handle circular schemas in anyof/oneof

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -71,6 +71,19 @@ function createAnyOneOf(schema: SchemaObject): any {
           const label = anyOneSchema.title
             ? anyOneSchema.title
             : `MOD${index + 1}`;
+
+          // Handle resolved circular schema
+          if (
+            typeof anyOneSchema === "object" &&
+            Object.keys(anyOneSchema).length === 0
+          ) {
+            return create("TabItem", {
+              label: label,
+              value: `${index}-item-properties`,
+              children: [],
+            });
+          }
+
           const anyOneChildren = [];
 
           if (anyOneSchema.properties !== undefined) {


### PR DESCRIPTION
## Description

Fixed handling circular schema definitions in anyOf and oneOf properties. I am re-using the existing label logic, but it might be nice to display the name of the parent schema. Not really sure what would be the most appropriate way to do this though.

## Motivation and Context

Circular references in a oneOf or anyOf property will result in a error.


## How Has This Been Tested?

* Modify the demo/examples/petstore.yaml file and set pet/friend property to anyOf:
```diff
        friend:
-          allOf:
+          anyOf:
            - $ref: "#/components/schemas/Pet"
```

## Screenshots (if appropriate)

* Error
![image](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/7443666/bc4d9d16-19ab-4950-9fec-155ed8b40a64)


* Result
![image](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/7443666/60757ce7-7d71-4b13-9144-03defb20020f)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
