### PR TITLE
Dont render serverUrl on callbacks MethodEndpoint component

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbackMethodEndpoint.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbackMethodEndpoint.ts
@@ -7,12 +7,12 @@
 
 import { create } from "./utils";
 
-export function createMethodEndpoint(method: String, path: String) {
+export function createCallbackMethodEndpoint(method: String, path: String) {
   return [
     create("MethodEndpoint", {
       method: method,
       path: path,
-      context: "endpoint",
+      context: "callback",
     }),
     "\n\n",
   ];

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createCallbacks.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import { createCallbackMethodEndpoint } from "./createCallbackMethodEndpoint";
 import { createDescription } from "./createDescription";
-import { createMethodEndpoint } from "./createMethodEndpoint";
 import { createRequestBodyDetails } from "./createRequestBodyDetails";
 import { createStatusCodes } from "./createStatusCodes";
 import { create } from "./utils";
@@ -78,7 +78,7 @@ export function createCallbacks({ callbacks }: Props) {
                 label: `${method.toUpperCase()} ${name}`,
                 value: `${method}-${name}`,
                 children: [
-                  createMethodEndpoint(method, path),
+                  createCallbackMethodEndpoint(method, path),
                   // TODO: add `deprecation notice` when markdown support is added
                   createDescription(description),
                   createRequestBodyDetails({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -35,13 +35,20 @@ function colorForMethod(method: string) {
 export interface Props {
   method: string;
   path: string;
+  context?: "endpoint" | "callback";
 }
 
-function MethodEndpoint({ method, path }: Props) {
+function MethodEndpoint({ method, path, context }: Props) {
+  const server = useTypedSelector((state: any) => state);
+
   let serverValue = useTypedSelector((state: any) => state.server.value);
   let serverUrlWithVariables = "";
 
   const renderServerUrl = () => {
+    if (context === "callback") {
+      return "";
+    }
+
     if (serverValue && serverValue.variables) {
       serverUrlWithVariables = serverValue.url.replace(/\/$/, "");
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -39,8 +39,6 @@ export interface Props {
 }
 
 function MethodEndpoint({ method, path, context }: Props) {
-  const server = useTypedSelector((state: any) => state);
-
   let serverValue = useTypedSelector((state: any) => state.server.value);
   let serverUrlWithVariables = "";
 


### PR DESCRIPTION
## Description

This adds a new prop to the MethodEndpoint component to give it context as to where it is rendering. If the context is `callback` it does not prepend the serverUrl, any other context and the serverUrl is prepended. 

## Motivation and Context

Callback methods are rendering the path of the endpoint with the server URL which is incorrect. The callback section should only render the endpoint the spec defines. For example in the petstore versioned spec, the plugin currently renders this url in the method endpoint component `https://petstore.swagger.io/v2http://notificationServer.com?url={$request.body#/callbackUrl}&event={$request.body#/eventName}` 

<img width="765" alt="image" src="https://github.com/user-attachments/assets/6068d80a-3146-4c3f-aa2d-89cf89c3fa67">


The [OpenAPI specs section on callbacks](https://swagger.io/docs/specification/callbacks/) details that it's possible for this endpoint value to reference the requestBody which could be a nice feature to add but at the moment this change simply updates incorrect behaviour of the rendering component.

## How Has This Been Tested?

Worked against the Callbacks section on http://localhost:3000/petstore_versioned/subscribe-to-the-store-events

## Screenshots (if appropriate)

### Rendering the endpoint and server url

<img width="771" alt="image" src="https://github.com/user-attachments/assets/b61aeadd-e5a0-4790-a10c-c67f9ba409b0">


### Rendering the endpoint url only

<img width="684" alt="image" src="https://github.com/user-attachments/assets/4ff8dc5c-b6d8-423d-817f-fa1d520344a3">

<img width="766" alt="image" src="https://github.com/user-attachments/assets/70fc8fd6-f2f5-41ef-a1fe-e320c04681c1">


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
