### PR TITLE
Supporting merging all user defined languageTabs options

### DIFF
--- a/demo/docs/customization/languagetabs.mdx
+++ b/demo/docs/customization/languagetabs.mdx
@@ -8,98 +8,159 @@ description: Configuring language tabs for the API Demo Panel.
 
 ## Overview
 
-The Docusaurus OpenAPI docs plugin comes with support for 8 languages which you can render as code snippets on an API operation page. The languages currently supported are:
+The Docusaurus OpenAPI docs plugin comes with support for 18 languages which you can render as code snippets on an API operation page. 
+
+
+### Supported Languages and Variants
+
+The languages currently supported are:
 
 | Language     | Prism Highlighter | Variants                                         |
 | ------------ | ----------------- | ------------------------------------------------ |
-| `curl`       | bash              | `curl`\*                                         |
-| `python`     | python            | `requests`\*, `http.client`                      |
-| `go`         | go                | `native`\*                                       |
-| `nodejs`     | javascript        | `axios`\*, `native`                              |
-| `ruby`       | ruby              | `net::http`\*                                    |
-| `csharp`     | csharp            | `restsharp`\*, `httpclient`                      |
-| `php`        | php               | `curl`\*, `guzzle`, `pecl_http`, `http_request2` |
-| `java`       | java              | `okhttp`\*, `unirest`                            |
-| `powershell` | powershell        | `RestMethod`\*                                   |
+| `curl`       | bash              | `curl`                                           |
+| `python`     | python            | `requests`, `http.client`                        |
+| `go`         | go                | `native`                                         |
+| `nodejs`     | javascript        | `axios`, `native`, `request`, `unirest`          |
+| `ruby`       | ruby              | `net::http`                                      |
+| `csharp`     | csharp            | `httpclient`, `restsharp`                        |
+| `php`        | php               | `curl`, `guzzle`, `pecl_http`, `http_request2`   |
+| `java`       | java              | `okhttp`, `unirest`                              |
+| `powershell` | powershell        | `restmethod`                                     |
+| `dart`       | dart              | `dio`, `http`                                    |
+| `javascript` | javascript        | `fetch`, `jquery`, `xhr`                         |
+| `kotlin`     | kotlin            | `okhttp`                                         |
+| `c`          | c_cpp             | `libcurl`                                        |
+| `objective-c`| objectivec        | `nsurlsession`                                   |
+| `ocaml`      | ocaml             | `cohttp`                                         |
+| `r`          | r                 | `httr`, `rcurl`                                  |
+| `rust`       | rust              | `reqwest`                                        |
+| `swift`      | swift             | `urlsession`                                     |
 
-\* Default variant
+### Defining languages in languageTabs
 
 The enabled languages are defined for your site in a `languageTabs` array in the `themeConfig` object in your config file. If you do not define this configuration item all of the languages above are enabled. The config schema for each language is as follows:
 
 | Name              | Type      | Default              | Description                                                                                                            |
 | ----------------- | --------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `highlight`       | `string`  | `null`               | The syntax highlighting ruleset to use.                                                                                |
 | `language`        | `string`  | `null`               | The programming language to use when generating the example.                                                           |
