### PR TITLE
Add option to disable frontmatter api prop compression

### DIFF
--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -240,6 +240,7 @@ const config = {
               "https://raw.githubusercontent.com/PaloAltoNetworks/docusaurus-openapi-docs/main/demo/examples/petstore.yaml",
             hideSendButton: false,
             showSchemas: true,
+            disableCompression: true,
           },
           cos: {
             specPath: "examples/openapi-cos.json",

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -119,6 +119,7 @@ export default function pluginOpenAPIDocs(
       markdownGenerators,
       downloadUrl,
       sidebarOptions,
+      disableCompression,
     } = options;
 
     // Remove trailing slash before proceeding
@@ -319,9 +320,11 @@ custom_edit_url: null
           // const deserialize = (s: any) => {
           //   return zlib.inflateSync(Buffer.from(s, "base64")).toString();
           // };
-          item.json = zlib
-            .deflateSync(JSON.stringify(item.api))
-            .toString("base64");
+          disableCompression
+            ? (item.json = JSON.stringify(item.api))
+            : (item.json = zlib
+                .deflateSync(JSON.stringify(item.api))
+                .toString("base64"));
           let infoBasePath = `${outputDir}/${item.infoId}`;
           if (docRouteBasePath) {
             infoBasePath = `${docRouteBasePath}/${outputDir

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -320,7 +320,7 @@ custom_edit_url: null
           // const deserialize = (s: any) => {
           //   return zlib.inflateSync(Buffer.from(s, "base64")).toString();
           // };
-          disableCompression
+          disableCompression === true
             ? (item.json = JSON.stringify(item.api))
             : (item.json = zlib
                 .deflateSync(JSON.stringify(item.api))

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -39,6 +39,7 @@ export const OptionsSchema = Joi.object({
         sidebarOptions: sidebarOptions,
         markdownGenerators: markdownGenerators,
         showSchemas: Joi.boolean(),
+        disableCompression: Joi.boolean(),
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -47,6 +47,7 @@ export interface APIOptions {
   proxy?: string;
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
+  disableCompression?: boolean;
 }
 
 export interface MarkdownGenerator {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -57,11 +57,12 @@ export default function ApiItem(props: Props): JSX.Element {
   const { schema } = frontMatter as SchemaFrontMatter;
   // decompress and parse
   if (api) {
-    api = JSON.parse(
-      zlib.inflateSync(Buffer.from(api as any, "base64")).toString()
-    );
+    try {
+      api = JSON.parse(
+        zlib.inflateSync(Buffer.from(api as any, "base64")).toString()
+      );
+    } catch {}
   }
-
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const options = themeConfig.api;


### PR DESCRIPTION
## Description

See #692 for background.

## Motivation and Context

Allows users to disable compression to avoid differences in compressed frontmatter `api` output between local and CI operating system.

## How Has This Been Tested?

Tested using petstore API