### PR TITLE
fix: markdown table within the description attribute cannot be rendered correctly

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -61,7 +61,7 @@ export const lessThan =
 export const greaterThan =
   /(?<!(button|code|details|summary|hr|br|span|strong|small|table|thead|tbody|td|tr|th|h1|h2|h3|h4|h5|h6|title|p|em|b|i|u|strike|bold|a|li|ol|ul|img|svg|div|center|\/|\s|"|'))>/gu;
 export const codeFence = /`{1,3}[\s\S]*?`{1,3}/g;
-export const curlyBrackets = /([{|}])/g;
+export const curlyBrackets = /([{}])/g;
 export const codeBlock = /(^```.*[\s\S]*?```$|`[^`].+?`)/gm;
 
 export function clean(value: string | undefined): string {


### PR DESCRIPTION
## Description

fix markdown table within the description attribute cannot be rendered correctly

## Motivation and Context

The "|" character within the description attribute is being escaped, which causes the markdown table to not render correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<img width="869" alt="image" src="https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/18374110/b972f536-fe1c-43b9-99b2-0cbcc58d9df0">

![image](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/18374110/da9a5a2c-a04f-46fb-96db-2c453fc67cdc)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