-| `logoClass`       | `string`  | `null`               | The CSS class to be added to render the appropriate logo.                                                              |
-| `variant`         | `string`  | `null`               | The language variant to use when generating the example, see below for a tip on where you can find the variants.       |
-| `options`         | `object`  | `null`               | _Optional:_ Set of options for language customization. See below for common options, exact options depend on language. |
-| `followRedirect`  | `string`  | `null`               | _Optional:_ Follow redirects when handling requests.                                                                   |
-| `trimRequestBody` | `string`  | `null`               | _Optional:_ Trim request body fields.                                                                                  |
-| `indentCount`     | `integer` | _language dependent_ | _Optional:_ Alter the number of indentations used when generating the examples.                                        |
-| `indentType`      | `string`  | _language dependent_ | _Optional:_ Alter the type of indentation used, `Space` or `Tab` are acceptable options for this.                      |
+| `highlight`       | `string`  | _language dependent_ | _Optional:_ The prism syntax highlighting language to use.                                                             |
+| `logoClass`       | `string`  | _language dependent_ | _Optional:_ The CSS class suffix to be added to render the appropriate logo.                                           |
+| `variant`         | `string`  | _language dependent_ | _Optional:_ The default language variant to use when generating the code snippet. |
+| `variants`        | `array`   | _language dependent_ | _Optional:_ An array of strings representing the variants available for the language.                            |
+| `options`         | `object`  | _language dependent_ | _Optional:_ Set of options for language customization. See below for common options, exact options depend on language.  |
+| &nbsp;&nbsp;&nbsp;&nbsp;`followRedirect`  | `boolean` | _language dependent_ | _Optional:_ Follow redirects when handling requests.                                                                   |
+| &nbsp;&nbsp;&nbsp;&nbsp;`trimRequestBody` | `boolean` | _language dependent_ | _Optional:_ Trim request body fields.                                                                                  |
+| &nbsp;&nbsp;&nbsp;&nbsp;`indentCount`     | `integer` | _language dependent_ | _Optional:_ Alter the number of indentations used when generating the examples.                                        |
+| &nbsp;&nbsp;&nbsp;&nbsp;`indentType`      | `string`  | _language dependent_ | _Optional:_ Alter the type of indentation used, `Space` or `Tab` are acceptable options for this.                      |
 
 :::tip
-The order you define the languages under `languageTabs` is the order in which they will appear once rendered.
+The order you define the languages under `languageTabs` is the order in which they will appear once rendered. You may also choose a subset of languages and variants to include.
 :::
 
 :::danger
 Individual languages may only be defined once, meaning you cannot define a language multiple times with different variants. For example, you cannot define both `nodejs\axios` and `nodejs\unirest` or `python/requests` and `python/http.client`.
 :::
 
-## Demo Languages
+### Languages in Demo
 
-The demo site disables the `ruby` and `php` languages using the following `languageTabs` config object.
+The demo site defines all supported languages using the following `languageTabs` config object.
+
+:::note
+Only the `language` property is required. The `highlight` and `logoClass` properties are provided only for reference.
+:::
 
 ```js
-      languageTabs: [
-        {
-          highlight: "bash",
-          language: "curl",
-          logoClass: "bash",
-        },
-        {
-          highlight: "python",
-          language: "python",
-          logoClass: "python",
-          variant: "requests",
-        },
-        {
-          highlight: "go",
-          language: "go",
-          logoClass: "go",
-        },
-        {
-          highlight: "javascript",
-          language: "nodejs",
-          logoClass: "nodejs",
-          variant: "axios",
-        },
-        {
-          highlight: "ruby",
-          language: "ruby",
-          logoClass: "ruby",
-        },
-        {
-          highlight: "csharp",
-          language: "csharp",
-          logoClass: "csharp",
-          variant: "httpclient",
-        },
-        {
-          highlight: "php",
-          language: "php",
-          logoClass: "php",
-        },
-        {
-          highlight: "java",
-          language: "java",
-          logoClass: "java",
-          variant: "unirest",
-        },
-        {
-          highlight: "powershell",
-          language: "powershell",
-          logoClass: "powershell",
-        },
-      ],
+languageTabs: [
+  {
+    highlight: "python",
+    language: "python",
+    logoClass: "python",
+  },
+  {
+    highlight: "bash",
+    language: "curl",
+    logoClass: "bash",
+  },
+  {
+    highlight: "csharp",
+    language: "csharp",
+    logoClass: "csharp",
+  },
+  {
+    highlight: "go",
+    language: "go",
+    logoClass: "go",
+  },
+  {
+    highlight: "javascript",
+    language: "nodejs",
+    logoClass: "nodejs",
+  },
+  {
+    highlight: "ruby",
+    language: "ruby",
+    logoClass: "ruby",
+  },
+  {
+    highlight: "php",
+    language: "php",
+    logoClass: "php",
+  },
+  {
+    highlight: "java",
+    language: "java",
+    logoClass: "java",
+    variant: "unirest",
+  },
+  {
+    highlight: "powershell",
+    language: "powershell",
+    logoClass: "powershell",
+  },
+  {
+    highlight: "dart",
+    language: "dart",
+    logoClass: "dart",
+  },
+  {
+    highlight: "javascript",
+    language: "javascript",
+    logoClass: "javascript",
+  },
+  {
+    highlight: "c",
+    language: "c",
+    logoClass: "c",
+  },
+  {
+    highlight: "objective-c",
+    language: "objective-c",
+    logoClass: "objective-c",
+  },
+  {
+    highlight: "ocaml",
+    language: "ocaml",
+    logoClass: "ocaml",
+  },
+  {
+    highlight: "r",
+    language: "r",
+    logoClass: "r",
+  },
+  {
+    highlight: "swift",
+    language: "swift",
+    logoClass: "swift",
+  },
+  {
+    highlight: "kotlin",
+    language: "kotlin",
+    logoClass: "kotlin",
+  },
+  {
+    highlight: "rust",
+    language: "rust",
+    logoClass: "rust",
+  },
+],
 ```

