### PR TITLE
Fix bug where oneOf within anyOf would not be rendered in request schemas

### DIFF
--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.1
+info:
+  title: AnyOf Variations API
+  description: Demonstrates various anyOf combinations.
+  version: 1.0.0
+tags:
+  - name: anyOf
+    description: anyOf tests
+paths:
+  /anyof-primitives:
+    get:
+      tags:
+        - anyOf
+      summary: anyOf with primitives
+      description: |
+        Schema:
+        ```yaml
+        anyOf:
+          - type: string
+          - type: integer
+          - type: boolean
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: string
+                  - type: integer
+                  - type: boolean
+
+  /anyof-oneof:
+    get:
+      tags:
+        - anyOf
+      summary: anyOf with oneOf
+      description: |
+        Schema:
+        ```yaml
+        anyOf:
+          - oneOf:
+            - type: string
+            - type: integer
+          - type: boolean
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - oneOf:
+                      - type: string
+                        title: A string
+                      - type: integer
+                        title: An integer
+                    title: A string or integer
+                  - type: boolean
+                    title: A boolean
+                title: A string or integer, or a boolean

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -368,6 +368,93 @@ Array [
 ]
 `;
 
+exports[`createNodes anyOf should render oneOf within anyOf 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>oneOfProperty</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <div>
+        <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+          anyOf
+        </span>
+        <SchemaTabs>
+          <TabItem label={\\"An int or a bool\\"} value={\\"0-item-properties\\"}>
+            <div>
+              <span
+                className={\\"badge badge--info\\"}
+                style={{ marginBottom: \\"1rem\\" }}
+              >
+                oneOf
+              </span>
+              <SchemaTabs>
+                <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+                  <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                    integer
+                  </div>
+                </TabItem>
+                <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+                  <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                    boolean
+                  </div>
+                </TabItem>
+              </SchemaTabs>
+            </div>
+          </TabItem>
+          <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+            <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+              string
+            </div>
+          </TabItem>
+        </SchemaTabs>
+      </div>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes anyOf should render primitives within anyOf 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>oneOfProperty</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <div>
+        <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+          anyOf
+        </span>
+        <SchemaTabs>
+          <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+            <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+              integer
+            </div>
+          </TabItem>
+          <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+            <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+              boolean
+            </div>
+          </TabItem>
+        </SchemaTabs>
+      </div>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;
+
 exports[`createNodes discriminator should handle basic discriminator with mapping 1`] = `
 Array [
   "<div>

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -246,6 +246,70 @@ describe("createNodes", () => {
     });
   });
 
+  describe("anyOf", () => {
+    it("should render primitives within anyOf", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          oneOfProperty: {
+            anyOf: [
+              {
+                type: "integer",
+              },
+              {
+                type: "boolean",
+              },
+            ],
+            title: "One of int or bool",
+          },
+        },
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("should render oneOf within anyOf", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          oneOfProperty: {
+            anyOf: [
+              {
+                oneOf: [
+                  {
+                    type: "integer",
+                  },
+                  {
+                    type: "boolean",
+                  },
+                ],
+                title: "An int or a bool",
+              },
+              {
+                type: "string",
+              },
+            ],
+            title: "One of int or bool, or a string",
+          },
+        },
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+  });
+
   describe("allOf", () => {
     it("should render same-level properties with allOf", async () => {
       const schema: SchemaObject = {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -104,6 +104,11 @@ function createAnyOneOf(schema: SchemaObject): any {
             delete anyOneSchema.allOf;
           }
 
+          if (anyOneSchema.oneOf !== undefined) {
+            anyOneChildren.push(createNodes(anyOneSchema, SCHEMA_TYPE));
+            delete anyOneSchema.oneOf;
+          }
+
           if (anyOneSchema.items !== undefined) {
             anyOneChildren.push(createItems(anyOneSchema));
             delete anyOneSchema.items;


### PR DESCRIPTION
## Description

* Add support for `oneOf` within `anyOf` when generating a schema

## Motivation and Context

My schema looks like this:

```yaml
MySchema:
  properties:
    some_property:
      anyOf:
        - oneOf:
            - $ref: '#/components/schemas/SchemaPartA'
            - $ref: '#/components/schemas/SchemaPartB'
          title: Either of SchemaPartA or SchemaPartB
        - type: 'null'
```

Currently, when I generate MySchema, the SchemaTabs component has no children which causes the page to crash. I added a workaround for that to SchemaTabs, i.e. `if (!children?.length) return null`.

This PR aims to add support for nested `oneOf` constructs within `anyOf` in a schema.

I realise that the same could be expressed as below, but the schema is generated from FastAPI and I have less control over changing that. As far as I can tell, the schema snippet above is valid.

```
      anyOf:
        - $ref: '#/components/schemas/SchemaPartA'
        - $ref: '#/components/schemas/SchemaPartB'
        - type: 'null'
```

Keen to hear if there is a better way to do this, or if this is simply not the right approach! Thanks in advance.

## Screenshot

![image](https://github.com/user-attachments/assets/4ccf5005-e6b5-433a-8303-8b5da45a57de)

## How Has This Been Tested?

* Added a test
* Updated snapshots
* Added example to docs demo site

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
