### PR TITLE
Implement the `x-tags` extension for schema objects

### DIFF
--- a/demo/docs/customization/styling.md
+++ b/demo/docs/customization/styling.md
@@ -18,13 +18,15 @@ The demo site uses the following CSS to add coloured labels to each request incl
 
 ```css
 /* API Menu Items */
-.api-method > .menu__link {
+.api-method > .menu__link,
+.schema > .menu__link {
   align-items: center;
   justify-content: start;
 }
 
-.api-method > .menu__link::before {
-  width: 50px;
+.api-method > .menu__link::before,
+.schema > .menu__link::before {
+  width: 55px;
   height: 20px;
   font-size: 12px;
   line-height: 20px;
@@ -68,6 +70,16 @@ The demo site uses the following CSS to add coloured labels to each request incl
   content: "head";
   background-color: var(--ifm-color-secondary-darkest);
 }
+
+.event > .menu__link::before {
+  content: "event";
+  background-color: var(--ifm-color-secondary-darkest);
+}
+
+.schema > .menu__link::before {
+  content: "schema";
+  background-color: var(--ifm-color-secondary-darkest);
+}
 ```
 
 ## Alternative Styling
@@ -76,13 +88,15 @@ In [this issue](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issu
 
 ```css
 /* Sidebar Method labels */
-.api-method > .menu__link {
+.api-method > .menu__link,
+.schema > .menu__link {
   align-items: center;
   justify-content: start;
 }
 
-.api-method > .menu__link::before {
-  width: 50px;
+.api-method > .menu__link::before,
+.schema > .menu__link::before {
+  width: 55px;
   height: 20px;
   font-size: 12px;
   line-height: 20px;
@@ -133,6 +147,20 @@ In [this issue](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issu
 
 .head > .menu__link::before {
   content: "head";
+  background-color: var(--ifm-color-secondary-contrast-background);
+  color: var(--ifm-color-secondary-contrast-foreground);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+.event > .menu__link::before {
+  content: "event";
+  background-color: var(--ifm-color-secondary-contrast-background);
+  color: var(--ifm-color-secondary-contrast-foreground);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+.schema > .menu__link::before {
+  content: "schema";
   background-color: var(--ifm-color-secondary-contrast-background);
   color: var(--ifm-color-secondary-contrast-foreground);
   border-color: var(--ifm-color-secondary-dark);

--- a/demo/docs/sidebars.md
+++ b/demo/docs/sidebars.md
@@ -66,3 +66,9 @@ The OpenAPI Docs plugin can leverage this feature in a number of ways, including
 - Using the `generated-index` feature to create an index of all paths/endpoints available under a tag.
 - Setting the `tag` description of an OpenAPI specification as the content that displays when a category is clicked.
 - Setting the `info` section of an OpenAPI specification as the page that displays when a category is clicked (reserved primarily for micro-specs).
+
+### Grouping Schemas by `x-tags`
+
+The OpenAPI plugin provides out-of-the-box support for grouping schema objects into tags alongside path objects grouped by that same tag.
+
+What this means is that when the `groupPathsBy` sidebar option is set to `tag`, any `x-tag`ged schema objects will be gathered together with the tagged paths in that sidebar category. In the event that `showSchemas` is not configured, and `x-tags` is found on a schema object, the schema **will be included** in the relevant tag's category sidebar.

--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -37,7 +37,7 @@ info:
     Petstore offers two forms of authentication:
       - API Key
       - OAuth2
-      
+
     OAuth2 - an open protocol to allow secure authorization in a simple
     and standard method from web, mobile and desktop applications.
 
@@ -934,6 +934,8 @@ components:
         message:
           type: string
     Cat:
+      x-tags:
+        - pet
       description: A representation of a cat
       allOf:
         - $ref: "#/components/schemas/Pet"

--- a/demo/src/css/custom.css
+++ b/demo/src/css/custom.css
@@ -37,13 +37,15 @@ a:any-link:hover {
 }
 
 /* Sidebar Method labels */
-.api-method > .menu__link {
+.api-method > .menu__link,
+.schema > .menu__link {
   align-items: center;
   justify-content: start;
 }
 
-.api-method > .menu__link::before {
-  width: 50px;
+.api-method > .menu__link::before,
+.schema > .menu__link::before {
+  width: 55px;
   height: 20px;
   font-size: 12px;
   line-height: 20px;
@@ -90,6 +92,11 @@ a:any-link:hover {
 
 .event > .menu__link::before {
   content: "event";
+  background-color: var(--ifm-color-secondary-darkest);
+}
+
+.schema > .menu__link::before {
+  content: "schema";
   background-color: var(--ifm-color-secondary-darkest);
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -13,6 +13,7 @@ import { SchemaObject } from "../openapi/types";
 describe("createNodes", () => {
   it("should create readable MODs for oneOf primitive properties", () => {
     const schema: SchemaObject = {
+      "x-tags": ["clown"],
       type: "object",
       properties: {
         oneOfProperty: {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/examples/openapi.yaml
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/examples/openapi.yaml
@@ -40,3 +40,10 @@ x-tagGroups:
     tags:
       - tag3
       - tag4
+
+components:
+  schemas:
+    HelloString:
+      x-tags:
+        - tag1
+      type: string

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -31,6 +31,10 @@ describe("openapi", () => {
 
       expect(yaml?.data.tags).toBeDefined();
       expect(yaml?.data["x-tagGroups"]).toBeDefined();
+
+      expect(
+        yaml?.data.components?.schemas?.HelloString["x-tags"]
+      ).toBeDefined();
     });
   });
 });

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -410,43 +410,53 @@ function createItems(
     }
   }
 
-  if (options?.showSchemas === true) {
+  if (
+    options?.showSchemas === true ||
+    Object.entries(openapiData?.components?.schemas ?? {})
+      .flatMap(([_, s]) => s["x-tags"])
+      .filter((item) => !!item).length > 0
+  ) {
     // Gather schemas
     for (let [schema, schemaObject] of Object.entries(
       openapiData?.components?.schemas ?? {}
     )) {
-      const baseIdSpaces =
-        schemaObject?.title?.replace(" ", "-").toLowerCase() ?? "";
-      const baseId = kebabCase(baseIdSpaces);
+      if (options?.showSchemas === true || schemaObject["x-tags"]) {
+        const baseIdSpaces =
+          schemaObject?.title?.replace(" ", "-").toLowerCase() ?? "";
+        const baseId = kebabCase(baseIdSpaces);
 
-      const schemaDescription = schemaObject.description;
-      let splitDescription: any;
-      if (schemaDescription) {
-        splitDescription = schemaDescription.match(/[^\r\n]+/g);
-      }
+        const schemaDescription = schemaObject.description;
+        let splitDescription: any;
+        if (schemaDescription) {
+          splitDescription = schemaDescription.match(/[^\r\n]+/g);
+        }
 
-      const schemaPage: PartialPage<SchemaPageMetadata> = {
-        type: "schema",
-        id: baseId,
-        infoId: infoId ?? "",
-        unversionedId: baseId,
-        title: schemaObject.title
-          ? schemaObject.title.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
-          : schema,
-        description: schemaObject.description
-          ? schemaObject.description.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
-          : "",
-        frontMatter: {
-          description: splitDescription
-            ? splitDescription[0]
-                .replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
-                .replace(/\s+$/, "")
+        const schemaPage: PartialPage<SchemaPageMetadata> = {
+          type: "schema",
+          id: baseId,
+          infoId: infoId ?? "",
+          unversionedId: baseId,
+          title: schemaObject.title
+            ? schemaObject.title.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
+            : schema,
+          description: schemaObject.description
+            ? schemaObject.description.replace(
+                /((?:^|[^\\])(?:\\{2})*)"/g,
+                "$1'"
+              )
             : "",
-        },
-        schema: schemaObject,
-      };
+          frontMatter: {
+            description: splitDescription
+              ? splitDescription[0]
+                  .replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'")
+                  .replace(/\s+$/, "")
+              : "",
+          },
+          schema: schemaObject,
+        };
 
-      items.push(schemaPage);
+        items.push(schemaPage);
+      }
     }
   }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -352,6 +352,7 @@ export type SchemaObject = Omit<
   externalDocs?: ExternalDocumentationObject;
   example?: any;
   deprecated?: boolean;
+  "x-tags"?: string[];
 };
 
 export type SchemaObjectWithRef = Omit<

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -237,7 +237,9 @@ function groupByTags(
         label: "Schemas",
         collapsible: sidebarCollapsible!,
         collapsed: sidebarCollapsed!,
-        items: schemaItems.map(createDocItem),
+        items: schemaItems
+          .filter(({ schema }) => !schema["x-tags"])
+          .map(createDocItem),
       },
     ];
   }

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -48,7 +48,7 @@ function groupByTags(
   tags: TagObject[][],
   docPath: string
 ): ProcessedSidebar {
-  let { outputDir, label } = options;
+  let { outputDir, label, showSchemas } = options;
 
   // Remove trailing slash before proceeding
   outputDir = outputDir.replace(/\/$/, "");
@@ -184,15 +184,20 @@ function groupByTags(
         } as SidebarItemCategoryLinkConfig;
       }
 
+      const taggedApiItems = apiItems.filter(
+        (item) => !!item.api.tags?.includes(tag)
+      );
+      const taggedSchemaItems = schemaItems.filter(
+        (item) => !!item.schema["x-tags"]?.includes(tag)
+      );
+
       return {
         type: "category" as const,
         label: tagObject?.["x-displayName"] ?? tag,
         link: linkConfig,
         collapsible: sidebarCollapsible,
         collapsed: sidebarCollapsed,
-        items: apiItems
-          .filter((item) => !!item.api.tags?.includes(tag))
-          .map(createDocItem),
+        items: [...taggedSchemaItems, ...taggedApiItems].map(createDocItem),
       };
     })
     .filter((item) => item.items.length > 0); // Filter out any categories with no items.
@@ -217,7 +222,7 @@ function groupByTags(
   }
 
   let schemas: SidebarItemCategory[] = [];
-  if (schemaItems.length > 0) {
+  if (showSchemas && schemaItems.length > 0) {
     schemas = [
       {
         type: "category" as const,

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -78,17 +78,22 @@ function groupByTags(
       .flatMap((item) => item.api.tags)
       .filter((item): item is string => !!item)
   );
+  const schemaTags = uniq(
+    schemaItems
+      .flatMap((item) => item.schema["x-tags"])
+      .filter((item): item is string => !!item)
+  );
 
-  // Combine globally defined tags with operation tags
-  // Only include global tag if referenced in operation tags
+  // Combine globally defined tags with operation and schema tags
+  // Only include global tag if referenced in operation/schema tags
   let apiTags: string[] = [];
   tags.flat().forEach((tag) => {
     // Should we also check x-displayName?
-    if (operationTags.includes(tag.name!)) {
+    if (operationTags.includes(tag.name!) || schemaTags.includes(tag.name!)) {
       apiTags.push(tag.name!);
     }
   });
-  apiTags = uniq(apiTags.concat(operationTags));
+  apiTags = uniq(apiTags.concat(operationTags, schemaTags));
 
   const basePath = docPath
     ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -108,9 +108,12 @@ function groupByTags(
             },
             item.api.method
           )
-        : clsx({
-            "menu__list-item--deprecated": item.schema.deprecated,
-          });
+        : clsx(
+            {
+              "menu__list-item--deprecated": item.schema.deprecated,
+            },
+            "schema"
+          );
     return {
       type: "doc" as const,
       id: basePath === "" || undefined ? `${id}` : `${basePath}/${id}`,

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -25,6 +25,7 @@ import type {
   APIOptions,
   ApiPageMetadata,
   ApiMetadata,
+  InfoPageMetadata,
   SchemaPageMetadata,
 } from "../types";
 
@@ -41,7 +42,7 @@ function isSchemaItem(item: ApiMetadata): item is ApiMetadata {
 }
 
 function groupByTags(
-  items: ApiPageMetadata[],
+  items: ApiMetadata[],
   sidebarOptions: SidebarOptions,
   options: APIOptions,
   tags: TagObject[][],
@@ -59,9 +60,9 @@ function groupByTags(
     categoryLinkSource,
   } = sidebarOptions;
 
-  const apiItems = items.filter(isApiItem);
-  const infoItems = items.filter(isInfoItem);
-  const schemaItems = items.filter(isSchemaItem);
+  const apiItems = items.filter(isApiItem) as ApiPageMetadata[];
+  const infoItems = items.filter(isInfoItem) as InfoPageMetadata[];
+  const schemaItems = items.filter(isSchemaItem) as SchemaPageMetadata[];
   const intros = infoItems.map((item: any) => {
     return {
       id: item.id,
@@ -263,7 +264,7 @@ export default function generateSidebarSlice(
         collapsible: true,
         collapsed: true,
         items: groupByTags(
-          api as ApiPageMetadata[],
+          api,
           sidebarOptions,
           options,
           [filteredTags],
@@ -274,13 +275,7 @@ export default function generateSidebarSlice(
       sidebarSlice.push(groupCategory);
     });
   } else if (sidebarOptions.groupPathsBy === "tag") {
-    sidebarSlice = groupByTags(
-      api as ApiPageMetadata[],
-      sidebarOptions,
-      options,
-      tags,
-      docPath
-    );
+    sidebarSlice = groupByTags(api, sidebarOptions, options, tags, docPath);
   }
 
   return sidebarSlice;


### PR DESCRIPTION
## Description

This change enables schemas to have `x-tags` defined for them, which allows them to be grouped alongside related path objects when `sidebarOptions.groupPathsBy: 'tag'` is configured.

## Motivation and Context

In reporting the unexpected behavior in #836, I began poking around and discovered [the `x-tags` extension by redocly](https://redocly.com/docs/api-reference-docs/specification-extensions/x-tags/). It seems like a useful feature, and was easy enough to get working.

It's intended (by redocly, and so here) that it's a "competing" option for configuring `showSchemas: true`, which is why you'll see some changes to the checks/logic in `openapi/openapi.ts` surrounding if/when to add schema objects to the sidebar slice.

## How Has This Been Tested?

Tested this on my local computer, using the demo app. I've added (only locally, I think) `x-tags` to a few of the defined schemas, and made sure they show up where they belong.

## Screenshots (if appropriate)

![Screenshot 2024-06-12 at 1 51 12 PM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/2024293/2f018c37-b997-47b1-bba6-3ba1c6a444e4)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
