### PR TITLE
[Chore] Update readme for 3.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,13 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `versions` can be configured with the following options:
 
-| Name       | Type     | Default | Description                                                                                                              |
-| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `specPath` | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
-| `ouputDir` | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
-| `label`    | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
-| `baseUrl`  | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
+| Name          | Type     | Default | Description                                                                                                              |
+| ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `specPath`    | `string` | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of micro OpenAPI specification files. |
+| `ouputDir`    | `string` | `null`  | Desired output path for versioned, generated MDX files.                                                                  |
+| `label`       | `string` | `null`  | _Optional:_ Version label used when generating version selector dropdown menu.                                           |
+| `baseUrl`     | `string` | `null`  | _Optional:_ Version base URL used when generating version selector dropdown menu.                                        |
+| `downloadUrl` | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification for versioned.                                          |
 
 > All versions will automatically inherit `sidebarOptions` from the parent/base config.
 


### PR DESCRIPTION
## Description

Update Readme.md file about missing configuration in the versioned section.

## Motivation and Context

Update documentation to markdown the changes.

## How Has This Been Tested?

N/A


## Types of changes

Added a new row in versions configuration 
`| `downloadUrl` | `string` | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification for versioned.                                          |
`

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
