### PR TITLE
fix: add back @hookform/error-message as a regular dep

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -36,10 +36,10 @@
     "eslint-plugin-prettier": "^5.0.1",
     "docusaurus-plugin-openapi-docs": "^4.2.0",
     "@docusaurus/theme-common": "^3.5.0",
-    "@hookform/error-message": "^2.0.1",
     "docusaurus-plugin-sass": "^0.2.3"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
     "@reduxjs/toolkit": "^1.7.1",
     "allof-merge": "^0.6.6",
     "clsx": "^1.1.1",
@@ -69,7 +69,6 @@
     "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0",
     "docusaurus-plugin-openapi-docs": "^4.0.0",
     "@docusaurus/theme-common": "^3.5.0",
-    "@hookform/error-message": "^2.0.1",
     "docusaurus-plugin-sass": "^0.2.3"
   },
   "engines": {


### PR DESCRIPTION
## Description

## Motivation and Context

Fixes https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1019#issuecomment-2478563994.

I think I was a little aggressive initially in moving deps to peer deps, let's move this one back.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
