### PR TITLE
Reintroduce password type to auth inputs

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
@@ -48,6 +48,7 @@ function Authorization() {
             <FormItem label="Bearer Token" key={a.key + "-bearer"}>
               <FormTextInput
                 placeholder="Bearer Token"
+                password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value;
@@ -69,6 +70,7 @@ function Authorization() {
             <FormItem label="Bearer Token" key={a.key + "-oauth2"}>
               <FormTextInput
                 placeholder="Bearer Token"
+                password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value;
@@ -130,6 +132,7 @@ function Authorization() {
             <FormItem label={`${a.key}`} key={a.key + "-apikey"}>
               <FormTextInput
                 placeholder={`${a.key}`}
+                password
                 value={data[a.key].apiKey ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const value = e.target.value;


### PR DESCRIPTION
## Description

Reintroduces password type to API key/token input fields. Although credentials will still be plain text in code snippets, we could at least mask them in the form input.

## Motivation and Context

Could be helpful to mask API key/token or passwords when performing a live demo or screen recording. Next step is to find a viable approach to mask or obfuscate them in code snippets without breaking the underlying request.

## How Has This Been Tested?

Tested locally in dev. See deploy preview for production test.

## Screenshots (if appropriate)

See deploy preview

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)
