### PR TITLE
fix col row padding footer&pagination

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/Layout/index.tsx
@@ -62,12 +62,16 @@ export default function DocItemLayout({ children }: Props): JSX.Element {
             <DocVersionBadge />
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
-            <div className={clsx("col", api ? "col--7" : "col--12")}>
-              <DocItemFooter />
+            <div className="row">
+              <div className={clsx("col", api ? "col--7" : "col--12")}>
+                <DocItemFooter />
+              </div>
             </div>
           </article>
-          <div className={clsx("col", api ? "col--7" : "col--12")}>
-            <DocItemPaginator />
+          <div className="row">
+            <div className={clsx("col", api ? "col--7" : "col--12")}>
+              <DocItemPaginator />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

adds a row wrapper for col classes to ensure proper padding
![image](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/76127644/c4eb4932-e4ad-47b0-b13f-06375012f22d)

fix a bug, which is also available on the demo site
