### PR TITLE
Ollie.monk/x enum descriptions

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -351,6 +351,10 @@ paths:
                 - available
                 - pending
                 - sold
+              x-enumDescriptions:
+                available: When the pet is available
+                pending: When the pet is being sold
+                sold: When the pet has been sold
               default: available
       responses:
         "200":
@@ -1114,6 +1118,15 @@ components:
             - available
             - pending
             - sold
+          x-enumDescriptions:
+            available: When the pet is available
+            pending: When the pet is being sold
+            sold: |
+              When the pet has been sold.
+
+              These descriptions can contain line
+
+              breaks and also [links](https://docusaurus.io/)
         petType:
           description: Type of a pet
           type: string

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createParamsDetails.ts
@@ -43,12 +43,17 @@ export function createParamsDetails({ parameters, type }: Props) {
       create("div", {
         children: [
           create("ul", {
-            children: params.map((param) =>
-              create("ParamsItem", {
+            children: params.map((param) => {
+              return create("ParamsItem", {
                 className: "paramsItem",
-                param: param,
-              })
-            ),
+                param: {
+                  ...param,
+                  enumDescriptions: Object.entries(
+                    param?.schema?.items?.["x-enumDescriptions"] ?? {}
+                  ),
+                },
+              });
+            }),
           }),
         ],
       }),

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -197,7 +197,7 @@ export interface ParameterObject {
   param?: Object;
   // ignoring stylings: matrix, label, form, simple, spaceDelimited,
   // pipeDelimited and deepObject
-  "x-enumDescriptions": Record<string, string>;
+  "x-enumDescriptions"?: Record<string, string>;
 }
 
 export interface ParameterObjectWithRef {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -197,6 +197,7 @@ export interface ParameterObject {
   param?: Object;
   // ignoring stylings: matrix, label, form, simple, spaceDelimited,
   // pipeDelimited and deepObject
+  "x-enumDescriptions": Record<string, string>;
 }
 
 export interface ParameterObjectWithRef {
@@ -353,6 +354,7 @@ export type SchemaObject = Omit<
   example?: any;
   deprecated?: boolean;
   "x-tags"?: string[];
+  "x-enumDescriptions"?: Record<string, string>;
 };
 
 export type SchemaObjectWithRef = Omit<

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/services/OpenAPIParser.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/services/OpenAPIParser.ts
@@ -270,6 +270,7 @@ export class OpenAPIParser {
       const {
         type,
         enum: enumProperty,
+        "x-enumDescription": enumDescription,
         properties,
         items,
         required,

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -57,6 +57,7 @@
     "react-modal": "^3.15.1",
     "react-redux": "^7.2.0",
     "rehype-raw": "^6.1.1",
+    "remark-gfm": "3.0.1",
     "sass": "^1.58.1",
     "sass-loader": "^13.3.2",
     "webpack": "^5.61.0",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/MethodEndpoint/index.tsx
@@ -39,8 +39,6 @@ export interface Props {
 }
 
 function MethodEndpoint({ method, path, context }: Props) {
-  const server = useTypedSelector((state: any) => state);
-
   let serverValue = useTypedSelector((state: any) => state.server.value);
   let serverUrlWithVariables = "";
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
@@ -14,6 +14,7 @@ import TabItem from "@theme/TabItem";
 import clsx from "clsx";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
 
 import { createDescription } from "../../markdown/createDescription";
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
@@ -39,12 +40,38 @@ export interface Props {
     required: boolean;
     deprecated: boolean;
     schema: any;
+    enumDescriptions?: [string, string][];
   };
 }
 
-function ParamsItem({
-  param: { description, example, examples, name, required, schema, deprecated },
-}: Props) {
+const getEnumDescriptionMarkdown = (enumDescriptions?: [string, string][]) => {
+  if (enumDescriptions?.length) {
+    return `| Enum | Description |
+| ---- | ----- |
+${enumDescriptions
+  .map((desc) => {
+    return `| ${desc[0]} | ${desc[1]} | `.replaceAll("\n", "<br/>");
+  })
+  .join("\n")}
+    `;
+  }
+
+  return "";
+};
+
+function ParamsItem({ param, ...rest }: Props) {
+  const {
+    description,
+    example,
+    examples,
+    name,
+    required,
+    deprecated,
+    enumDescriptions,
+  } = param;
+
+  let schema = param.schema;
+
   if (!schema || !schema?.type) {
     schema = { type: "any" };
   }
@@ -90,6 +117,19 @@ function ParamsItem({
       />
     </div>
   ));
+
+  const renderEnumDescriptions = guard(
+    getEnumDescriptionMarkdown(enumDescriptions),
+    (value) => {
+      return (
+        <ReactMarkdown
+          rehypePlugins={[rehypeRaw]}
+          remarkPlugins={[remarkGfm]}
+          children={value}
+        />
+      );
+    }
+  );
 
   const renderDefaultValue = guard(
     schema && schema.items
@@ -158,6 +198,7 @@ function ParamsItem({
       {renderSchema}
       {renderDefaultValue}
       {renderDescription}
+      {renderEnumDescriptions}
       {renderExample}
       {renderExamples}
     </div>


### PR DESCRIPTION
## Description

This PR adds the ability to render `x-enumDescription` values alongside enum lists

## Motivation and Context

I am working on a spec with ~100 uses of [`x-enumDescription`](https://redocly.com/docs/api-reference-docs/specification-extensions/x-enum-descriptions), a feature of redocly. We have just migrated from redocly and would rather not require reformatting my spec to.

## How Has This Been Tested?

See new entries to parameters and response body in the petstore yaml

## Screenshots (if appropriate)

### Response body

<img width="380" alt="image" src="https://github.com/user-attachments/assets/ff38aa20-ffc6-4116-860d-76ff4ad22de9">

### Parameter

<img width="507" alt="image" src="https://github.com/user-attachments/assets/6e20fd8c-8600-4f69-a881-9387afb7b305">

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
