### PR TITLE
Fix change type of Show optional parameters button

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
@@ -80,6 +80,7 @@ function ParamOptions() {
       {optionalParams.length > 0 && (
         <>
           <button
+            type="button"
             className="openapi-explorer__show-more-btn"
             onClick={() => setShowOptional((prev) => !prev)}
           >


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix #798 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The button `Show optional parameters` is in a form, so [it's type is default to `submit`
](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#type).
![image](https://github.com/user-attachments/assets/3a78b0e3-09ae-426c-8a02-553fe28e0fe6)

Since, we don't want to submit form in this case, we need to change button type to `button`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local env

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

**To reproduce**

https://github.com/user-attachments/assets/4dc5d7f7-23c2-4be3-941a-bda5bc24e65d

This can be reproduced on https://docusaurus-openapi.tryingpan.dev/cos/list-buckets

**After fixed**

https://github.com/user-attachments/assets/e246e72d-3434-44eb-a4a7-4cc26c3ee7f8

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
