### PR TITLE
feat: Implement schema pages behind a config option `showSchemas`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ dist
 demo/**/*.api.mdx
 demo/**/*.info.mdx
 demo/**/*.tag.mdx
+demo/**/*.schema.mdx
 demo/**/sidebar.js
 demo/**/versions.json
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `baseUrl`            | `string`  | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                                               |
 | `versions`           | `object`  | `null`  | _Optional:_ Set of options for versioning configuration. See below for a list of supported options.                                             |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content with a set of options for specifying markdown generator functions. See below for a list of supported options. |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages and adds them to the sidebar.                                                              |
 
 `sidebarOptions` can be configured with the following options:
 
@@ -197,11 +198,12 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `markdownGenerators` can be configured with the following options:
 
-| Name               | Type       | Default | Description                                                                                                                                |
-| ------------------ | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `createApiPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for API pages.<br/><br/>**Function type:** `(pageData: ApiPageMetadata) => string`   |
-| `createInfoPageMD` | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for info pages.<br/><br/>**Function type:** `(pageData: InfoPageMetadata) => string` |
-| `createTagPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for tag pages.<br/><br/>**Function type:** `(pageData: TagPageMetadata) => string`   |
+| Name                 | Type       | Default | Description                                                                                                                                    |
+| -------------------- | ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createApiPageMD`    | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for API pages.<br/><br/>**Function type:** `(pageData: ApiPageMetadata) => string`       |
+| `createInfoPageMD`   | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for info pages.<br/><br/>**Function type:** `(pageData: InfoPageMetadata) => string`     |
+| `createTagPageMD`    | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for tag pages.<br/><br/>**Function type:** `(pageData: TagPageMetadata) => string`       |
+| `createSchemaPageMD` | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for schema pages.<br/><br/>**Function type:** `(pageData: SchemaPageMetadata) => string` |
 
 ## CLI Usage
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -336,6 +336,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `baseUrl`            | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                                        |
 | `versions`           | `object` | `null`  | _Optional:_ Set of options for versioning configuration. See below for a list of supported options.                                      |
 | `markdownGenerators` | `object` | `null`  | _Optional:_ Customize MDX content with a set of options for specifying markdown generator functions. See below for a list of supported options. |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages and adds them to the sidebar. |
 
 ### sidebarOptions
 
@@ -373,11 +374,12 @@ All versions will automatically inherit `sidebarOptions` from the parent/base co
 
 `markdownGenerators` can be configured with the following options:
 
-| Name                 | Type      | Default | Description                                                                                                                    |
-| ------------------ | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------|
-| `createApiPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for API pages.<br/><br/>**Function type:** `(pageData: ApiPageMetadata) => string`   |
-| `createInfoPageMD` | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for info pages.<br/><br/>**Function type:** `(pageData: InfoPageMetadata) => string` |
-| `createTagPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for tag pages.<br/><br/>**Function type:** `(pageData: TagPageMetadata) => string`   |
+| Name                  | Type      | Default | Description                                                                                                                    |
+| ------------------- | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------|
+| `createApiPageMD`   | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for API pages.<br/><br/>**Function type:** `(pageData: ApiPageMetadata) => string`   |
+| `createInfoPageMD`  | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for info pages.<br/><br/>**Function type:** `(pageData: InfoPageMetadata) => string` |
+| `createTagPageMD`   | `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for tag pages.<br/><br/>**Function type:** `(pageData: TagPageMetadata) => string`   |
+| `createSchemaPageMD`| `function` | `null`  | _Optional:_ Returns a string of the raw markdown body for schema pages.<br/><br/>**Function type:** `(pageData: SchemaPageMetadata) => string`   |
 
 :::info NOTE
 If a config option is not provided, its default markdown generator will be used. 

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -239,6 +239,7 @@ const config = {
             downloadUrl:
               "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
             hideSendButton: false,
+            showSchemas: true,
           },
           cos: {
             specPath: "examples/openapi-cos.json",

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -159,6 +159,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `baseUrl`            | `string`  | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                                               |
 | `versions`           | `object`  | `null`  | _Optional:_ Set of options for versioning configuration. See below for a list of supported options.                                             |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content with a set of options for specifying markdown generator functions. See below for a list of supported options. |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages and adds them to the sidebar.                                                              |
 
 `sidebarOptions` can be configured with the following options:
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts
@@ -11,7 +11,12 @@ import {
   MediaTypeObject,
   SecuritySchemeObject,
 } from "../openapi/types";
-import { ApiPageMetadata, InfoPageMetadata, TagPageMetadata } from "../types";
+import {
+  ApiPageMetadata,
+  InfoPageMetadata,
+  SchemaPageMetadata,
+  TagPageMetadata,
+} from "../types";
 import { createAuthentication } from "./createAuthentication";
 import { createAuthorization } from "./createAuthorization";
 import { createCallbacks } from "./createCallbacks";
@@ -26,11 +31,12 @@ import { createMethodEndpoint } from "./createMethodEndpoint";
 import { createParamsDetails } from "./createParamsDetails";
 import { createRequestBodyDetails } from "./createRequestBodyDetails";
 import { createRequestHeader } from "./createRequestHeader";
+import { createNodes } from "./createSchema";
 import { createStatusCodes } from "./createStatusCodes";
 import { createTermsOfService } from "./createTermsOfService";
 import { createVendorExtensions } from "./createVendorExtensions";
 import { createVersionBadge } from "./createVersionBadge";
-import { greaterThan, lessThan, render } from "./utils";
+import { create, greaterThan, lessThan, render } from "./utils";
 
 interface RequestBodyProps {
   title: string;
@@ -129,4 +135,19 @@ export function createInfoPageMD({
 
 export function createTagPageMD({ tag: { description } }: TagPageMetadata) {
   return render([createDescription(description)]);
+}
+
+export function createSchemaPageMD({ schema }: SchemaPageMetadata) {
+  const { title = "", description } = schema;
+  return render([
+    `import DiscriminatorTabs from "@theme/DiscriminatorTabs";\n`,
+    `import SchemaItem from "@theme/SchemaItem";\n`,
+    `import SchemaTabs from "@theme/SchemaTabs";\n`,
+    `import TabItem from "@theme/TabItem";\n\n`,
+    createHeading(title.replace(lessThan, "&lt;").replace(greaterThan, "&gt;")),
+    createDescription(description),
+    create("ul", {
+      children: createNodes(schema, "response"),
+    }),
+  ]);
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -37,6 +37,7 @@ export const OptionsSchema = Joi.object({
         showExtensions: Joi.boolean(),
         sidebarOptions: sidebarOptions,
         markdownGenerators: markdownGenerators,
+        showSchemas: Joi.boolean(),
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -10,6 +10,7 @@ import type Request from "@paloaltonetworks/postman-collection";
 import {
   InfoObject,
   OperationObject,
+  SchemaObject,
   SecuritySchemeObject,
   TagObject,
 } from "./openapi/types";
@@ -44,12 +45,14 @@ export interface APIOptions {
   };
   proxy?: string;
   markdownGenerators?: MarkdownGenerator;
+  showSchemas?: boolean;
 }
 
 export interface MarkdownGenerator {
   createApiPageMD?: (pageData: ApiPageMetadata) => string;
   createInfoPageMD?: (pageData: InfoPageMetadata) => string;
   createTagPageMD?: (pageData: TagPageMetadata) => string;
+  createSchemaPageMD?: (pageData: SchemaPageMetadata) => string;
 }
 
 export interface SidebarOptions {
@@ -72,7 +75,11 @@ export interface LoadedContent {
   // loadedDocs: DocPageMetadata[]; TODO: cleanup
 }
 
-export type ApiMetadata = ApiPageMetadata | InfoPageMetadata | TagPageMetadata;
+export type ApiMetadata =
+  | ApiPageMetadata
+  | InfoPageMetadata
+  | TagPageMetadata
+  | SchemaPageMetadata;
 
 export interface ApiMetadataBase {
   sidebar?: string;
@@ -128,6 +135,12 @@ export interface InfoPageMetadata extends ApiMetadataBase {
 export interface TagPageMetadata extends ApiMetadataBase {
   type: "tag";
   tag: TagObject;
+  markdown?: string;
+}
+
+export interface SchemaPageMetadata extends ApiMetadataBase {
+  type: "schema";
+  schema: SchemaObject;
   markdown?: string;
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -44,12 +44,17 @@ interface ApiFrontMatter extends DocFrontMatter {
   readonly api?: ApiItemType;
 }
 
+interface SchemaFrontMatter extends DocFrontMatter {
+  readonly schema?: boolean;
+}
+
 export default function ApiItem(props: Props): JSX.Element {
   const docHtmlClassName = `docs-doc-id-${props.content.metadata.unversionedId}`;
   const MDXComponent = props.content;
   const { frontMatter } = MDXComponent;
   const { info_path: infoPath } = frontMatter as DocFrontMatter;
   let { api } = frontMatter as ApiFrontMatter;
+  const { schema } = frontMatter as SchemaFrontMatter;
   // decompress and parse
   if (api) {
     api = JSON.parse(
@@ -155,6 +160,21 @@ export default function ApiItem(props: Props): JSX.Element {
                 </div>
               </div>
             </Provider>
+          </DocItemLayout>
+        </HtmlClassNameProvider>
+      </DocProvider>
+    );
+  } else if (schema) {
+    return (
+      <DocProvider content={props.content}>
+        <HtmlClassNameProvider className={docHtmlClassName}>
+          <DocItemMetadata />
+          <DocItemLayout>
+            <div className={clsx("row", "theme-api-markdown")}>
+              <div className="col col--12">
+                <MDXComponent />
+              </div>
+            </div>
           </DocItemLayout>
         </HtmlClassNameProvider>
       </DocProvider>


### PR DESCRIPTION
## Description

Adds support for schema/model definition pages which are generated when `showSchemas` is set to `true`.
The out-of-the-box behavior is kept the same - no schema pages.

## Motivation and Context

I am a SE over from [Canopy Connect](https://www.usecanopy.com), and we are looking to take our [documentation](https://docs.usecanopy.com/reference/getting-started) to the next level. After some considerations (Readme - current, Docusaurus, Mintlify, Starlight Astro) I believe Docusaurus to be one of the best options, expect for the fact that this openapi plugin doesn't have schema pages, which we require. I'm hoping to help push this along so we can make our switch to Docusaurus.

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/713
https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/225

## How Has This Been Tested?

Toggling `showSchemas` on various configs in demo, running `yarn clean-api` and `yarn watch:demo`.
When `showSchemas` is `true`, a new sidebar category is added: "Schemas". Within this category should exist any schemas defined in `components.schemas` of the openapi spec.

## Screenshots (if appropriate)

Sidebar:
<img width="312" alt="Screenshot 2024-03-07 at 6 25 47 PM" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/13179783/77b64506-2ee6-4e40-b678-b6b4f87f72ea">

Petstore User schema example:
<img width="1512" alt="Screenshot 2024-03-07 at 6 26 17 PM" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/13179783/c7b5cf16-ec3f-4af4-8b10-21fa79a85c18">

Video click through:
<video src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/13179783/a5bb0e85-ae2b-4466-ba7d-c1df2899c63c" placeholder="Video click through" autoplay loop controls muted>
    Sorry, your browser doesn't support HTML 5 video. Go to: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/13179783/a5bb0e85-ae2b-4466-ba7d-c1df2899c63c
   </video>



## Types of changes

- New feature (non-breaking change which adds functionality)
  - Default behavior is unchanged - to be affected by changes `showSchemas` must be set to true

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
