### PR TITLE
Add missing security schemes component

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
@@ -114,6 +114,10 @@
   }
 }
 
+.openapi-security__summary-container {
+  background: var(--ifm-pre-background);
+}
+
 // Prevent auto zoom on mobile iOS devices when focusing on input elmenents
 @media screen and (-webkit-min-device-pixel-ratio: 0) and (max-device-width: 1024px) {
   .prism-code,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/_Request.scss
@@ -116,6 +116,7 @@
 
 .openapi-security__summary-container {
   background: var(--ifm-pre-background);
+  border-radius: var(--ifm-pre-border-radius);
 }
 
 // Prevent auto zoom on mobile iOS devices when focusing on input elmenents

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import CodeSnippets from "@theme/ApiExplorer/CodeSnippets";
 import Request from "@theme/ApiExplorer/Request";
 import Response from "@theme/ApiExplorer/Response";
+import SecuritySchemes from "@theme/ApiExplorer/SecuritySchemes";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import sdk from "postman-collection";
 
@@ -24,6 +25,7 @@ function ApiExplorer({
 
   return (
     <>
+      <SecuritySchemes infoPath={infoPath} />
       {item.method !== "event" && (
         <CodeSnippets
           postman={postman}


### PR DESCRIPTION
## Description

Similar to #673, adds missing `SecuritySchemes` component back to `ApiExplorer`. Still not certain when this was removed but it was likely when the migration to ApiExplorer occurred.
