### PR TITLE
Uncomment line preventing grouping by operation tags

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -87,7 +87,7 @@ function groupByTags(
       apiTags.push(tag.name!);
     }
   });
-  // apiTags = uniq(apiTags.concat(operationTags));
+  apiTags = uniq(apiTags.concat(operationTags));
 
   const basePath = docPath
     ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")


### PR DESCRIPTION
## Description

Uncomments line that extracts and groups operation tags with global tags.

## Motivation and Context

Commenting this line prevented tag grouping when no global tags were defined in the OpenAPi spec.

See #762 

This regression bug was introdudced in #737 

## How Has This Been Tested?

Tested by commenting out globally defined groups in petstore OpenAPI spec. When doing so, the plugin generates tag groupings using the operation tags.