### PR TITLE
Remove unused global selector

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ApiCodeBlock/Line/_Line.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ApiCodeBlock/Line/_Line.scss
@@ -8,13 +8,6 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
   --docusaurus-highlighted-code-line-bg: rgb(100 100 100);
 }
 
-.theme-code-block-highlighted-line {
-  background-color: var(--docusaurus-highlighted-code-line-bg);
-  display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding: 0 var(--ifm-pre-padding);
-}
-
 .openapi-explorer__code-block-code-line {
   display: table-row;
   counter-increment: line-count;
@@ -34,11 +27,6 @@ the background in custom CSS file due bug https://github.com/facebook/docusaurus
 .openapi-explorer__code-block-code-line-number::before {
   content: counter(line-count);
   opacity: 0.4;
-}
-
-:global(.theme-code-block-highlighted-line)
-  .openapi-explorer__code-block-code-line-number::before {
-  opacity: 0.8;
 }
 
 .openapi-explorer__code-block-code-line-number {


### PR DESCRIPTION
## Description

This PR consists of removing the global selector and class name selector (`.theme-code-block-highlighted-line`) defined in `Line.scss`, as this class name is no longer being used in the project.

## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1021 for context. 

## How Has This Been Tested?

Tested by ensuring styles were not affected for the `CodeBlock` component and warnings mentioned in https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1021 have been cleared.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
