### PR TITLE
[bugfix] Ensure 0 and false are guarded correctly and add deprecated support to params

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -24,7 +24,7 @@ export function guard<T>(
   value: T | undefined,
   cb: (value: T) => Children
 ): string {
-  if (!!value) {
+  if (!!value || value === 0) {
     const children = cb(value);
     return render(children);
   }

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts
@@ -22,6 +22,11 @@ describe("guard", () => {
     expect(actual).toBe("");
   });
 
+  it("should guard false booleans", () => {
+    const actual = guard(false, (value) => `${value}`);
+    expect(actual).toBe("");
+  });
+
   it("should not guard strings", () => {
     const actual = guard("hello", (value) => value);
     expect(actual).toBe("hello");
@@ -37,10 +42,6 @@ describe("guard", () => {
     expect(actual).toBe("0");
   });
 
-  it("should not guard false booleans", () => {
-    const actual = guard(false, (value) => `${value}`);
-    expect(actual).toBe("false");
-  });
   it("should not guard true booleans", () => {
     const actual = guard(true, (value) => `${value}`);
     expect(actual).toBe("true");

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
@@ -24,11 +24,11 @@ export function guard<T>(
   value: T | undefined | string,
   cb: (value: T) => Children
 ): string {
-  if (value === undefined || value === "") {
-    return "";
+  if (!!value || value === 0) {
+    const children = cb(value as T);
+    return render(children);
   }
-  const children = cb(value as T);
-  return render(children);
+  return "";
 }
 
 export function render(children: Children): string {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.js
@@ -26,8 +26,10 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 
 function ParamsItem({
-  param: { description, example, examples, name, required, schema },
+  param: { description, example, examples, name, required, schema, deprecated },
 }) {
+  console.log(name, required);
+
   if (!schema || !schema?.type) {
     schema = { type: "any" };
   }
@@ -38,6 +40,10 @@ function ParamsItem({
 
   const renderSchemaRequired = guard(required, () => (
     <span className="openapi-schema__required">required</span>
+  ));
+
+  const renderDeprecated = guard(deprecated, () => (
+    <span className="openapi-schema__deprecated">deprecated</span>
   ));
 
   const renderSchema = guard(getQualifierMessage(schema), (message) => (
@@ -121,8 +127,11 @@ function ParamsItem({
       <span className="openapi-schema__container">
         <strong className="openapi-schema__property">{name}</strong>
         {renderSchemaName}
-        {required && <span className="openapi-schema__divider"></span>}
-        {renderSchemaRequired}
+        {(required || deprecated) && (
+          <span className="openapi-schema__divider"></span>
+        )}
+        {!deprecated && renderSchemaRequired}
+        {renderDeprecated}
       </span>
       {renderSchema}
       {renderDefaultValue}


### PR DESCRIPTION
## Description

* refactor `guard` to allow `0` values
* update utils tests to ensure `false` values are properly guarded
* ensure `deprecated` is supported for params


## Motivation and Context

Addresses regression bug introduced in https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/725

## How Has This Been Tested?

All utils tests passed as expected:

PASS  packages/docusaurus-theme-openapi-docs/src/markdown/utils.test.ts

Performed spot check by comparing rendered output of plugin with Redocly 
