### PR TITLE
Handle case where auth options are combined

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -54,7 +54,6 @@ function CodeSnippets({ postman, codeSamples }: Props) {
 
   const auth = useTypedSelector((state: any) => state.auth);
   const clonedAuth = cloneDeep(auth);
-  console.log(clonedAuth);
   let placeholder: string;
 
   function cleanCredentials(obj: any) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -54,13 +54,17 @@ function CodeSnippets({ postman, codeSamples }: Props) {
 
   const auth = useTypedSelector((state: any) => state.auth);
   const clonedAuth = cloneDeep(auth);
+  console.log(clonedAuth);
   let placeholder: string;
 
   function cleanCredentials(obj: any) {
     for (const key in obj) {
       if (typeof obj[key] === "object" && obj[key] !== null) {
         // use name as placeholder if exists
-        placeholder = clonedAuth?.options?.[key]?.[0]?.name;
+        const comboAuthId = Object.keys(obj).join(" and ");
+        const authOptions =
+          clonedAuth?.options?.[key] ?? clonedAuth?.options?.[comboAuthId];
+        placeholder = authOptions?.[0]?.name;
         obj[key] = cleanCredentials(obj[key]);
       } else {
         obj[key] = `<${placeholder ?? key}>`;


### PR DESCRIPTION
## Description

Continuation of #1050 and #1039. Adds support for parsing auth placeholders when auth options are combined or required in pairs, e.g. id and key.

## Motivation and Context

Ensures full coverage.

## How Has This Been Tested?

Tested with IoT API spec.