### PR TITLE
changed theme and plugin to headings

### DIFF
--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -96,13 +96,13 @@ yarn start
 Both the plugin and theme are currently designed to pair with a specific Docusaurus release. The Docusaurus badge in the `README.md` and at the top of this page will always reflect the current compatible versions.
 :::
 
-Plugin:
+### Plugin
 
 ```bash
 yarn add docusaurus-plugin-openapi-docs
 ```
 
-Theme:
+### Theme
 
 ```bash
 yarn add docusaurus-theme-openapi-docs


### PR DESCRIPTION
## Description

Myself and others were not able to install the beta plugin properly. I think it's because we were skipping past the information about installing both the plugin and the theme. I changed them to headings. Take it or leave it.

## Motivation and Context

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/discussions/735

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ NA] I have added tests to cover my changes if appropriate.
- [NA ] All new and existing tests passed.
