### PR TITLE
Use scrollLeft to avoid scrolling entire page to active code tab

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
@@ -59,8 +59,12 @@ function TabList({
       const activeTabRect = activeTab.getBoundingClientRect();
 
       // Calculate the distance to scroll to align active tab to the left
+      const glowOffset = 3;
       const scrollOffset =
-        activeTabRect.left - containerRect.left + container.scrollLeft;
+        activeTabRect.left -
+        containerRect.left +
+        container.scrollLeft -
+        glowOffset;
 
       // Check if the active tab is not already at the left position
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
@@ -44,6 +44,7 @@ function TabList({
   tabValues,
 }: CodeTabsProps & ReturnType<typeof useTabs>) {
   const tabRefs = useRef<(HTMLLIElement | null)[]>([]);
+  const tabsScrollContainerRef = useRef<any>();
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();
 
@@ -51,12 +52,18 @@ function TabList({
     const activeTab = tabRefs.current.find(
       (tab) => tab?.getAttribute("aria-selected") === "true"
     );
-    if (activeTab) {
-      activeTab.scrollIntoView({
-        behavior: "auto",
-        block: "center",
-        inline: "start",
-      });
+
+    if (activeTab && tabsScrollContainerRef.current) {
+      const container = tabsScrollContainerRef.current;
+      const containerRect = container.getBoundingClientRect();
+      const activeTabRect = activeTab.getBoundingClientRect();
+
+      // Calculate the distance to scroll to align active tab to the left
+      const scrollOffset =
+        activeTabRect.left - containerRect.left + container.scrollLeft;
+
+      // Adjust the scroll of the container
+      container.scrollLeft = scrollOffset;
     }
   }, []);
 
@@ -139,6 +146,7 @@ function TabList({
         },
         className
       )}
+      ref={tabsScrollContainerRef}
     >
       {tabValues.map(({ value, label, attributes }) => (
         <li

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeTabs/index.tsx
@@ -62,8 +62,12 @@ function TabList({
       const scrollOffset =
         activeTabRect.left - containerRect.left + container.scrollLeft;
 
-      // Adjust the scroll of the container
-      container.scrollLeft = scrollOffset;
+      // Check if the active tab is not already at the left position
+
+      if (Math.abs(scrollOffset - container.scrollLeft) > 4) {
+        // Adjust the scroll of the container
+        container.scrollLeft = scrollOffset;
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Description

On mobile/smaller viewports, scrollIntoView caused the entire page to scroll to active code snippet tab. This change implements scrollLeft to ensure the active tab is visible when the user scrolls without scrolling the entire page.

Before:

https://github.com/user-attachments/assets/73f11a13-1534-483f-93a8-7a3ee0155f7f

After:

https://github.com/user-attachments/assets/2cb0de3f-fceb-4d3d-a8d8-42a355dd31bf