### PR TITLE
Check if the outputDir exists before attempting to create the version…

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -535,6 +535,18 @@ custom_edit_url: null
       });
     }
 
+    if (!fs.existsSync(outputDir)) {
+      try {
+        fs.mkdirSync(outputDir, { recursive: true });
+        console.log(chalk.green(`Successfully created "${outputDir}"`));
+      } catch (err) {
+        console.error(
+          chalk.red(`Failed to create "${outputDir}"`),
+          chalk.yellow(err)
+        );
+      }
+    }
+
     const versionsJson = JSON.stringify(versionsArray, null, 2);
     try {
       fs.writeFileSync(


### PR DESCRIPTION
…s.json file

## Description

When generating API specifications using the versioning configuration, there is not check if the directory exists like in the generateApiDocs function. This results in an error when creating the versions.json file.

## Motivation and Context

This change is required so that you can generate versioned docs without any issues.

## How Has This Been Tested?

I changed my version of the plugin locally and verified that this does in fact fix the issue. I generated versioned api docs and did not get the error after implementing this change.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
