### PR TITLE
Add support for json schema null type

### DIFF
--- a/demo/examples/petstore-3.1.yaml
+++ b/demo/examples/petstore-3.1.yaml
@@ -1077,7 +1077,9 @@ components:
             - $ref: "#/components/schemas/Category"
         name:
           description: The name given to a pet
-          type: string
+          type:
+            - string
+            - "null"
           example: Guru
         photoUrls:
           description: The list of URL to a cute photos featuring pet

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -72,8 +72,12 @@ export default function SchemaItem(props: Props) {
     enumDescriptions = transformEnumDescriptions(schema["x-enumDescriptions"]);
     defaultValue = schema.default;
     example = schema.example;
-    nullable = schema.nullable;
+    nullable =
+      schema.nullable ||
+      (Array.isArray(schema.type) && schema.type.includes("null")); // support JSON Schema nullable
   }
+
+  console.log(schema);
 
   const renderRequired = guard(
     Array.isArray(required) ? required.includes(name) : required,


### PR DESCRIPTION
## Description

See #1052 for background. 

## Motivation and Context

Ultimately this plugin aims to provide as much support coverage as possible for OpenAPI 3.1, including null types.

## How Has This Been Tested?

Example added to OpenAPI 3.1 Petstore API.

## Screenshots (if appropriate)

See deploy preview

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)