### PR TITLE
Fix allOf schema qualifier and type

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -624,7 +624,6 @@ function createEdges({
     }: { mergedSchemas: SchemaObject; required: string[] | boolean } =
       mergeAllOf(schema.allOf);
     const mergedSchemaName = getSchemaName(mergedSchemas);
-
     if (
       mergedSchemas.oneOf !== undefined ||
       mergedSchemas.anyOf !== undefined
@@ -685,8 +684,8 @@ function createEdges({
       collapsible: false,
       name,
       required: Array.isArray(required) ? required.includes(name) : required,
-      schemaName: schemaName,
-      qualifierMessage: getQualifierMessage(schema),
+      schemaName: mergedSchemaName,
+      qualifierMessage: getQualifierMessage(mergedSchemas),
       schema: mergedSchemas,
     });
   }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
@@ -39,7 +39,9 @@ function prettyName(schema: SchemaObject, circular?: boolean) {
     return schema.xml?.name ?? schema.type;
     // return schema.type;
   }
-
+  if (schema.title && schema.type) {
+    return `${schema.title} (${schema.type})`;
+  }
   return schema.title ?? schema.type;
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
@@ -39,9 +39,11 @@ function prettyName(schema: SchemaObject, circular?: boolean) {
     return schema.xml?.name ?? schema.type;
     // return schema.type;
   }
+
   if (schema.title && schema.type) {
     return `${schema.title} (${schema.type})`;
   }
+
   return schema.title ?? schema.type;
 }
 


### PR DESCRIPTION
## Description

Address bug preventing qualifier and type (schemaName) from properly rendering for allOf schemas.

## Motivation and Context

See https://github.com/PaloAltoNetworks/pan.dev/issues/587

## How Has This Been Tested?

Tested using the OpenAPI snippet in https://github.com/PaloAltoNetworks/pan.dev/issues/587