### PR TITLE
Prevent default behavior when adding params items 

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
@@ -56,7 +56,8 @@ export default function ParamArrayFormItem({ param }: ParamProps) {
 
   const showErrorMessage = errors?.paramArray?.message;
 
-  function handleAddItem() {
+  function handleAddItem(e: any) {
+    e.preventDefault(); // prevent form from submitting
     setItems((i) => [
       ...i,
       {


### PR DESCRIPTION
## Description

Addresses an issue that caused API requests to be inadvertently submitted while adding params array items to the request.

## Motivation and Context

API requests should only be sent when users click the "Send API Request" button.

## How Has This Been Tested?

Tested using API Intercept spec

## Screenshots (if appropriate)

n/a

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