--- a/demo/docs/customization/styling.mdx
+++ b/demo/docs/customization/styling.mdx
@@ -8,16 +8,83 @@ description: Styling tweaks for docusaurus-openapi-docs.
 
 ## Overview
 
-The Docusaurus OpenAPI docs plugin comes with Infima based styling as standard. In the demos on this site you'll see some features which are not included in the default styling including the request method labels before each request. To add these to your site you can use one of the two options outlined below.
+In the API demos on this site, you'll see some features which are not included in the default Docusaurus styling including the operation method sidebar badges. To add these to your site you can use one of the two options outlined below.
 
 The method labels are pure CSS and as a result there are few, if any, limits on how you style / present these on your site.
 
-## Demo Styling
+## Method Badge Styles
 
-The demo site uses the following CSS to add coloured labels to each request including the name of the method. Adding this to your site's custom CSS will replicate exactly the demo-site's label aesthetic using your site's variables.
+```mdx-code-block
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import BrowserWindow from '@site/src/components/BrowserWindow';
+```
 
-```css
-/* API Menu Items */
+<Tabs>
+<TabItem value="demo" label="Demo Styles">
+
+These are the styles implemented on this very demo site.
+
+<BrowserWindow bodyStyle={{height: 250, overflow: "auto"}} url="https://docusaurus-openapi.tryingpan.dev/customization/styling#method-badge-styles">
+
+  <ul
+    className="menu__list"
+  >
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item schema">
+      <a className="menu__link" tabIndex="0" href="#">
+        Cat
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method post">
+      <a className="menu__link" tabIndex="0" href="#">
+        Add a new pet to the store
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method put">
+      <a className="menu__link" tabIndex="0" href="#">
+        Update an existing pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method get">
+      <a className="menu__link" tabIndex="0" href="#">
+        Find pet by ID
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method post">
+      <a className="menu__link" tabIndex="0" href="#">
+        Updates a pet in the store with form data
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method delete">
+      <a className="menu__link" tabIndex="0" href="#">
+        Deletes a pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method post">
+      <a className="menu__link" tabIndex="0" href="#">
+        uploads an image
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method get">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by status
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item menu__list-item--deprecated api-method get">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by tags
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method event">
+      <a className="menu__link" tabIndex="0" href="#">
+        New pet
+      </a>
+    </li>
+  </ul>
+
+</BrowserWindow>
+
+```css title="Demo Styles"
 .api-method > .menu__link,
 .schema > .menu__link {
   align-items: center;
@@ -82,12 +149,71 @@ The demo site uses the following CSS to add coloured labels to each request incl
 }
 ```
 
-## Alternative Styling
+</TabItem>
+<TabItem value="contrast" label="High Contrast">
 
 In [this issue](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/249) community member [@ThomasHeartman](https://github.com/thomasheartman) shared some alternative CSS with better contrast and some other stylistic tweaks to the method labels. The CSS to replicate this is below:
 
-```css
-/* Sidebar Method labels */
+<BrowserWindow bodyStyle={{height: 250, overflow: "auto"}} url="https://docusaurus-openapi.tryingpan.dev/customization/styling#method-badge-styles">
+
+  <ul
+    className="menu__list"
+  >
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item schema-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Cat
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast post-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Add a new pet to the store
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast put-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Update an existing pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast get-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Find pet by ID
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast post-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Updates a pet in the store with form data
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast delete-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Deletes a pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast post-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        uploads an image
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast get-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by status
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item menu__list-item--deprecated api-method-contrast get-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by tags
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-contrast event-contrast">
+      <a className="menu__link" tabIndex="0" href="#">
+        New pet
+      </a>
+    </li>
+  </ul>
+
+</BrowserWindow>
+
+```css title="High Contrast"
 .api-method > .menu__link,
 .schema > .menu__link {
   align-items: center;
@@ -166,3 +292,132 @@ In [this issue](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issu
   border-color: var(--ifm-color-secondary-dark);
 }
 ```
