### PR TITLE
Fix - @theme/ApiItem causes undesired website-wide style changes

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -189,7 +189,7 @@ export default function ApiItem(props: Props): JSX.Element {
         <DocItemMetadata />
         <DocItemLayout>
           <div className="row">
-            <div className="col col--12">
+            <div className="col col--12 markdown">
               <MDXComponent />
             </div>
           </div>


### PR DESCRIPTION
## Description

Adding `docItemComponent: "@theme/ApiItem"` in the docusaurus config causes undesired behavior in the website, including pages that are completely unrelated to the api.

After investigation, it seems that the main div in each page is missing the `markdown` classname, causing the following changes in all pages of the site:
1. My `h2` headers change size.
2. My `h2` headers' margins change.

If I inspect the page, and add the `markdown` classname to the div, the original styling is applied and all is good.

## Motivation and Context

This issue affects the styling of the entire docusaurus website, including pages that are unrelated to the api.

## How Has This Been Tested?

Tested using Docusaurus V3, using the latest V3 beta of this library.

## Screenshots
Here is what the site looks like **without** the library:
![Screenshot 2024-05-22 at 14 21 56](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/96784606/48cc64af-2fb0-4d84-910e-2cee9ae85ccf)
<br/>
Here is what the site looks like **with** the library (note the changed header size and missing margin-top):
![Screenshot 2024-05-22 at 14 21 13](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/96784606/86fa4a0a-15db-4666-90e5-216dfaa845f5)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
