### PR TITLE
Ensure sidebars.ts and schemas are properly cleaned

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,21 +4,21 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     }
   },
   "[javascript][typescript][typescriptreact]": {

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -476,11 +476,7 @@ custom_edit_url: null
       cwd: path.resolve(apiDir),
       deep: 1,
     });
-    const schemaMdxFiles = await Globby(["*.schema.mdx"], {
-      cwd: path.resolve(apiDir, "schemas"),
-      deep: 1,
-    });
-    const sidebarFile = await Globby(["sidebar.js"], {
+    const sidebarFile = await Globby(["sidebar.js", "sidebar.ts"], {
       cwd: path.resolve(apiDir),
       deep: 1,
     });
@@ -497,20 +493,17 @@ custom_edit_url: null
       })
     );
 
-    schemaMdxFiles.map((mdx) =>
-      fs.unlink(`${apiDir}/schemas/${mdx}`, (err) => {
-        if (err) {
-          console.error(
-            chalk.red(`Cleanup failed for "${apiDir}/schemas/${mdx}"`),
-            chalk.yellow(err)
-          );
-        } else {
-          console.log(
-            chalk.green(`Cleanup succeeded for "${apiDir}/schemas/${mdx}"`)
-          );
-        }
-      })
-    );
+    try {
+      fs.rmSync(`${apiDir}/schemas`, { recursive: true });
+      console.log(chalk.green(`Cleanup succeeded for "${apiDir}/schemas"`));
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        console.error(
+          chalk.red(`Cleanup failed for "${apiDir}/schemas"`),
+          chalk.yellow(err)
+        );
+      }
+    }
 
     sidebarFile.map((sidebar) =>
       fs.unlink(`${apiDir}/${sidebar}`, (err) => {


### PR DESCRIPTION
## Description

* Ensure `sidebars.ts` is removed when performing clean
* Move to recursively deleting generated `schemas` directory

## Motivation and Context

See #811 for background. Concerning `schemas`, I observed the `schemas` directory was left behind after the schemas MDX files were cleaned. Instead of attempting to first clean the MDX files followed by the container directory, I opted to perform a recursive removal of the entire directory.

## How Has This Been Tested?

Tested locally using example API specs.