### PR TITLE
Import MethodEndpoint hooks from @theme

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -8,8 +8,7 @@
 import React from "react";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
-
-import { useTypedSelector } from "../../ApiItem/hooks";
+import { useTypedSelector } from "@theme/ApiItem/hooks";
 
 function colorForMethod(method: string) {
   switch (method.toLowerCase()) {


### PR DESCRIPTION
## Description

Imports hooks from theme as opposed to relative path to avoid import error when swizzling component.