### PR TITLE
Render discriminator with no mapping as simply propert

### DIFF
--- a/demo/examples/tests/discriminator.yaml
+++ b/demo/examples/tests/discriminator.yaml
@@ -1,0 +1,487 @@
+openapi: 3.0.1
+info:
+  title: Discriminator Variations API
+  description: Demonstrates various discriminator schema combinations with and without mappings.
+  version: 1.0.0
+tags:
+  - name: discriminator
+    description: discriminator tests
+paths:
+  /discriminator-basic:
+    get:
+      tags:
+        - discriminator
+      summary: Basic Discriminator without Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseBasic"
+
+  /discriminator-nested:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Nested Schemas without Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/NestedTypeA'
+          - $ref: '#/components/schemas/NestedTypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseNested"
+
+  /discriminator-shared:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Shared Properties without Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+        properties:
+          type:
+            type: string
+          sharedProp:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseShared"
+
+  /discriminator-allof:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with AllOf without Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+        properties:
+          type:
+            type: string
+        allOf:
+          - oneOf:
+              - $ref: '#/components/schemas/TypeA'
+              - $ref: '#/components/schemas/TypeB'
+          - type: object
+            properties:
+              sharedProp:
+                type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseAllOf"
+
+  /discriminator-required:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Required Properties without Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseRequired"
+
+  /discriminator-basic-mapping:
+    get:
+      tags:
+        - discriminator
+      summary: Basic Discriminator with Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            typeA: "#/components/schemas/TypeA"
+            typeB: "#/components/schemas/TypeB"
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseBasicMapping"
+
+  /discriminator-nested-mapping:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Nested Schemas and Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            nestedTypeA: "#/components/schemas/NestedTypeA"
+            nestedTypeB: "#/components/schemas/NestedTypeB"
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/NestedTypeA'
+          - $ref: '#/components/schemas/NestedTypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseNestedMapping"
+
+  /discriminator-shared-mapping:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Shared Properties and Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            typeA: "#/components/schemas/TypeA"
+            typeB: "#/components/schemas/TypeB"
+        properties:
+          type:
+            type: string
+          sharedProp:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseSharedMapping"
+
+  /discriminator-allof-mapping:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with AllOf and Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            typeA: "#/components/schemas/TypeA"
+            typeB: "#/components/schemas/TypeB"
+        properties:
+          type:
+            type: string
+        allOf:
+          - oneOf:
+              - $ref: '#/components/schemas/TypeA'
+              - $ref: '#/components/schemas/TypeB'
+          - type: object
+            properties:
+              sharedProp:
+                type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseAllOfMapping"
+
+  /discriminator-required-mapping:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Required Properties and Mapping
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            typeA: "#/components/schemas/TypeA"
+            typeB: "#/components/schemas/TypeB"
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/TypeA'
+          - $ref: '#/components/schemas/TypeB'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseRequiredMapping"
+components:
+  schemas:
+    BaseBasic:
+      type: object
+      discriminator:
+        propertyName: type
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    BaseNested:
+      type: object
+      discriminator:
+        propertyName: type
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/NestedTypeA"
+        - $ref: "#/components/schemas/NestedTypeB"
+
+    BaseShared:
+      type: object
+      discriminator:
+        propertyName: type
+      properties:
+        type:
+          type: string
+        sharedProp:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    BaseAllOf:
+      type: object
+      discriminator:
+        propertyName: type
+      properties:
+        type: string
+      allOf:
+        - oneOf:
+            - $ref: "#/components/schemas/TypeA"
+            - $ref: "#/components/schemas/TypeB"
+        - type: object
+          properties:
+            sharedProp:
+              type: string
+
+    BaseRequired:
+      type: object
+      discriminator:
+        propertyName: type
+      properties:
+        type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    BaseBasicMapping:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          typeA: "#/components/schemas/TypeA"
+          typeB: "#/components/schemas/TypeB"
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    BaseNestedMapping:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          nestedTypeA: "#/components/schemas/NestedTypeA"
+          nestedTypeB: "#/components/schemas/NestedTypeB"
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/NestedTypeA"
+        - $ref: "#/components/schemas/NestedTypeB"
+
+    BaseSharedMapping:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          typeA: "#/components/schemas/TypeA"
+          typeB: "#/components/schemas/TypeB"
+      properties:
+        type:
+          type: string
+        sharedProp:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    BaseAllOfMapping:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          typeA: "#/components/schemas/TypeA"
+          typeB: "#/components/schemas/TypeB"
+      properties:
+        type: string
+      allOf:
+        - oneOf:
+            - $ref: "#/components/schemas/TypeA"
+            - $ref: "#/components/schemas/TypeB"
+        - type: object
+          properties:
+            sharedProp:
+              type: string
+
+    BaseRequiredMapping:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          typeA: "#/components/schemas/TypeA"
+          typeB: "#/components/schemas/TypeB"
+      properties:
+        type: string
+      oneOf:
+        - $ref: "#/components/schemas/TypeA"
+        - $ref: "#/components/schemas/TypeB"
+
+    TypeA:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["typeA"]
+        propA:
+          type: string
+      required:
+        - type
+
+    TypeB:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["typeB"]
+        propB:
+          type: number
+      required:
+        - type
+
+    NestedTypeA:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["nestedTypeA"]
+        nestedA:
+          type: object
+          properties:
+            propA1:
+              type: string
+            propA2:
+              type: number
+      required:
+        - type
+
+    NestedTypeB:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["nestedTypeB"]
+        nestedB:
+          type: object
+          properties:
+            propB1:
+              type: string
+            propB2:
+              type: boolean
+      required:
+        - type

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -368,6 +368,738 @@ Array [
 ]
 `;
 
+exports[`createNodes discriminator should handle basic discriminator with mapping 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+  <div>
+    <span className={\\"openapi-schema__container\\"}>
+      <strong
+        className={\\"openapi-discriminator__name openapi-schema__property\\"}
+      >
+        type
+      </strong>
+      <span className={\\"openapi-schema__name\\"}>string</span>
+    </span>
+    <div style={{ paddingLeft: \\"1rem\\" }}>
+      **Possible values:** [\`typeA\`, \`typeB\`]
+    </div>
+    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeA
+        </div>
+      </TabItem>
+      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeB
+        </div>
+      </TabItem>
+    </DiscriminatorTabs>
+  </div>
+</div>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle basic discriminator with oneOf 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with additional properties 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with allOf 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"sharedProp\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with allOf and mapping 1`] = `
+Array [
+  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+  <div>
+    <span className={\\"openapi-schema__container\\"}>
+      <strong
+        className={\\"openapi-discriminator__name openapi-schema__property\\"}
+      >
+        type
+      </strong>
+      <span className={\\"openapi-schema__name\\"}>string</span>
+    </span>
+    <div style={{ paddingLeft: \\"1rem\\" }}>
+      **Possible values:** [\`typeA\`, \`typeB\`]
+    </div>
+    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeA
+        </div>
+      </TabItem>
+      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeB
+        </div>
+      </TabItem>
+    </DiscriminatorTabs>
+  </div>
+</div>;
+",
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"sharedProp\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with nested schemas 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+        <details style={{}} className={\\"openapi-markdown__details\\"}>
+          <summary style={{}}>
+            <span className={\\"openapi-schema__container\\"}>
+              <strong className={\\"openapi-schema__property\\"}>nestedA</strong>
+              <span className={\\"openapi-schema__name\\"}>object</span>
+            </span>
+          </summary>
+          <div style={{ marginLeft: \\"1rem\\" }}>
+            <SchemaItem
+              collapsible={false}
+              name={\\"propA1\\"}
+              required={false}
+              schemaName={\\"string\\"}
+              qualifierMessage={undefined}
+              schema={{ type: \\"string\\" }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"propA2\\"}
+              required={false}
+              schemaName={\\"number\\"}
+              qualifierMessage={undefined}
+              schema={{ type: \\"number\\" }}
+            ></SchemaItem>
+          </div>
+        </details>
+      </SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+        <details style={{}} className={\\"openapi-markdown__details\\"}>
+          <summary style={{}}>
+            <span className={\\"openapi-schema__container\\"}>
+              <strong className={\\"openapi-schema__property\\"}>nestedB</strong>
+              <span className={\\"openapi-schema__name\\"}>object</span>
+            </span>
+          </summary>
+          <div style={{ marginLeft: \\"1rem\\" }}>
+            <SchemaItem
+              collapsible={false}
+              name={\\"propB1\\"}
+              required={false}
+              schemaName={\\"string\\"}
+              qualifierMessage={undefined}
+              schema={{ type: \\"string\\" }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"propB2\\"}
+              required={false}
+              schemaName={\\"boolean\\"}
+              qualifierMessage={undefined}
+              schema={{ type: \\"boolean\\" }}
+            ></SchemaItem>
+          </div>
+        </details>
+      </SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with required properties 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={true}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with required properties and mapping 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={true}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+  <div>
+    <span className={\\"openapi-schema__container\\"}>
+      <strong
+        className={\\"openapi-discriminator__name openapi-schema__property\\"}
+      >
+        type
+      </strong>
+      <span className={\\"openapi-schema__name\\"}>string</span>
+    </span>
+    <div style={{ paddingLeft: \\"1rem\\" }}>
+      **Possible values:** [\`typeA\`, \`typeB\`]
+    </div>
+    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeA
+        </div>
+      </TabItem>
+      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeB
+        </div>
+      </TabItem>
+    </DiscriminatorTabs>
+  </div>
+</div>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with shared properties 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"type\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"sharedProp\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes discriminator should handle discriminator with shared properties and mapping 1`] = `
+Array [
+  "<div>
+  <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+    oneOf
+  </span>
+  <SchemaTabs>
+    <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeA\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propA\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+    </TabItem>
+    <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"type\\"}
+        required={true}
+        schemaName={\\"string\\"}
+        qualifierMessage={\\"**Possible values:** [\`typeB\`]\\"}
+        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
+        name={\\"propB\\"}
+        required={false}
+        schemaName={\\"number\\"}
+        qualifierMessage={undefined}
+        schema={{ type: \\"number\\" }}
+      ></SchemaItem>
+    </TabItem>
+  </SchemaTabs>
+</div>;
+",
+  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+  <div>
+    <span className={\\"openapi-schema__container\\"}>
+      <strong
+        className={\\"openapi-discriminator__name openapi-schema__property\\"}
+      >
+        type
+      </strong>
+      <span className={\\"openapi-schema__name\\"}>string</span>
+    </span>
+    <div style={{ paddingLeft: \\"1rem\\" }}>
+      **Possible values:** [\`typeA\`, \`typeB\`]
+    </div>
+    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeA
+        </div>
+      </TabItem>
+      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+          #/definitions/TypeB
+        </div>
+      </TabItem>
+    </DiscriminatorTabs>
+  </div>
+</div>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"sharedProp\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  qualifierMessage={undefined}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
 exports[`createNodes oneOf should create readable MODs for oneOf primitive properties 1`] = `
 Array [
   "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -500,6 +500,428 @@ describe("createNodes", () => {
     // });
   });
 
