### PR TITLE
Fix: makes sure that the operationObject is an object.

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -132,6 +132,9 @@ function createItems(
     const { $ref, description, parameters, servers, summary, ...rest } =
       pathObject;
     for (let [method, operationObject] of Object.entries({ ...rest })) {
+      // Lets assume the operationObject is an object or continue. 
+      if(typeof operationObject !== 'object') continue; 
+      
       const title =
         operationObject.summary ??
         operationObject.operationId ??


### PR DESCRIPTION
## Description

For reasons unbeknown to me, probably related to changes in the standard, the parser gets tripped up at this type of structure

"openapi":"3.1.0",
"paths":{
**"openapi":{
 "0":"3","1":".","2":"0","3":".","4":"2"**
}

It ends up trying to add a description to a string. Then errors out. 

## Motivation and Context

I made the bold assumtion that the opperations made on the variable named "operationObject" where ment to be object related opperations. So a small check for an object fixed my build issues. 


## How Has This Been Tested?

I have not made any attempt to run the test scripts as i was unable to resolve the dependency tree. 

`
npm ERR! While resolving: demo@2.1.3
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from demo@2.1.3
npm ERR!   demo
npm ERR!     demo@2.1.3
npm ERR!     node_modules/demo
npm ERR!       workspace demo from the root project
npm ERR!`

However as i mentioned this change fixed my build, and has for me been without issue. 
Do with this what you will, it might be that I'm the idiot - but seeing as it parsed fine in redoc I thought I'd create the issue. 

Have a good day. 

