### PR TITLE
[bug] Ensure resize observer is calculated once per frame to avoid loops

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.js
@@ -67,11 +67,13 @@ function TabList({
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
-          setShowTabArrows(true);
-        } else {
-          setShowTabArrows(false);
-        }
+        requestAnimationFrame(() => {
+          if (entry.target.offsetWidth < entry.target.scrollWidth) {
+            setShowTabArrows(true);
+          } else {
+            setShowTabArrows(false);
+          }
+        });
       }
     });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.js
@@ -57,11 +57,13 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
-          setShowTabArrows(true);
-        } else {
-          setShowTabArrows(false);
-        }
+        requestAnimationFrame(() => {
+          if (entry.target.offsetWidth < entry.target.scrollWidth) {
+            setShowTabArrows(true);
+          } else {
+            setShowTabArrows(false);
+          }
+        });
       }
     });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/index.js
@@ -94,11 +94,13 @@ function TabList({
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
-          setShowTabArrows(true);
-        } else {
-          setShowTabArrows(false);
-        }
+        requestAnimationFrame(() => {
+          if (entry.target.offsetWidth < entry.target.scrollWidth) {
+            setShowTabArrows(true);
+          } else {
+            setShowTabArrows(false);
+          }
+        });
       }
     });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/index.js
@@ -60,11 +60,13 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
-          setShowTabArrows(true);
-        } else {
-          setShowTabArrows(false);
-        }
+        requestAnimationFrame(() => {
+          if (entry.target.offsetWidth < entry.target.scrollWidth) {
+            setShowTabArrows(true);
+          } else {
+            setShowTabArrows(false);
+          }
+        });
       }
     });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -57,11 +57,13 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
       for (let entry of entries) {
-        if (entry.target.offsetWidth < entry.target.scrollWidth) {
-          setShowTabArrows(true);
-        } else {
-          setShowTabArrows(false);
-        }
+        requestAnimationFrame(() => {
+          if (entry.target.offsetWidth < entry.target.scrollWidth) {
+            setShowTabArrows(true);
+          } else {
+            setShowTabArrows(false);
+          }
+        });
       }
     });
 


### PR DESCRIPTION
## Description

Use `requestAnimationFrame` to sync resize observer to frame rate.

## Motivation and Context

Helps avoid resize observer loop/notification errors.

## How Has This Been Tested?

Tested using the Petstore info page, where the error was observed locally.