### PR TITLE
Fix tagGroup display when showSchemas is configured

### DIFF
--- a/demo/docs/sidebars.md
+++ b/demo/docs/sidebars.md
@@ -57,6 +57,8 @@ The OpenAPI docs plugin provides out-of-the-box support for grouping paths by "t
 What this means is that the plugin will automatically generate a sidebar slice using the first path group as the "group by" value and the path itself as one of the `tags` under that category.
 Use `x-tagGroups` to group tags in the [Reference](https://redocly.com/docs/api-reference-docs/specification-extensions/x-tag-groups/) docs navigation sidebar. Add it to the root OpenAPI object.
 
+If `x-tagGroups` is used for grouping API paths, and you've also configured `showSchemas: true` for your OpenAPI Docs plugin, an additional "sibling" category labelled `Schemas` will be created and placed at the end of sidebar, after all the `tagGroups` categories.
+
 ### Category Links
 
 Docusaurus now supports the ability to designate or customize what page gets displayed when a category is clicked.

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -263,6 +263,7 @@ const config = {
             sidebarOptions: {
               groupPathsBy: "tagGroup",
             },
+            showSchemas: true,
           },
         },
       },

--- a/demo/examples/food/restaurant/openapi.yaml
+++ b/demo/examples/food/restaurant/openapi.yaml
@@ -43,6 +43,17 @@ paths:
         200:
           description: OK
 
+components:
+  schemas:
+    Payment:
+      type: object
+      properties:
+        amount:
+          type: number
+        method:
+          type: string
+          enum: [cash, card, check]
+
 tags:
   - name: tag1
     description: Everything about your restaurant

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -264,6 +264,7 @@ export default function generateSidebarSlice(
   let sidebarSlice: ProcessedSidebar = [];
 
   if (sidebarOptions.groupPathsBy === "tagGroup") {
+    let schemasGroup: ProcessedSidebar = [];
     tagGroups?.forEach((tagGroup) => {
       //filter tags only included in group
       const filteredTags: TagObject[] = [];
@@ -285,10 +286,24 @@ export default function generateSidebarSlice(
           [filteredTags],
           docPath
         ),
-      } as ProcessedSidebarItem;
+      };
 
-      sidebarSlice.push(groupCategory);
+      if (options.showSchemas) {
+        // For the first tagGroup, save the generated "Schemas" category for later.
+        if (schemasGroup.length === 0) {
+          schemasGroup = groupCategory.items?.filter(
+            (item) => item.type === "category" && item.label === "Schemas"
+          );
+        }
+        // Remove the "Schemas" category from every `groupCategory`.
+        groupCategory.items = groupCategory.items.filter((item) =>
+          "label" in item ? item.label !== "Schemas" : true
+        );
+      }
+      sidebarSlice.push(groupCategory as ProcessedSidebarItem);
     });
+    // Add `schemasGroup` to the end of the sidebar.
+    sidebarSlice.push(...schemasGroup);
   } else if (sidebarOptions.groupPathsBy === "tag") {
     sidebarSlice = groupByTags(api, sidebarOptions, options, tags, docPath);
   }


### PR DESCRIPTION
## Description

The `groupByTags()` function in `sidebars/index.ts` is already generating the Schemas category for both `groupBy: "tag"` and `groupBy: "tagGroup"`. It seems like the simplest, least disruptive way of accomplishing what I wanted was to utilize the Schemas category _after_ `groupByTags()` was finished going through all the tagGroups.

In the case of tagGroups, now, it moves the "Schemas" category (if any) from the first tagGroup category (since all the schema categories are identical anyway) to the end of the sidebar, as a "sibling" to all the tagGroup categories. Then, it discards the "Schemas" category from _all_ of the tagGroup categories.

## Motivation and Context

As reported in #836, an extra Schemas category is currently placed inside ever tagGroup category if `showSchemas: true` is configured. This PR aims resolve this.

## How Has This Been Tested?

Visibly in this PR, I've added a schema object to the Restaurant example API, and configured it with `showSchemas: true`. Additionally, I have (locally) tested this out with the `tagGroup`ed API spec that I initially noticed the bug with.

## Screenshots (if appropriate)

![Screenshot 2024-06-26 at 4 06 31 PM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/2024293/f19cbe43-0150-45ee-bd42-24625a38b318)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes if appropriate.~~ I couldn't quite figure out where to place a relevant test. None of the existing ones looked like they were applicable to this kind of fix.
- [x] All new and existing tests passed.

