### PR TITLE
Ensure allOf and properties are merged into SchemaObject

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -7,7 +7,7 @@
 
 import * as prettier from "prettier";
 
-import { createNodes } from "./createSchema";
+import { createNodes, mergeAllOf } from "./createSchema";
 import { SchemaObject } from "../openapi/types";
 
 describe("createNodes", () => {
@@ -142,5 +142,56 @@ describe("createNodes", () => {
         ).toMatchSnapshot();
       }
     );
+  });
+});
+
+describe("mergeAllOf", () => {
+  it("merges the parent schema properties into the allOf properties", () => {
+    const schema: SchemaObject = {
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            allOfProp1: {
+              type: "string",
+            },
+            allOfProp2: {
+              type: "string",
+            },
+          },
+        },
+      ],
+      properties: {
+        parentProp1: {
+          type: "string",
+        },
+        parentProp2: {
+          type: "string",
+        },
+      },
+    };
+
+    const { mergedSchemas } = mergeAllOf(
+      schema.allOf as SchemaObject[],
+      schema as SchemaObject
+    );
+
+    expect(mergedSchemas).toStrictEqual({
+      type: "object",
+      properties: {
+        allOfProp1: {
+          type: "string",
+        },
+        allOfProp2: {
+          type: "string",
+        },
+        parentProp1: {
+          type: "string",
+        },
+        parentProp2: {
+          type: "string",
+        },
+      },
+    });
   });
 });

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -67,7 +67,8 @@ function sampleRequestFromProp(name: string, prop: any, obj: any): any {
     obj[name] = sampleRequestFromSchema(prop.anyOf[0]);
   } else if (prop.allOf) {
     const { mergedSchemas }: { mergedSchemas: SchemaObject } = mergeAllOf(
-      prop.allOf
+      prop.allOf,
+      prop
     );
     sampleRequestFromProp(name, mergedSchemas, obj);
   } else {
@@ -107,8 +108,10 @@ export const sampleRequestFromSchema = (schema: SchemaObject = {}): any => {
     }
 
     if (allOf) {
-      const { mergedSchemas }: { mergedSchemas: SchemaObject } =
-        mergeAllOf(allOf);
+      const { mergedSchemas }: { mergedSchemas: SchemaObject } = mergeAllOf(
+        allOf,
+        schema
+      );
       if (mergedSchemas.properties) {
         for (const [key, value] of Object.entries(mergedSchemas.properties)) {
           if ((value.readOnly && value.readOnly === true) || value.deprecated) {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -67,7 +67,8 @@ function sampleResponseFromProp(name: string, prop: any, obj: any): any {
     obj[name] = sampleResponseFromSchema(prop.anyOf[0]);
   } else if (prop.allOf) {
     const { mergedSchemas }: { mergedSchemas: SchemaObject } = mergeAllOf(
-      prop.allOf
+      prop.allOf,
+      prop
     );
     sampleResponseFromProp(name, mergedSchemas, obj);
   } else {
@@ -87,8 +88,10 @@ export const sampleResponseFromSchema = (schema: SchemaObject = {}): any => {
     }
 
     if (allOf) {
-      const { mergedSchemas }: { mergedSchemas: SchemaObject } =
-        mergeAllOf(allOf);
+      const { mergedSchemas }: { mergedSchemas: SchemaObject } = mergeAllOf(
+        allOf,
+        schemaCopy
+      );
       if (mergedSchemas.properties) {
         for (const [key, value] of Object.entries(mergedSchemas.properties)) {
           if (


### PR DESCRIPTION
## Description

Ensures that `schema.allOf` and `schema.properties` are merged together in the createSchema method. See linked issue below for more information

## Motivation and Context

Fixes https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/902

## How Has This Been Tested?

Tests have been added, I've also run gen-all on the demo repo with the new changes and everything compiles successfully

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
