### PR TITLE
Handle case where propertyName not defined in schemas and/or 0-length mapping

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -319,7 +319,7 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
 
   // default to empty object if no parent-level properties exist
   const discriminatorProperty = schema.properties
-    ? schema.properties![discriminator.propertyName]
+    ? (schema.properties![discriminator.propertyName] ?? {})
     : {};
 
   if (schema.allOf) {
@@ -339,6 +339,12 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
       }
     );
     discriminator.mapping = inferredMapping;
+  }
+
+  // handle invalid discriminator definition where no discriminated schemas are defined
+  if (Object.keys(discriminator.mapping).length === 0) {
+    delete schema.discriminator;
+    return <SchemaNode schema={schema} schemaType={schemaType} />;
   }
 
   // Merge sub schema discriminator property with parent


### PR DESCRIPTION
## Description

Handles cases where the discriminator `propertyName` is not defined in `properties` and/or there are no `mapping` schemas or `oneOf` or `anyOf` defined.

## Motivation and Context

Provides additional fallback for edge case that could lead to rendering error.

## How Has This Been Tested?

Tested using the following spec:

https://raw.githubusercontent.com/PaloAltoNetworks/pan.dev/refs/heads/master/openapi-specs/cspm/AssetInventory.json

## Screenshots (if appropriate)

n/a

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
