### PR TITLE
Ensure same-level properties and allOf are rendered 

### DIFF
--- a/demo/docusaurus.config.ts
+++ b/demo/docusaurus.config.ts
@@ -71,6 +71,10 @@ const config: Config = {
               label: "Petstore (versioned)",
               to: "/category/petstore-versioned-api",
             },
+            {
+              label: "Tests",
+              to: "/category/tests",
+            },
           ],
         },
         {
@@ -266,6 +270,16 @@ const config: Config = {
             sidebarOptions: {
               groupPathsBy: "tagGroup",
             },
+            showSchemas: true,
+          } satisfies OpenApiPlugin.Options,
+          tests: {
+            specPath: "examples/tests",
+            outputDir: "docs/tests",
+            sidebarOptions: {
+              groupPathsBy: "tag",
+              categoryLinkSource: "info",
+            },
+            hideSendButton: true,
             showSchemas: true,
           } satisfies OpenApiPlugin.Options,
         } satisfies Plugin.PluginOptions,

--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -200,43 +200,43 @@ paths:
                           innerProp2:
                             type: number
 
-  /allof-discriminator:
-    get:
-      tags:
-        - allOf
-      summary: allOf with Discriminator
-      description: |
-        Schema:
-        ```yaml
-        allOf:
-          - type: object
-            discriminator:
-              propertyName: type
-            properties:
-              type:
-                type: string
-          - type: object
-            properties:
-              specificProp:
-                type: string
-        ```
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - type: object
-                    discriminator:
-                      propertyName: type
-                    properties:
-                      type:
-                        type: string
-                  - type: object
-                    properties:
-                      specificProp:
-                        type: string
+  # /allof-discriminator:
+  #   get:
+  #     tags:
+  #       - allOf
+  #     summary: allOf with Discriminator
+  #     description: |
+  #       Schema:
+  #       ```yaml
+  #       allOf:
+  #         - type: object
+  #           discriminator:
+  #             propertyName: type
+  #           properties:
+  #             type:
+  #               type: string
+  #         - type: object
+  #           properties:
+  #             specificProp:
+  #               type: string
+  #       ```
+  #     responses:
+  #       "200":
+  #         description: Successful response
+  #         content:
+  #           application/json:
+  #             schema:
+  #               allOf:
+  #                 - type: object
+  #                   discriminator:
+  #                     propertyName: type
+  #                   properties:
+  #                     type:
+  #                       type: string
+  #                 - type: object
+  #                   properties:
+  #                     specificProp:
+  #                       type: string
 
   /allof-same-level-properties:
     get:

