### PR TITLE
preventing to send form onClick left/right arrows in SchemaTabs compo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- preventing to send form onClick left/right arrows in SchemaTabs component
+
 ## 2.1.3 (Mar 22, 2024)
 
 High level enhancements

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.js
@@ -74,11 +74,13 @@ function TabList({ className, block, selectedValue, selectValue, tabValues }) {
     };
   }, []);
 
-  const handleRightClick = () => {
+  const handleRightClick = (e) => {
+    e.preventDefault();
     tabItemListContainerRef.current.scrollLeft += 90;
   };
 
-  const handleLeftClick = () => {
+  const handleLeftClick = (e) => {
+    e.preventDefault();
     tabItemListContainerRef.current.scrollLeft -= 90;
   };
 


### PR DESCRIPTION
…nent

## Description

Add event.preventDefault() in SchemaTabs 

## Motivation and Context

Currently when we have arrows in code examples onClick event triggers the form. 

## Types of changes

<!--- What types of changes does your code introduce? -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
