### PR TITLE
[V3] Avoid concatenating all tags when grouped by tagGroups

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -93,7 +93,10 @@ function groupByTags(
       apiTags.push(tag.name!);
     }
   });
-  apiTags = uniq(apiTags.concat(operationTags, schemaTags));
+
+  if (sidebarOptions.groupPathsBy !== "tagGroup") {
+    apiTags = uniq(apiTags.concat(operationTags, schemaTags));
+  }
 
   const basePath = docPath
     ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")


### PR DESCRIPTION
## Description

Before concatenating the `apiTags`, `operationTags`, and `schemaTags`, the `sidebars/index.ts` file now checks to make sure that `gropuPathsBy` is not "tagGroup." This prevents the undesired tag categories from being added to the tagGroup category.

## Motivation and Context

As reported in #792, using `groupBy: "tagGroups"` still leaves the sidebar with extra, undesired tags categories inside each tagGroup category. This PR resolves that, in the v3 branch.

## How Has This Been Tested?

Locally, I've inspected the running dev site. I've run `yarn test`, and everything still passes. 

## Screenshots (if appropriate)

![Screenshot 2024-06-26 at 4 56 48 PM](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/assets/2024293/703a8b67-c20b-4221-8987-3901c65bb95b)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
