### PR TITLE
Support schemas with array of types

### DIFF
--- a/demo/examples/petstore-1.0.0.yaml
+++ b/demo/examples/petstore-1.0.0.yaml
@@ -242,10 +242,14 @@ paths:
               properties:
                 name:
                   description: Updated name of the pet
-                  type: string
+                  type:
+                    - string
+                    - "null"
                 status:
                   description: Updated status of the pet
-                  type: string
+                  type:
+                    - string
+                    - "null"
     delete:
       tags:
         - pet

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -195,7 +195,9 @@ export default function SchemaItem(props: Props) {
         >
           {name}
         </strong>
-        <span className="openapi-schema__name"> {schemaName}</span>
+        <span className="openapi-schema__name">
+          {Array.isArray(schemaName) ? schemaName.join(" | ") : schemaName}
+        </span>
         {(nullable || required || deprecated) && (
           <span className="openapi-schema__divider"></span>
         )}


### PR DESCRIPTION
## Description

Support an array of schema types (IE string & null)

## Motivation and Context

- We are trying to switch away from readme.com which supports array of schema types

## How Has This Been Tested?

Used the pet store demo to test - http://localhost:3000/petstore_versioned/1.0.0/update-pet-with-form

```yaml
type:
  - string
  - 'null'
```
```json
"type": [
  "string",
  "null"
]
```
Before the above schemas would result in `stringnull`, now they result in `string | null`

## Screenshots (if appropriate)

Before:
<img width="295" alt="Screenshot 2024-11-07 at 1 14 30 PM" src="https://github.com/user-attachments/assets/fa523577-ced2-43e0-b611-c7c420be3796">

After:
<img width="285" alt="Screenshot 2024-11-07 at 12 54 41 PM" src="https://github.com/user-attachments/assets/e9ca90b2-3b1e-4c0c-a225-31f1a6b21b2b">


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
