### PR TITLE
Add the ability to add custom classes to api-method sidebar items

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -107,6 +107,18 @@ function groupByTags(
     const sidebar_label = item.frontMatter.sidebar_label;
     const title = item.title;
     const id = item.type === "schema" ? `schemas/${item.id}` : item.id;
+    interface classChecks  {
+      [key: string]: string;
+    }
+
+    let classNameConfig: classChecks = {}
+
+    if(customProps !== undefined) {
+        for (const [key, value] of Object.entries(customProps['additionalClassChecks'] as Object)) {
+          classNameConfig[key] = new Function('item', `return ${value}`)(item) as string; // Type assertion for the return value
+      }
+    }
+
     const className =
       item.type === "api"
         ? clsx(
@@ -114,6 +126,7 @@ function groupByTags(
               "menu__list-item--deprecated": item.api.deprecated,
               "api-method": !!item.api.method,
             },
+            classNameConfig,
             item.api.method
           )
         : clsx(


### PR DESCRIPTION
Add the ability to customize the sidebar class names based upon custom api specification criteria. This is a code change to implement https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/858.

This code allows you to use the customProps option within the sidebarOptions to specify custom spec criteria to enable class names.

Where the key is the class name to add and the value is the criteria check which will evaluate to true or false.

```json
{
    "sidebarOptions": {
        "groupPathsBy": "tag",
        "categoryLinkSource": "tag",
        "customProps": {
            "additionalClassChecks": {
                "menu__list-item--experimental": "!!item.api.parameters?.find(header => header.name === 'X-SailPoint-Experimental')"
            }
        }
    }
}
```

Feel free to change the names of variables or config items.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/858.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in my local environment off of the latest main branch of this plugin.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
