### PR TITLE
Support enum descriptions in schema object

### DIFF
--- a/demo/examples/tests/enumDescriptions.yaml
+++ b/demo/examples/tests/enumDescriptions.yaml
@@ -1,0 +1,84 @@
+openapi: 3.0.1
+info:
+  title: Enum descriptions test
+  description: Demonstrates of enum descriptions.
+  version: 1.0.0
+tags:
+  - name: enumDescriptions
+    description: enumDescriptions tests
+paths:
+  /filter-one-status:
+    get:
+      tags:
+        - enumDescriptions
+      summary: Get entities by status
+      description: Get all entities or search by status
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+              - pending
+            x-enumDescriptions:
+              active: The entity is active
+              inactive: The entity is inactive
+              pending: The entity is pending approval
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnumDescriptionsEntity"
+  /filter-multiple-status:
+    get:
+      tags:
+        - enumDescriptions
+      summary: Get entities by multiple status
+      description: Get all entities or search by multiple status
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - active
+                - inactive
+                - pending
+              x-enumDescriptions:
+                active: The entity is active
+                inactive: The entity is inactive
+                pending: The entity is pending approval
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnumDescriptionsEntity"
+components:
+  schemas:
+    EnumDescriptionsEntity:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+            - pending
+          x-enumDescriptions:
+            active: The entity is active
+            inactive: The entity is inactive
+            pending: The entity is pending approval

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createParamsDetails.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createParamsDetails.ts
@@ -49,7 +49,9 @@ export function createParamsDetails({ parameters, type }: Props) {
                 param: {
                   ...param,
                   enumDescriptions: Object.entries(
-                    param?.schema?.items?.["x-enumDescriptions"] ?? {}
+                    param?.schema?.["x-enumDescriptions"] ??
+                      param?.schema?.items?.["x-enumDescriptions"] ??
+                      {}
                   ),
                 },
               });


### PR DESCRIPTION
## Description

#951 added support for `x-enumDescriptions` but it on get `x-enumDescriptions` on parameter with schema type array. This pull add support for other schema type.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Additional enhancement for #951 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by adding a test schema `demo/examples/tests/enumDescriptions.yaml`

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/98ee5e34-dc0b-4dd2-ae22-700a490776a0)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
