### PR TITLE
Transparent background when displaying response placeholder

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -88,7 +88,10 @@ function Response({ item }: { item: NonNullable<ApiItem> }) {
       </div>
       <div
         style={{
-          backgroundColor: prismTheme.plain.backgroundColor,
+          backgroundColor:
+            code && prettyResponse !== "Fetching..."
+              ? prismTheme.plain.backgroundColor
+              : "transparent",
           paddingLeft: "1rem",
           paddingTop: "1rem",
           ...((prettyResponse === "Fetching..." || !code) && {


### PR DESCRIPTION
## Description

Before: 

![Screenshot 2024-06-24 at 11 32 04 AM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/9343811/a235ab95-d5b8-4214-8934-e01836d8fb24)

After:

![Screenshot 2024-06-24 at 11 32 45 AM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/9343811/0f9b941d-7780-4a2a-93f2-d133b7b42ef4)