--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -1,0 +1,279 @@
+openapi: 3.0.1
+info:
+  title: AllOf Variations API
+  description: Demonstrates various allOf schema combinations.
+  version: 1.0.0
+paths:
+  /multiple-allof-nested:
+    get:
+      tags:
+        - allOf
+      summary: Multiple allOf with Nested Properties
+      description: |
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            properties:
+              outerProp1:
+                type: object
+                properties:
+                  innerProp1:
+                    type: string
+          - type: object
+            properties:
+              outerProp2:
+                type: object
+                properties:
+                  innerProp2:
+                    type: number
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      outerProp1:
+                        type: object
+                        properties:
+                          innerProp1:
+                            type: string
+                  - type: object
+                    properties:
+                      outerProp2:
+                        type: object
+                        properties:
+                          innerProp2:
+                            type: number
+
+  /allof-shared-required:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Shared Required Properties
+      description: |
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            properties:
+              sharedProp:
+                type: string
+            required: [sharedProp]
+          - type: object
+            properties:
+              anotherProp:
+                type: number
+            required: [anotherProp]
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      sharedProp:
+                        type: string
+                    required: [sharedProp]
+                  - type: object
+                    properties:
+                      anotherProp:
+                        type: number
+                    required: [anotherProp]
+
+  # /allof-conflicting-properties:
+  #   get:
+  #     tags:
+  #       - allOf
+  #     summary: allOf with Conflicting Properties
+  #     description: |
+  #       Schema:
+  #       ```yaml
+  #       allOf:
+  #         - type: object
+  #           properties:
+  #             conflictingProp:
+  #               type: string
+  #         - type: object
+  #           properties:
+  #             conflictingProp:
+  #               type: number
+  #       ```
+  #     responses:
+  #       '200':
+  #         description: Successful response
+  #         content:
+  #           application/json:
+  #             schema:
+  #               allOf:
+  #                 - type: object
+  #                   properties:
+  #                     conflictingProp:
+  #                       type: string
+  #                 - type: object
+  #                   properties:
+  #                     conflictingProp:
+  #                       type: number
+
+  # /allof-mixed-data-types:
+  #   get:
+  #     tags:
+  #       - allOf
+  #     summary: allOf with Mixed Data Types
+  #     description: |
+  #       Schema:
+  #       ```yaml
+  #       allOf:
+  #         - type: object
+  #           properties:
+  #             mixedTypeProp1:
+  #               type: string
+  #         - type: array
+  #           items:
+  #             type: number
+  #       ```
+  #     responses:
+  #       '200':
+  #         description: Successful response
+  #         content:
+  #           application/json:
+  #             schema:
+  #               allOf:
+  #                 - type: object
+  #                   properties:
+  #                     mixedTypeProp1:
+  #                       type: string
+  #                 - type: array
+  #                   items:
+  #                     type: number
+
+  /allof-deep-merging:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Deep Merging
+      description: |
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            properties:
+              deepProp:
+                type: object
+                properties:
+                  innerProp1:
+                    type: string
+          - type: object
+            properties:
+              deepProp:
+                type: object
+                properties:
+                  innerProp2:
+                    type: number
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      deepProp:
+                        type: object
+                        properties:
+                          innerProp1:
+                            type: string
+                  - type: object
+                    properties:
+                      deepProp:
+                        type: object
+                        properties:
+                          innerProp2:
+                            type: number
+
+  /allof-discriminator:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Discriminator
+      description: |
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            discriminator:
+              propertyName: type
+            properties:
+              type:
+                type: string
+          - type: object
+            properties:
+              specificProp:
+                type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    discriminator:
+                      propertyName: type
+                    properties:
+                      type:
+                        type: string
+                  - type: object
+                    properties:
+                      specificProp:
+                        type: string
+
+  /allof-same-level-properties:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Same-Level Properties
+      description: |
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            properties:
+              allOfProp1:
+                type: string
+              allOfProp2:
+                type: string
+        properties:
+          parentProp1:
+            type: string
+          parentProp2:
+            type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      allOfProp1:
+                        type: string
+                      allOfProp2:
+                        type: string
+                properties:
+                  parentProp1:
+                    type: string
+                  parentProp2:
+                    type: string

--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -3,6 +3,9 @@ info:
   title: AllOf Variations API
   description: Demonstrates various allOf schema combinations.
   version: 1.0.0
+tags:
+  - name: allOf
+    description: allOf tests
 paths:
   /multiple-allof-nested:
     get:

--- a/demo/sidebars.ts
+++ b/demo/sidebars.ts
@@ -170,6 +170,20 @@ const sidebars: SidebarsConfig = {
       items: petstoreVersionSidebar,
     },
   ],
+
+  tests: [
+    {
+      type: "category",
+      label: "Tests",
+      link: {
+        type: "generated-index",
+        title: "Tests",
+        description: "Various OpenAPI test cases",
+        slug: "/category/tests",
+      },
+      items: require("./docs/tests/sidebar.js"),
+    },
+  ],
 };
 
 export default sidebars;

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -223,6 +223,110 @@ Array [
 ]
 `;
 
+exports[`createNodes allOf should correctly deep merge properties in allOf schemas 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>deepProp</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"innerProp1\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"innerProp2\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes allOf should correctly handle shared required properties across allOf schemas 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"sharedProp\\"}
+  required={true}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"anotherProp\\"}
+  required={true}
+  schemaName={\\"number\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"number\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes allOf should correctly merge nested properties from multiple allOf schemas 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>outerProp1</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"innerProp1\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </div>
+  </details>
+</SchemaItem>;
+",
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>outerProp2</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"innerProp2\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;
+
 exports[`createNodes allOf should render same-level properties with allOf 1`] = `
 Array [
   "<SchemaItem

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -223,7 +223,48 @@ Array [
 ]
 `;
 
-exports[`createNodes should create readable MODs for oneOf primitive properties 1`] = `
+exports[`createNodes allOf should render same-level properties with allOf 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"parentProp1\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"parentProp2\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"allOfProp1\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"allOfProp2\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes oneOf should create readable MODs for oneOf primitive properties 1`] = `
 Array [
   "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
   <details style={{}} className={\\"openapi-markdown__details\\"}>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -93,6 +93,221 @@ describe("createNodes", () => {
         )
       ).toMatchSnapshot();
     });