+  describe("discriminator", () => {
+    it("should handle basic discriminator with oneOf", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with shared properties", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+          sharedProp: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with nested schemas", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              nestedA: {
+                type: "object",
+                properties: {
+                  propA1: { type: "string" },
+                  propA2: { type: "number" },
+                },
+              },
+            },
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              nestedB: {
+                type: "object",
+                properties: {
+                  propB1: { type: "string" },
+                  propB2: { type: "boolean" },
+                },
+              },
+            },
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with additional properties", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            additionalProperties: false,
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            additionalProperties: true,
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with allOf", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+        },
+        allOf: [
+          {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", enum: ["typeA"] },
+                  propA: { type: "string" },
+                },
+                required: ["type"],
+              },
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", enum: ["typeB"] },
+                  propB: { type: "number" },
+                },
+                required: ["type"],
+              },
+            ],
+          },
+          {
+            type: "object",
+            properties: {
+              sharedProp: { type: "string" },
+            },
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with required properties", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: { propertyName: "type" },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type", "propA"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type", "propB"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle basic discriminator with mapping", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: {
+          propertyName: "type",
+          mapping: {
+            typeA: "#/definitions/TypeA",
+            typeB: "#/definitions/TypeB",
+          },
+        },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with shared properties and mapping", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: {
+          propertyName: "type",
+          mapping: {
+            typeA: "#/definitions/TypeA",
+            typeB: "#/definitions/TypeB",
+          },
+        },
+        properties: {
+          type: { type: "string" },
+          sharedProp: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with allOf and mapping", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: {
+          propertyName: "type",
+          mapping: {
+            typeA: "#/definitions/TypeA",
+            typeB: "#/definitions/TypeB",
+          },
+        },
+        properties: {
+          type: { type: "string" },
+        },
+        allOf: [
+          {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", enum: ["typeA"] },
+                  propA: { type: "string" },
+                },
+                required: ["type"],
+              },
+              {
+                type: "object",
+                properties: {
+                  type: { type: "string", enum: ["typeB"] },
+                  propB: { type: "number" },
+                },
+                required: ["type"],
+              },
+            ],
+          },
+          {
+            type: "object",
+            properties: {
+              sharedProp: { type: "string" },
+            },
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should handle discriminator with required properties and mapping", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        discriminator: {
+          propertyName: "type",
+          mapping: {
+            typeA: "#/definitions/TypeA",
+            typeB: "#/definitions/TypeB",
+          },
+        },
+        properties: {
+          type: { type: "string" },
+        },
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeA"] },
+              propA: { type: "string" },
+            },
+            required: ["type", "propA"],
+          },
+          {
+            type: "object",
+            properties: {
+              type: { type: "string", enum: ["typeB"] },
+              propB: { type: "number" },
+            },
+            required: ["type", "propB"],
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+  });
+
   describe("additionalProperties", () => {
     it.each([
       [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -524,8 +524,9 @@ function createPropertyDiscriminator(
     return undefined;
   }
 
+  // render as a simple property if there's no mapping
   if (discriminator.mapping === undefined) {
-    return undefined;
+    return createEdges({ name, schema, required });
   }
 
   return create("div", {


### PR DESCRIPTION
## Description

Addresses a bug where discriminator properties with no `mapping` were not rendered/returned. Going forward, the plugin will handle/render these cases as "simple" properties, similar to how Swagger UI and Redoc handle them.

> Note: this fix will be backported to v2 in support of pan.dev

> Note: additional fixes coming for broken cases highlighted in new tests