### PR TITLE
Add infoPath to apiItem

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -20,7 +20,6 @@ import sdk from "postman-collection";
 
 import { sampleRequestFromSchema } from "./createRequestExample";
 import { OpenApiObject, TagGroupObject, TagObject } from "./types";
-import { loadAndResolveSpec } from "./utils/loadAndResolveSpec";
 import { isURL } from "../index";
 import {
   ApiMetadata,
@@ -31,6 +30,7 @@ import {
   SidebarOptions,
   TagPageMetadata,
 } from "../types";
+import { loadAndResolveSpec } from "./utils/loadAndResolveSpec";
 
 /**
  * Convenience function for converting raw JSON to a Postman Collection object.
@@ -86,6 +86,7 @@ function createItems(
 ): ApiMetadata[] {
   // TODO: Find a better way to handle this
   let items: PartialPage<ApiMetadata>[] = [];
+
   const infoIdSpaces = openapiData.info.title.replace(" ", "-").toLowerCase();
   const infoId = kebabCase(infoIdSpaces);
 
@@ -227,6 +228,7 @@ function createItems(
         type: "api",
         id: baseId,
         infoId: infoId ?? "",
+        infoPath: infoId ?? "",
         unversionedId: baseId,
         title: title ? title.replace(/((?:^|[^\\])(?:\\{2})*)"/g, "$1'") : "",
         description: operationObject.description


### PR DESCRIPTION
## Description

To be really honest I'm finding it very hard to follow a lot of the inner workings of this plugin.

I am attempting to replicate the authorization section in my local schema. There is only one security schema in my schema but the plugin choses not to render anything in the ApiItem component but it does in the ApiExplorer

This line is the offending culprit https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/main/packages/docusaurus-plugin-openapi-docs/src/markdown/index.ts#L84

I've seen for some reason the API item doesn't have an infoPath so this change adds the info path and renders the auth item appropriately in my project. 

Perhaps you could help explain why?

[This line](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/blob/main/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx#L54) picks out info_path of MDX frontmatter and passes it to the ApiExplorer. Unfortunately at that point the MDX for the main ApiItem has been compiled.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Locally

## Screenshots (if appropriate)

<img width="828" alt="image" src="https://github.com/user-attachments/assets/a311cdd0-e037-438b-a853-62e32f9034e6">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix?

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
