### PR TITLE
normalize body array instead of returning literal

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -181,7 +181,7 @@ export const sampleRequestFromSchema = (schema: SchemaObject = {}): any => {
         return items?.oneOf.map((item: any) => sampleRequestFromSchema(item));
       }
 
-      return [sampleRequestFromSchema(items)];
+      return normalizeArray(sampleRequestFromSchema(items));
     }
 
     if (schemaCopy.enum) {


### PR DESCRIPTION
## Description

Addresses a bug that resulted in request body arrays rendering inside nested brackets. This change uses the `normalizeArray` utility to prevent this from happening.

## Motivation and Context

Encountered this bug while testing the API Intercept async scan endpoint.

## How Has This Been Tested?

Tested using the API Intercept spec.

## Screenshots (if appropriate)

<img width="532" alt="Screenshot 2025-01-22 at 9 27 18 AM" src="https://github.com/user-attachments/assets/ec394f72-a366-42cd-9ad8-2410d1ed2b40" />

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
