### PR TITLE
Combines mergedSchemas with original to ensure no edge properties are lost in schema item

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -687,50 +687,57 @@ function createEdges({
     const { mergedSchemas }: { mergedSchemas: SchemaObject } = mergeAllOf(
       schema.allOf
     );
+    delete schema.allOf;
+    const combinedSchemas = { ...schema, ...mergedSchemas };
 
     if (SCHEMA_TYPE === "request") {
-      if (mergedSchemas.readOnly && mergedSchemas.readOnly === true) {
+      if (combinedSchemas.readOnly && combinedSchemas.readOnly === true) {
         return undefined;
       }
     }
 
     if (SCHEMA_TYPE === "response") {
-      if (mergedSchemas.writeOnly && mergedSchemas.writeOnly === true) {
+      if (combinedSchemas.writeOnly && combinedSchemas.writeOnly === true) {
         return undefined;
       }
     }
 
-    const mergedSchemaName = getSchemaName(mergedSchemas);
+    const mergedSchemaName = getSchemaName(combinedSchemas);
+
+    if (name === "eventName") {
+      console.log(mergedSchemaName, combinedSchemas);
+    }
+
     if (
-      mergedSchemas.oneOf !== undefined ||
-      mergedSchemas.anyOf !== undefined
+      combinedSchemas.oneOf !== undefined ||
+      combinedSchemas.anyOf !== undefined
     ) {
       return createDetailsNode(
         name,
         mergedSchemaName,
-        mergedSchemas,
+        combinedSchemas,
         required,
-        schema.nullable
+        combinedSchemas.nullable
       );
     }
 
-    if (mergedSchemas.properties !== undefined) {
+    if (combinedSchemas.properties !== undefined) {
       return createDetailsNode(
         name,
         mergedSchemaName,
-        mergedSchemas,
+        combinedSchemas,
         required,
-        schema.nullable
+        combinedSchemas.nullable
       );
     }
 
-    if (mergedSchemas.additionalProperties !== undefined) {
+    if (combinedSchemas.additionalProperties !== undefined) {
       return createDetailsNode(
         name,
         mergedSchemaName,
-        mergedSchemas,
+        combinedSchemas,
         required,
-        schema.nullable
+        combinedSchemas.nullable
       );
     }
 
@@ -739,9 +746,9 @@ function createEdges({
       return createDetailsNode(
         name,
         mergedSchemaName,
-        mergedSchemas,
+        combinedSchemas,
         required,
-        schema.nullable
+        combinedSchemas.nullable
       );
     }
 
@@ -750,8 +757,8 @@ function createEdges({
       name,
       required: Array.isArray(required) ? required.includes(name) : required,
       schemaName: mergedSchemaName,
-      qualifierMessage: getQualifierMessage(mergedSchemas),
-      schema: mergedSchemas,
+      qualifierMessage: getQualifierMessage(combinedSchemas),
+      schema: combinedSchemas,
     });
   }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -66,6 +66,7 @@ export default function SchemaItem(props: Props) {
   let deprecated;
   let schemaDescription;
   let defaultValue: string | undefined;
+  let example: string | undefined;
   let nullable;
   let enumDescriptions: [string, string][] = [];
 
@@ -74,6 +75,7 @@ export default function SchemaItem(props: Props) {
     schemaDescription = schema.description;
     enumDescriptions = transformEnumDescriptions(schema["x-enumDescriptions"]);
     defaultValue = schema.default;
+    example = schema.example;
     nullable = schema.nullable;
   }
 
@@ -157,6 +159,30 @@ export default function SchemaItem(props: Props) {
     return undefined;
   }
 
+  function renderExample() {
+    if (example !== undefined) {
+      if (typeof example === "string") {
+        return (
+          <div>
+            <strong>Example: </strong>
+            <span>
+              <code>{example}</code>
+            </span>
+          </div>
+        );
+      }
+      return (
+        <div>
+          <strong>Example: </strong>
+          <span>
+            <code>{JSON.stringify(example)}</code>
+          </span>
+        </div>
+      );
+    }
+    return undefined;
+  }
+
   const schemaContent = (
     <div>
       <span className="openapi-schema__container">
@@ -179,6 +205,7 @@ export default function SchemaItem(props: Props) {
       {renderEnumDescriptions}
       {renderQualifierMessage}
       {renderDefaultValue()}
+      {renderExample()}
       {collapsibleSchemaContent ?? collapsibleSchemaContent}
     </div>
   );


### PR DESCRIPTION
## Description

Addresses issue reported in #977 and also adds support for rendering `example` value.

## Motivation and Context

Previously, if an edge property referenced an allOf the behavior was to resolve the allOf and render the `SchemaItem` based solely on that result. This change now merges the allOf result with the original schema to ensure nothing is lost.

## How Has This Been Tested?

Tested by reproducing issue described in #977 

## Screenshots (if appropriate)

<img width="873" alt="Screenshot 2024-10-04 at 11 25 30 AM" src="https://github.com/user-attachments/assets/51140180-fcad-409d-8ee3-06fd3d34192e">

```
  eventName:
    description: Event name for the subscription
    default: ONE
    allOf: 
      - $ref: '#/components/schemas/Test'
```

```
Test:
  type: string
  example: TWO
  enum:
    - ONE
    - TWO
```