### PR TITLE
Support empty object schemas

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createRequestSchema.ts
@@ -108,12 +108,6 @@ export function createRequestSchema({ title, body, ...rest }: Props) {
     return undefined;
   }
 
-  // we don't show the table if there is no properties to show
-  if (firstBody.properties !== undefined) {
-    if (Object.keys(firstBody.properties).length === 0) {
-      return undefined;
-    }
-  }
   return create("MimeTabs", {
     className: "openapi-tabs__mime",
     children: [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createResponseSchema.ts
@@ -60,12 +60,6 @@ export function createResponseSchema({ title, body, ...rest }: Props) {
           return undefined;
         }
 
-        if (firstBody?.properties !== undefined) {
-          if (Object.keys(firstBody?.properties).length === 0) {
-            return undefined;
-          }
-        }
-
         return create("TabItem", {
           label: `${mimeType}`,
           value: `${mimeType}`,

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -129,6 +129,16 @@ function createAnyOneOf(schema: SchemaObject): any {
  */
 function createProperties(schema: SchemaObject) {
   const discriminator = schema.discriminator;
+  if (Object.keys(schema.properties!).length === 0) {
+    return create("SchemaItem", {
+      collapsible: false,
+      name: "",
+      required: false,
+      schemaName: "object",
+      qualifierMessage: undefined,
+      schema: {},
+    });
+  }
   return Object.entries(schema.properties!).map(([key, val]) => {
     return createEdges({
       name: key,


### PR DESCRIPTION
## Description

Addresses #813 

Effectively adds support for empty object schemas. Tested in both request and response including schema items.