+
+
+</TabItem>
+<TabItem value="simple" label="Simple">
+
+These styles are more similar to the ones found on https://pan.dev.
+
+<BrowserWindow bodyStyle={{height: 250, overflow: "auto"}} url="https://docusaurus-openapi.tryingpan.dev/customization/styling#method-badge-styles">
+
+  <ul
+    className="menu__list"
+  >
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple schema-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Cat
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple post-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Add a new pet to the store
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple put-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Update an existing pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple get-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Find pet by ID
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple post-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Updates a pet in the store with form data
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple delete-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Deletes a pet
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple post-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        uploads an image
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple get-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by status
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item menu__list-item--deprecated api-method-simple get-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        Finds Pets by tags
+      </a>
+    </li>
+    <li className="theme-doc-sidebar-item-link theme-doc-sidebar-item-link-level-3 menu__list-item api-method-simple event-simple">
+      <a className="menu__link" tabIndex="0" href="#">
+        New pet
+      </a>
+    </li>
+  </ul>
+
+</BrowserWindow>
+
+```css title="Simple"
+.api-method > .menu__link {
+  align-items: center;
+  justify-content: start;
+}
+.api-method > .menu__link::before {
+  width: 55px;
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: 0.25rem;
+  align-content: start;
+  margin-right: var(--ifm-spacing-horizontal);
+  text-align: right;
+  flex-shrink: 0;
+  border-color: transparent;
+}
+
+.get > .menu__link::before {
+  content: "get";
+  color: var(--ifm-color-info);
+}
+
+.post > .menu__link::before {
+  content: "post";
+  color: var(--ifm-color-success);
+}
+
+.delete > .menu__link::before {
+  content: "del";
+  color: var(--ifm-color-danger);
+}
+
+.put > .menu__link::before {
+  content: "put";
+  color: var(--ifm-color-warning);
+}
+
+.patch > .menu__link::before {
+  content: "patch";
+  color: var(--ifm-color-warning);
+}
+
+.head > .menu__link::before {
+  content: "head";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+
+.event > .menu__link::before {
+  content: "event";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+
+.schema > .menu__link::before {
+  content: "schema";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+```
+
+</TabItem>
+</Tabs>

--- a/demo/src/css/custom.css
+++ b/demo/src/css/custom.css
@@ -100,6 +100,145 @@ a:any-link:hover {
   background-color: var(--ifm-color-secondary-darkest);
 }
 
