### PR TITLE
Children interface is now ReactNode, theme utility methods are deprecated in favour of plugin methods

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -5,9 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-export type Children = string | undefined | (string | string[] | undefined)[];
+import { type ReactNode } from "react";
 
-export type Props = Record<string, any> & { children?: Children };
+/** @deprecated use ReactNode from React instead */
+export type Children = ReactNode;
+
+export type Props = Record<string, any> & { children?: ReactNode };
 
 export type Options = { inline?: boolean };
 
@@ -36,7 +39,7 @@ export function create(
 
 export function guard<T>(
   value: T | undefined,
-  cb: (value: T) => Children
+  cb: (value: T) => ReactNode
 ): string {
   if (!!value || value === 0) {
     const children = cb(value);
@@ -45,14 +48,14 @@ export function guard<T>(
   return "";
 }
 
-export function render(children: Children): string {
+export function render(children: ReactNode): string {
   if (Array.isArray(children)) {
     const filteredChildren = children.filter((c) => c !== undefined);
     return filteredChildren
       .map((i: any) => (Array.isArray(i) ? i.join("") : i))
       .join("");
   }
-  return children ?? "";
+  return `${children ?? ""}`;
 }
 
 // Regex to selectively URL-encode '>' and '<' chars

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/utils.ts
@@ -7,10 +7,13 @@
 
 import { ReactNode } from "react";
 
-export type Children = ReactNode | string | undefined | (string | undefined)[];
+/** @deprecated use ReactNode from React instead */
+export type Children = ReactNode;
 
-export type Props = Record<string, any> & { children?: Children };
+/** @deprecated use Props from docusaurus-plugin-openapi-docs/src/markdown/utils instead */
+export type Props = Record<string, any> & { children?: ReactNode };
 
+/** @deprecated use create() from docusaurus-plugin-openapi-docs/src/markdown/utils instead */
 export function create(tag: string, props: Props): string {
   const { children, ...rest } = props;
 
@@ -22,9 +25,10 @@ export function create(tag: string, props: Props): string {
   return `<${tag}${propString}>${render(children)}</${tag}>`;
 }
 
+/** @deprecated use guard() from docusaurus-plugin-openapi-docs/src/markdown/utils instead */
 export function guard<T>(
   value: T | undefined | string,
-  cb: (value: T) => Children
+  cb: (value: T) => ReactNode
 ): string {
   if (!!value || value === 0) {
     const children = cb(value as T);
@@ -33,11 +37,11 @@ export function guard<T>(
   return "";
 }
 
-export function render(children: Children): string {
+export function render(children: ReactNode): string {
   if (Array.isArray(children)) {
     return children.filter((c) => c !== undefined).join("");
   }
-  return (children as string) ?? "";
+  return `${children ?? ""}`;
 }
 
 export function toString(value: any): string | undefined {


### PR DESCRIPTION
## Description

This fixes a type incompatibility where using `guard()` and returning a React or DOM element would not pass type checking. The Children interface now extends ReactNode for backwards compatibility and is marked as depreacated. Use ReactNode directly in future.

Duplicated markdown utility functions in the theme are now deprecated in favour of their equivalents in the plugin package.

## Motivation and Context

Refer to theme: `ParamsItem/index.tsx`:

```tsx
const renderDeprecated = guard(deprecated, () => (
  <span className="openapi-schema__deprecated">deprecated</span>
));
```

The return value of the callback in this example was invalid, as a JSX.Element is not a string, etc. I've replaced the Children type with `ReactNode`, which supports React elements/JSX.Element, as well as all the other values that were there (string, undefined, number, iterable variants of it, etc).

## How Has This Been Tested?

Type checked locally.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Deprecation of existing APIs (requires minor release)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
