### PR TITLE
[UI Bug Fix] Firefox issue: Hide empty scrollbar track from Tab components 

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/_ApiTabs.scss
@@ -85,6 +85,7 @@
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none;
 }
 
 .openapi-tabs__response-list-container::-webkit-scrollbar {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/_DiscriminatorTabs.scss
@@ -59,6 +59,7 @@
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none;
 }
 
 .openapi-tabs__discriminator-list-container::-webkit-scrollbar {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/_MimeTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/MimeTabs/_MimeTabs.scss
@@ -45,6 +45,7 @@
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     display: none;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/OperationTabs/_OperationTabs.scss
@@ -44,6 +44,7 @@
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     display: none;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/_SchemaTabs.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/_SchemaTabs.scss
@@ -42,6 +42,7 @@
   overflow-y: hidden;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## Description

This PR addresses https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/272, where empty scroll bars for tab components are being rendered within Firefox browsers.

The `scrollbar-width: none` property has been added to the following classes: 
- `.openapi-tabs__response-list-container`
- `.openapi-tabs__discriminator-list-container`
- `.openapi-tabs__mime-list-container`
- `.openapi-tabs__operation-list-container`
- `.openapi-tabs__schema-list-container`

## Motivation and Context

The scrollbars should not be rendered if it is not necessary.

## How Has This Been Tested?

**Browser:** Firefox
Tested locally by navigating to http://localhost:3000/petstore_versioned/add-pet and ensuring empty scroll bars are not being rendered.

## Screenshots (if appropriate)

![Screenshot 2024-03-27 at 3 13 59 PM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/48506502/ca9cf15f-146e-4317-878c-15293b1c4847)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
