### PR TITLE
Allow default body to satisfy required

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
@@ -51,7 +51,7 @@ function App({
   ...props
 }: any): JSX.Element {
   const prismTheme = usePrismTheme();
-  const [code, setCode] = React.useState(children);
+  const [code, setCode] = React.useState(children.replace(/\n$/, ""));
 
   useEffect(() => {
     action(setStringRawBody(code));
@@ -76,7 +76,7 @@ function App({
       })}
     >
       <LiveProvider
-        code={children.replace(/\n$/, "")}
+        code={code}
         transformCode={transformCode ?? ((code) => `${code};`)}
         theme={prismTheme}
         language={language}
@@ -84,7 +84,9 @@ function App({
       >
         <Controller
           control={control}
-          rules={{ required: isRequired ? "This field is required" : false }}
+          rules={{
+            required: isRequired && !code ? "This field is required" : false,
+          }}
           name="requestBody"
           render={({ field: { onChange, name } }) => (
             <LiveComponent


### PR DESCRIPTION
## Description

The LiveEditor was not recognizing examples when validating the `required` prop. This change extends the required validation to also check for the existence of a default code snippet. If a default code snippet exists users should no longer see the "This field is required" error. Previously, to get around this, users would need to "dirty" the `LiveEditor` form by making a small change. This fix will correct it so users can simply select an example and hit send without having to edit.

## Motivation and Context

Improves user experience.

## How Has This Been Tested?

Tested using API Intercept spec

## Screenshots (if appropriate)

see deploy preview

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
