### PR TITLE
Hide credentials from generated code snippets

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
@@ -298,7 +298,7 @@ function buildPostmanRequest(
       if (apiKey === undefined) {
         otherHeaders.push({
           key: a.name,
-          value: "<API_KEY_VALUE>",
+          value: `<${a.name ?? a.type}>`,
         });
         continue;
       }


### PR DESCRIPTION
## Description

Follow up to #1039 with the goal of masking credentials in generated code snippets. The expected behavior is that any credentials included in code snippets will be replaced with placeholders, e.g. `<api_key>`, matching the key name of the credential property. Meanwhile, credentials passed to `makeRequest` will still be represented by the actual values.

## Motivation and Context

Follows best practice of hiding credentials from UI to improve privacy and security. Additionally, anyone creating screenshots or demo videos will not need to worry about credentials leaking or having to blur or mask them before publishing/sharing.

## How Has This Been Tested?

Tested locally in dev

## Screenshots (if appropriate)

See deploy preview

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)