+/* Sidebar Method labels High Contrast */
+.api-method-contrast > .menu__link,
+.schema-contrast > .menu__link {
+  align-items: center;
+  justify-content: start;
+}
+
+.api-method-contrast > .menu__link::before,
+.schema-contrast > .menu__link::before {
+  width: 55px;
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: 0.25rem;
+  border: 1px solid;
+  border-inline-start-width: 5px;
+  margin-right: var(--ifm-spacing-horizontal);
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.get-contrast > .menu__link::before {
+  content: "get";
+  background-color: var(--ifm-color-info-contrast-background);
+  color: var(--ifm-color-info-contrast-foreground);
+  border-color: var(--ifm-color-info-dark);
+}
+
+.post-contrast > .menu__link::before {
+  content: "post";
+  background-color: var(--ifm-color-success-contrast-background);
+  color: var(--ifm-color-success-contrast-foreground);
+  border-color: var(--ifm-color-success-dark);
+}
+
+.delete-contrast > .menu__link::before {
+  content: "del";
+  background-color: var(--ifm-color-danger-contrast-background);
+  color: var(--ifm-color-danger-contrast-foreground);
+  border-color: var(--ifm-color-danger-dark);
+}
+
+.put-contrast > .menu__link::before {
+  content: "put";
+  background-color: var(--ifm-color-warning-contrast-background);
+  color: var(--ifm-color-warning-contrast-foreground);
+  border-color: var(--ifm-color-warning-dark);
+}
+
+.patch-contrast > .menu__link::before {
+  content: "patch";
+  background-color: var(--ifm-color-success-contrast-background);
+  color: var(--ifm-color-success-contrast-foreground);
+  border-color: var(--ifm-color-success-dark);
+}
+
+.head-contrast > .menu__link::before {
+  content: "head";
+  background-color: var(--ifm-color-secondary-contrast-background);
+  color: var(--ifm-color-secondary-contrast-foreground);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+.event-contrast > .menu__link::before {
+  content: "event";
+  background-color: var(--ifm-color-secondary-contrast-background);
+  color: var(--ifm-color-secondary-contrast-foreground);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+.schema-contrast > .menu__link::before {
+  content: "schema";
+  background-color: var(--ifm-color-secondary-contrast-background);
+  color: var(--ifm-color-secondary-contrast-foreground);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+/* Simple */
+.api-method-simple > .menu__link {
+  align-items: center;
+  justify-content: start;
+}
+.api-method-simple > .menu__link::before {
+  width: 55px;
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: 0.25rem;
+  align-content: start;
+  margin-right: var(--ifm-spacing-horizontal);
+  text-align: right;
+  flex-shrink: 0;
+  border-color: transparent;
+}
+
+.get-simple > .menu__link::before {
+  content: "get";
+  color: var(--ifm-color-info);
+}
+
+.post-simple > .menu__link::before {
+  content: "post";
+  color: var(--ifm-color-success);
+}
+
+.delete-simple > .menu__link::before {
+  content: "del";
+  color: var(--ifm-color-danger);
+}
+
+.put-simple > .menu__link::before {
+  content: "put";
+  color: var(--ifm-color-warning);
+}
+
+.patch-simple > .menu__link::before {
+  content: "patch";
+  color: var(--ifm-color-warning);
+}
+
+.head-simple > .menu__link::before {
+  content: "head";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+
+.event-simple > .menu__link::before {
+  content: "event";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+
+.schema-simple > .menu__link::before {
+  content: "schema";
+  color: var(--ifm-color-secondary-contrast-foreground);
+}
+
 /* GitHub Header Link */
 .header-github-link:hover {
   opacity: 0.6;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
@@ -6,7 +6,6 @@
  * ========================================================================== */
 
 import find from "lodash/find";
-import isArray from "lodash/isArray";
 import mergeWith from "lodash/mergeWith";
 import unionBy from "lodash/unionBy";
 import codegen from "postman-code-generators";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
@@ -51,10 +51,7 @@ export const mergeArraysbyLanguage = (arr1: any, arr2: any) => {
       find(arr2, ["language", item["language"]]),
     ];
     return mergeWith({}, ...matchingItems, (objValue: any) => {
-      if (isArray(objValue)) {
-        return objValue;
-      }
-      return undefined;
+      return objValue;
     });
   });
 };


### PR DESCRIPTION
## Description

Fixes an issue that prevented all user-defined `languageTabs` options from merging. Prior to this, only `variants` were respected. After this change, all options, including `highlight`, `logoClass`, etc., will be respected.