+
+    it("should correctly merge nested properties from multiple allOf schemas", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              outerProp1: {
+                type: "object",
+                properties: {
+                  innerProp1: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              outerProp2: {
+                type: "object",
+                properties: {
+                  innerProp2: {
+                    type: "number",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should correctly handle shared required properties across allOf schemas", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              sharedProp: {
+                type: "string",
+              },
+            },
+            required: ["sharedProp"],
+          },
+          {
+            type: "object",
+            properties: {
+              anotherProp: {
+                type: "number",
+              },
+            },
+            required: ["anotherProp"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    // Could not resolve values for path:"properties.conflictingProp.type". They are probably incompatible. Values:
+    // "string"
+    // "number"
+    // it("should handle conflicting properties in allOf schemas", async () => {
+    //   const schema: SchemaObject = {
+    //     allOf: [
+    //       {
+    //         type: "object",
+    //         properties: {
+    //           conflictingProp: {
+    //             type: "string",
+    //           },
+    //         },
+    //       },
+    //       {
+    //         type: "object",
+    //         properties: {
+    //           conflictingProp: {
+    //             type: "number",
+    //           },
+    //         },
+    //       },
+    //     ],
+    //   };
+
+    //   expect(
+    //     await Promise.all(
+    //       createNodes(schema, "response").map(
+    //         async (md: any) => await prettier.format(md, { parser: "babel" })
+    //       )
+    //     )
+    //   ).toMatchSnapshot();
+    // });
+
+    // Could not resolve values for path:"type". They are probably incompatible. Values:
+    // "object"
+    // "array"
+    // it("should handle mixed data types in allOf schemas", async () => {
+    //   const schema: SchemaObject = {
+    //     allOf: [
+    //       {
+    //         type: "object",
+    //         properties: {
+    //           mixedTypeProp1: {
+    //             type: "string",
+    //           },
+    //         },
+    //       },
+    //       {
+    //         type: "array",
+    //         items: {
+    //           type: "number",
+    //         },
+    //       },
+    //     ],
+    //   };
+
+    //   expect(
+    //     await Promise.all(
+    //       createNodes(schema, "response").map(
+    //         async (md: any) => await prettier.format(md, { parser: "babel" })
+    //       )
+    //     )
+    //   ).toMatchSnapshot();
+    // });
+
+    it("should correctly deep merge properties in allOf schemas", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              deepProp: {
+                type: "object",
+                properties: {
+                  innerProp1: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              deepProp: {
+                type: "object",
+                properties: {
+                  innerProp2: {
+                    type: "number",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    // it("should handle discriminator with allOf schemas", async () => {
+    //   const schema: SchemaObject = {
+    //     allOf: [
+    //       {
+    //         type: "object",
+    //         discriminator: {
+    //           propertyName: "type",
+    //         },
+    //         properties: {
+    //           type: {
+    //             type: "string",
+    //           },
+    //         },
+    //       },
+    //       {
+    //         type: "object",
+    //         properties: {
+    //           specificProp: {
+    //             type: "string",
+    //           },
+    //         },
+    //       },
+    //     ],
+    //   };
+
+    //   expect(
+    //     await Promise.all(
+    //       createNodes(schema, "response").map(
+    //         async (md: any) => await prettier.format(md, { parser: "babel" })
+    //       )
+    //     )
+    //   ).toMatchSnapshot();
+    // });
   });
 
   describe("additionalProperties", () => {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -11,50 +11,88 @@ import { createNodes } from "./createSchema";
 import { SchemaObject } from "../openapi/types";
 
 describe("createNodes", () => {
-  it("should create readable MODs for oneOf primitive properties", async () => {
-    const schema: SchemaObject = {
-      "x-tags": ["clown"],
-      type: "object",
-      properties: {
-        oneOfProperty: {
-          oneOf: [
-            {
-              type: "object",
-              properties: {
-                noseLength: {
-                  type: "number",
+  describe("oneOf", () => {
+    it("should create readable MODs for oneOf primitive properties", async () => {
+      const schema: SchemaObject = {
+        "x-tags": ["clown"],
+        type: "object",
+        properties: {
+          oneOfProperty: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  noseLength: {
+                    type: "number",
+                  },
                 },
+                required: ["noseLength"],
+                description: "Clown's nose length",
               },
-              required: ["noseLength"],
-              description: "Clown's nose length",
-            },
-            {
-              type: "array",
-              items: {
+              {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+                description: "Array of strings",
+              },
+              {
+                type: "boolean",
+              },
+              {
+                type: "number",
+              },
+              {
                 type: "string",
               },
-              description: "Array of strings",
-            },
-            {
-              type: "boolean",
-            },
-            {
-              type: "number",
-            },
-            {
-              type: "string",
-            },
-          ],
+            ],
+          },
         },
-      },
-    };
-    expect(
-      await Promise.all(
-        createNodes(schema, "request").map(
-          async (md: any) => await prettier.format(md, { parser: "babel" })
+      };
+      expect(
+        await Promise.all(
+          createNodes(schema, "request").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
         )
-      )
-    ).toMatchSnapshot();
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("allOf", () => {
+    it("should render same-level properties with allOf", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              allOfProp1: {
+                type: "string",
+              },
+              allOfProp2: {
+                type: "string",
+              },
+            },
+          },
+        ],
+        properties: {
+          parentProp1: {
+            type: "string",
+          },
+          parentProp2: {
+            type: "string",
+          },
+        },
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
   });
 
   describe("additionalProperties", () => {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -171,6 +171,7 @@ describe("createNodes", () => {
     // Could not resolve values for path:"properties.conflictingProp.type". They are probably incompatible. Values:
     // "string"
     // "number"
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it("should handle conflicting properties in allOf schemas", async () => {
     //   const schema: SchemaObject = {
     //     allOf: [
@@ -205,6 +206,7 @@ describe("createNodes", () => {
     // Could not resolve values for path:"type". They are probably incompatible. Values:
     // "object"
     // "array"
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it("should handle mixed data types in allOf schemas", async () => {
     //   const schema: SchemaObject = {
     //     allOf: [
@@ -275,6 +277,7 @@ describe("createNodes", () => {
       ).toMatchSnapshot();
     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it("should handle discriminator with allOf schemas", async () => {
     //   const schema: SchemaObject = {
     //     allOf: [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -615,6 +615,7 @@ function createEdges({
   }
 
   const schemaName = getSchemaName(schema);
+
   if (discriminator !== undefined && discriminator.propertyName === name) {
     return createPropertyDiscriminator(
       name,
@@ -626,6 +627,47 @@ function createEdges({
   }
 
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
+    return createDetailsNode(
+      name,
+      schemaName,
+      schema,
+      required,
+      schema.nullable
+    );
+  }
+
+  if (schema.properties !== undefined) {
+    return createDetailsNode(
+      name,
+      schemaName,
+      schema,
+      required,
+      schema.nullable
+    );
+  }
+
+  if (schema.additionalProperties !== undefined) {
+    return createDetailsNode(
+      name,
+      schemaName,
+      schema,
+      required,
+      schema.nullable
+    );
+  }
+
+  // array of objects
+  if (schema.items?.properties !== undefined) {
+    return createDetailsNode(
+      name,
+      schemaName,
+      schema,
+      required,
+      schema.nullable
+    );
+  }
+
+  if (schema.items?.anyOf !== undefined || schema.items?.oneOf !== undefined) {
     return createDetailsNode(
       name,
       schemaName,
@@ -707,47 +749,6 @@ function createEdges({
     });
   }
 
-  if (schema.properties !== undefined) {
-    return createDetailsNode(
-      name,
-      schemaName,
-      schema,
-      required,
-      schema.nullable
-    );
-  }
-
-  if (schema.additionalProperties !== undefined) {
-    return createDetailsNode(
-      name,
-      schemaName,
-      schema,
-      required,
-      schema.nullable
-    );
-  }
-
-  // array of objects
-  if (schema.items?.properties !== undefined) {
-    return createDetailsNode(
-      name,
-      schemaName,
-      schema,
-      required,
-      schema.nullable
-    );
-  }
-
-  if (schema.items?.anyOf !== undefined || schema.items?.oneOf !== undefined) {
-    return createDetailsNode(
-      name,
-      schemaName,
-      schema,
-      required,
-      schema.nullable
-    );
-  }
-
   // primitives and array of non-objects
   return create("SchemaItem", {
     collapsible: false,
@@ -785,6 +786,24 @@ export function createNodes(
 
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
     nodes.push(createAnyOneOf(schema));
+    delete schema.oneOf;
+    delete schema.anyOf;
+  }
+
+  if (schema.properties !== undefined) {
+    nodes.push(createProperties(schema));
+    delete schema.properties;
+  }
+
+  if (schema.additionalProperties !== undefined) {
+    nodes.push(createAdditionalProperties(schema));
+    delete schema.additionalProperties;
+  }
+
+  // TODO: figure out how to handle array of objects
+  if (schema.items !== undefined) {
+    nodes.push(createItems(schema));
+    delete schema.items;
   }
 
   if (schema.allOf !== undefined) {
@@ -795,24 +814,14 @@ export function createNodes(
       mergedSchemas.anyOf !== undefined
     ) {
       nodes.push(createAnyOneOf(mergedSchemas));
+      delete mergedSchemas.oneOf;
+      delete mergedSchemas.anyOf;
     }
 
     if (mergedSchemas.properties !== undefined) {
       nodes.push(createProperties(mergedSchemas));
+      delete mergedSchemas.properties;
     }
-  }
-
-  if (schema.properties !== undefined) {
-    nodes.push(createProperties(schema));
-  }
-
-  if (schema.additionalProperties !== undefined) {
-    nodes.push(createAdditionalProperties(schema));
-  }
-
-  // TODO: figure out how to handle array of objects
-  if (schema.items !== undefined) {
-    nodes.push(createItems(schema));
   }
 
   if (nodes.length && nodes.length > 0) {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -786,24 +786,19 @@ export function createNodes(
 
   if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
     nodes.push(createAnyOneOf(schema));
-    delete schema.oneOf;
-    delete schema.anyOf;
   }
 
   if (schema.properties !== undefined) {
     nodes.push(createProperties(schema));
-    delete schema.properties;
   }
 
   if (schema.additionalProperties !== undefined) {
     nodes.push(createAdditionalProperties(schema));
-    delete schema.additionalProperties;
   }
 
   // TODO: figure out how to handle array of objects
   if (schema.items !== undefined) {
     nodes.push(createItems(schema));
-    delete schema.items;
   }
 
   if (schema.allOf !== undefined) {
@@ -814,13 +809,10 @@ export function createNodes(
       mergedSchemas.anyOf !== undefined
     ) {
       nodes.push(createAnyOneOf(mergedSchemas));
-      delete mergedSchemas.oneOf;
-      delete mergedSchemas.anyOf;
     }
 
     if (mergedSchemas.properties !== undefined) {
       nodes.push(createProperties(mergedSchemas));
-      delete mergedSchemas.properties;
     }
   }
 


### PR DESCRIPTION
## Description

Addresses #902 and proposed fix in #903. The root cause appeared to stem from the order in which same-level properties and allOf were being evaluated which led to the properties being ignored.

I added a small test to cover this case with plans to add coverage for additional variations in a later PR.