### PR TITLE
Add react 19 to plugin peer dependencies

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -60,7 +60,7 @@
     "@docusaurus/plugin-content-docs": "^3.5.0",
     "@docusaurus/utils": "^3.5.0",
     "@docusaurus/utils-validation": "^3.5.0",
-    "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
## Description

Addresses issue described in #1072 

## Motivation and Context

Missing peer dependency can block installation of plugin using `npm`.

Please note that workaround is possible using explicit `overrides` or `--force` option.

## How Has This Been Tested?

Tested using fresh docusaurus installation.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
