### PR TITLE
fix: move dependencies to peer dependencies

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -34,13 +34,13 @@
     "@types/json-schema": "^7.0.9",
     "@types/lodash": "^4.14.176",
     "@types/mustache": "^4.1.2",
-    "eslint-plugin-prettier": "^5.0.1"
+    "eslint-plugin-prettier": "^5.0.1",
+    "@docusaurus/plugin-content-docs": "^3.5.0",
+    "@docusaurus/utils": "^3.5.0",
+    "@docusaurus/utils-validation": "^3.5.0"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.5.4",
-    "@docusaurus/plugin-content-docs": "^3.5.0",
-    "@docusaurus/utils": "^3.5.0",
-    "@docusaurus/utils-validation": "^3.5.0",
     "@redocly/openapi-core": "^1.10.5",
     "allof-merge": "^0.6.6",
     "chalk": "^4.1.2",
@@ -57,7 +57,10 @@
     "xml-formatter": "^2.6.1"
   },
   "peerDependencies": {
-    "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0",
+    "@docusaurus/plugin-content-docs": "^3.5.0",
+    "@docusaurus/utils": "^3.5.0",
+    "@docusaurus/utils-validation": "^3.5.0"
   },
   "engines": {
     "node": ">=14"

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -33,18 +33,18 @@
     "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.176",
     "concurrently": "^5.2.0",
-    "eslint-plugin-prettier": "^5.0.1"
-  },
-  "dependencies": {
+    "eslint-plugin-prettier": "^5.0.1",
+    "docusaurus-plugin-openapi-docs": "^4.2.0",
     "@docusaurus/theme-common": "^3.5.0",
     "@hookform/error-message": "^2.0.1",
+    "docusaurus-plugin-sass": "^0.2.3"
+  },
+  "dependencies": {
     "@reduxjs/toolkit": "^1.7.1",
     "allof-merge": "^0.6.6",
     "clsx": "^1.1.1",
     "copy-text-to-clipboard": "^3.1.0",
     "crypto-js": "^4.1.1",
-    "docusaurus-plugin-openapi-docs": "^4.2.0",
-    "docusaurus-plugin-sass": "^0.2.3",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.20",
     "node-polyfill-webpack-plugin": "^3.0.0",
@@ -66,7 +66,11 @@
   },
   "peerDependencies": {
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0"
+    "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0",
+    "docusaurus-plugin-openapi-docs": "^4.0.0",
+    "@docusaurus/theme-common": "^3.5.0",
+    "@hookform/error-message": "^2.0.1",
+    "docusaurus-plugin-sass": "^0.2.3"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
## Description

## Motivation and Context

I'm trying to add this plugin to Backstage's docsite to automatically show OpenAPI-documented APIs (PR: https://github.com/backstage/backstage/pull/27573). I noticed that this package was causing a lot of lockfile churn and bringing in versions that I would expect to be duplicates, but aren't.

## How Has This Been Tested?

Locally linked this into my Backstage fork and verified that no additional docusaurus dependencies were duplicated, there was only a single version of each dep.

This is my first contribution to this repo, so please share any additional testing steps I should be taking here 🙇 .

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
