### PR TITLE
Fix clean-api-docs not deleting sidebar.ts

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -477,7 +477,7 @@ custom_edit_url: null
       cwd: path.resolve(apiDir, "schemas"),
       deep: 1,
     });
-    const sidebarFile = await Globby(["sidebar.js"], {
+    const sidebarFile = await Globby(["sidebar.{js,ts}"], {
       cwd: path.resolve(apiDir),
       deep: 1,
     });


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

Running `clean-api-docs` doesn't delete the generated sidebar.ts file, this causes the file to not carry over changes when `gen-api-docs` is ran. For now I have install & use `rimraf` to delete the sidebar.ts `docusaurus clean-api-docs all && rimraf <path>/sidebar.ts`

## How Has This Been Tested?

Used the local version of this branch in my typescript Docusaurus project, and confirmed `clean-api-docs` now deletes the sidebar.ts file without needing `rimraf`.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

Updates the glob string used to match `sidebar` files.
Originally `"sidebar.js"` was used. I updated it to `"sidebar.{js,ts}"`
You can test this glob [here](https://www.digitalocean.com/community/tools/glob?comments=true&glob=sidebar.%7Bjs%2Cts%7D&matches=false&tests=foobar.js&tests=foobar.ts&tests=sidebar.js&tests=sidebar.ts)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
