### PR TITLE
Allow custom plugin to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ Here is an example of properly configuring `docusaurus.config.js` file for `docu
 
 The `docusaurus-plugin-openapi-docs` plugin can be configured with the following options:
 
-| Name           | Type     | Default | Description                                                                                                                                          |
-| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | `string` | `null`  | A unique plugin ID.                                                                                                                                  |
-| `docsPluginId` | `string` | `null`  | The ID associated with the `plugin-content-docs` or `preset` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
+| Name           | Type     | Default                           | Description                                                                                                                                                   |
+| -------------- | -------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | `string` | `null`                            | A unique plugin ID.                                                                                                                                           |
+| `docsPlugin`   | `string` | `@docusaurus/plugin-content-docs` | The plugin used to render the OpenAPI docs (ignored if the plugin instance referenced by `docsPluginId` is a `preset`).                                       |
+| `docsPluginId` | `string` | `null`                            | The plugin ID associated with the `preset` or configured `docsPlugin` instance used to render the OpenAPI docs (e.g. "your-plugin-id", "classic", "default"). |
 
 ### config
 

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -41,6 +41,7 @@ export function isURL(str: string): boolean {
 
 export function getDocsPluginConfig(
   presetsPlugins: any[],
+  plugin: string,
   pluginId: string
 ): Object | undefined {
   // eslint-disable-next-line array-callback-return
@@ -52,10 +53,7 @@ export function getDocsPluginConfig(
       }
 
       // Search plugin-content-docs instances
-      if (
-        typeof data[0] === "string" &&
-        data[0] === "@docusaurus/plugin-content-docs"
-      ) {
+      if (typeof data[0] === "string" && data[0] === plugin) {
         const configPluginId = data[1].id ? data[1].id : "default";
         if (configPluginId === pluginId) {
           return data[1];
@@ -71,7 +69,7 @@ export function getDocsPluginConfig(
     }
 
     // Search plugin-content-docs instances
-    if (filteredConfig[0] === "@docusaurus/plugin-content-docs") {
+    if (filteredConfig[0] === plugin) {
       const configPluginId = filteredConfig[1].id
         ? filteredConfig[1].id
         : "default";
@@ -95,14 +93,22 @@ export default function pluginOpenAPIDocs(
   context: LoadContext,
   options: PluginOptions
 ): Plugin<LoadedContent> {
-  const { config, docsPluginId } = options;
+  const {
+    config,
+    docsPlugin = "@docusaurus/plugin-content-docs",
+    docsPluginId,
+  } = options;
   const { siteDir, siteConfig } = context;
 
   // Get routeBasePath and path from plugin-content-docs or preset
   const presets: any = siteConfig.presets;
   const plugins: any = siteConfig.plugins;
   const presetsPlugins = presets.concat(plugins);
-  let docData: any = getDocsPluginConfig(presetsPlugins, docsPluginId);
+  let docData: any = getDocsPluginConfig(
+    presetsPlugins,
+    docsPlugin,
+    docsPluginId
+  );
   let docRouteBasePath = docData ? docData.routeBasePath : undefined;
   let docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
 
@@ -121,7 +127,7 @@ export default function pluginOpenAPIDocs(
 
     // Override docPath if pluginId provided
     if (pluginId) {
-      docData = getDocsPluginConfig(presetsPlugins, pluginId);
+      docData = getDocsPluginConfig(presetsPlugins, docsPlugin, pluginId);
       docRouteBasePath = docData ? docData.routeBasePath : undefined;
       docPath = docData ? (docData.path ? docData.path : "docs") : undefined;
     }

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -23,6 +23,7 @@ const markdownGenerators = Joi.object({
 
 export const OptionsSchema = Joi.object({
   id: Joi.string().required(),
+  docsPlugin: Joi.string(),
   docsPluginId: Joi.string().required(),
   config: Joi.object()
     .pattern(

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -23,6 +23,7 @@ export type {
 } from "@docusaurus/plugin-content-docs-types";
 export interface PluginOptions {
   id?: string;
+  docsPlugin?: string;
   docsPluginId: string;
   config: {
     [key: string]: APIOptions;


### PR DESCRIPTION
## Description

This allows a custom plugin, other than the default `@docusaurus/plugin-content-docs`, to render the generated OpenAPI docs.

## Motivation and Context

In our Wiki, we have a custom plugin that renders our documentation. Although the plugin is based on `@docusaurus/plugin-content-docs`, it is named differently. Therefore, it couldn't be used to render OpenAPI docs because `@docusaurus/plugin-content-docs` is hard coded in the lookup logic of this plugin. The proposed change allows for a custom plugin, with `@docusaurus/plugin-content-docs` as default to maintain backward compatibility.

## How Has This Been Tested?

We use it in our own Docusaurus build [here](https://github.com/iotaledger/iota-wiki/blob/v3/docusaurus.config.js#L250).

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
