### PR TITLE
Expand support for parameter serialization

### DIFF
--- a/demo/examples/tests/paramSerialization.yaml
+++ b/demo/examples/tests/paramSerialization.yaml
@@ -63,7 +63,7 @@ paths:
         Example:
         ```
         {itemId} = [1, 2, 3]
-        Result: /items/.1,2,3
+        Result: /items/.1.2.3
         ```
       parameters:
         - name: itemId
@@ -79,7 +79,7 @@ paths:
         "200":
           description: Successful response
 
-  /products{productCode}:
+  /products/{productCode}:
     get:
       tags:
         - params

--- a/demo/examples/tests/paramSerialization.yaml
+++ b/demo/examples/tests/paramSerialization.yaml
@@ -311,3 +311,87 @@ paths:
       responses:
         "200":
           description: Successful response
+
+  /headers:
+    get:
+      tags:
+        - params
+      summary: Get with header parameters
+      description: |
+        Schema:
+        ```yaml
+        X-Custom-Header:
+          in: header
+          schema:
+            type: object
+            properties:
+              key1:
+                type: string
+              key2:
+                type: string
+          style: simple
+          explode: true
+        ```
+        Example:
+        ```
+        X-Custom-Header = {"key1": "value1", "key2": "value2"}
+        Result:
+        X-Custom-Header: key1=value1
+        X-Custom-Header: key2=value2
+        ```
+      parameters:
+        - name: X-Custom-Header
+          in: header
+          schema:
+            type: object
+            properties:
+              key1:
+                type: string
+              key2:
+                type: string
+          style: simple
+          explode: true
+      responses:
+        "200":
+          description: Successful response
+
+  /cookies:
+    get:
+      tags:
+        - params
+      summary: Get with cookie parameters
+      description: |
+        Schema:
+        ```yaml
+        userSettings:
+          in: cookie
+          schema:
+            type: object
+            properties:
+              theme:
+                type: string
+              language:
+                type: string
+          style: form
+          explode: false
+        ```
+        Example:
+        ```
+        userSettings = {"theme": "dark", "language": "en"}
+        Result: userSettings=theme,dark,language,en
+        ```
+      parameters:
+        - name: userSettings
+          in: cookie
+          schema:
+            type: object
+            properties:
+              theme:
+                type: string
+              language:
+                type: string
+          style: form
+          explode: false
+      responses:
+        "200":
+          description: Successful response

--- a/demo/examples/tests/paramSerialization.yaml
+++ b/demo/examples/tests/paramSerialization.yaml
@@ -1,0 +1,313 @@
+openapi: 3.0.0
+info:
+  title: Parameter Serialization Demo API
+  version: 1.0.0
+  description: An API to demonstrate various parameter serialization options in OpenAPI 3.0
+
+tags:
+  - name: params
+    description: Parameter Serialization Tests
+
+paths:
+  /users/{userId}:
+    get:
+      tags:
+        - params
+      summary: Get user by ID
+      description: |
+        Schema:
+        ```yaml
+        userId:
+          in: path
+          required: true
+          schema:
+            type: integer
+          style: simple
+          explode: false
+        ```
+        Example:
+        ```
+        {userId} = 123
+        Result: /users/123
+        ```
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: integer
+          style: simple
+          explode: false
+      responses:
+        "200":
+          description: Successful response
+
+  /items/{itemId}:
+    get:
+      tags:
+        - params
+      summary: Get item by ID (label style)
+      description: |
+        Schema:
+        ```yaml
+        itemId:
+          in: path
+          required: true
+          schema:
+            type: array
+            items:
+              type: integer
+          style: label
+          explode: false
+        ```
+        Example:
+        ```
+        {itemId} = [1, 2, 3]
+        Result: /items/.1,2,3
+        ```
+      parameters:
+        - name: itemId
+          in: path
+          required: true
+          schema:
+            type: array
+            items:
+              type: integer
+          style: label
+          explode: false
+      responses:
+        "200":
+          description: Successful response
+
+  /products{productCode}:
+    get:
+      tags:
+        - params
+      summary: Get product by code (matrix style)
+      description: |
+        Schema:
+        ```yaml
+        productCode:
+          in: path
+          required: true
+          schema:
+            type: object
+            properties:
+              category:
+                type: string
+              id:
+                type: integer
+          style: matrix
+          explode: true
+        ```
+        Example:
+        ```
+        {productCode} = {"category": "electronics", "id": 123}
+        Result: /products;category=electronics;id=123
+        ```
+      parameters:
+        - name: productCode
+          in: path
+          required: true
+          schema:
+            type: object
+            properties:
+              category:
+                type: string
+              id:
+                type: integer
+          style: matrix
+          explode: true
+      responses:
+        "200":
+          description: Successful response
+
+  /search:
+    get:
+      tags:
+        - params
+      summary: Search with various query parameter styles
+      description: |
+        Schema:
+        ```yaml
+        q:
+          in: query
+          schema:
+            type: string
+        tags:
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        filters:
+          in: query
+          schema:
+            type: object
+            properties:
+              minPrice:
+                type: number
+              maxPrice:
+                type: number
+          style: deepObject
+          explode: true
+        sort:
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: spaceDelimited
+          explode: false
+        fields:
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: pipeDelimited
+          explode: false
+        ```
+        Example:
+        ```
+        q = "openapi"
+        tags = ["api", "docs"]
+        filters = {"minPrice": 10, "maxPrice": 100}
+        sort = ["name", "price"]
+        fields = ["id", "name", "description"]
+        Result: /search?q=openapi&tags=api&tags=docs&filters[minPrice]=10&filters[maxPrice]=100&sort=name%20price&fields=id|name|description
+        ```
+      parameters:
+        - name: q
+          in: query
+          schema:
+            type: string
+        - name: tags
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: filters
+          in: query
+          schema:
+            type: object
+            properties:
+              minPrice:
+                type: number
+              maxPrice:
+                type: number
+          style: deepObject
+          explode: true
+        - name: sort
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: spaceDelimited
+          explode: false
+        - name: fields
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: pipeDelimited
+          explode: false
+      responses:
+        "200":
+          description: Successful response
+
+  /documents/{docId}:
+    get:
+      tags:
+        - params
+      summary: Get document with header parameter
+      description: |
+        Schema:
+        ```yaml
+        docId:
+          in: path
+          required: true
+          schema:
+            type: string
+        X-API-Version:
+          in: header
+          schema:
+            type: array
+            items:
+              type: string
+          style: simple
+          explode: false
+        ```
+        Example:
+        ```
+        {docId} = "doc123"
+        X-API-Version: ["v1", "v2"]
+        Result URL: /documents/doc123
+        Header: X-API-Version: v1,v2
+        ```
+      parameters:
+        - name: docId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: X-API-Version
+          in: header
+          schema:
+            type: array
+            items:
+              type: string
+          style: simple
+          explode: false
+      responses:
+        "200":
+          description: Successful response
+
+  /preferences:
+    get:
+      tags:
+        - params
+      summary: Get user preferences with cookie parameter
+      description: |
+        Schema:
+        ```yaml
+        userSettings:
+          in: cookie
+          schema:
+            type: object
+            properties:
+              theme:
+                type: string
+              language:
+                type: string
+          style: form
+          explode: true
+        ```
+        Example:
+        ```
+        userSettings = {"theme": "dark", "language": "en"}
+        Result URL: /preferences
+        Cookie: theme=dark; language=en
+        ```
+      parameters:
+        - name: userSettings
+          in: cookie
+          schema:
+            type: object
+            properties:
+              theme:
+                type: string
+              language:
+                type: string
+          style: form
+          explode: true
+      responses:
+        "200":
+          description: Successful response

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
@@ -22,7 +22,10 @@ export interface ParamProps {
 function ArrayItem({
   param,
   onChange,
-}: ParamProps & { onChange(value?: string): any }) {
+  initialValue,
+}: ParamProps & { onChange(value?: string): any; initialValue?: string }) {
+  const [value, setValue] = useState(initialValue || "");
+
   if (param.schema?.items?.type === "boolean") {
     return (
       <FormSelect
@@ -38,7 +41,9 @@ function ArrayItem({
   return (
     <FormTextInput
       placeholder={param.description || param.name}
+      value={value}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value);
         onChange(e.target.value);
       }}
     />
@@ -76,8 +81,20 @@ export default function ParamArrayFormItem({ param }: ParamProps) {
         value: values.length > 0 ? values : undefined,
       })
     );
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items]);
+
+  useEffect(() => {
+    if (param.schema?.example?.length > 0) {
+      const examplesWithIds = param.schema.example.map((item: any) => ({
+        id: nanoid(),
+        value: item.toString(),
+      }));
+
+      setItems(examplesWithIds);
+    }
+  }, [param.schema.example, param.schema.length]);
 
   function handleDeleteItem(itemToDelete: { id: string }) {
     return () => {
@@ -112,6 +129,7 @@ export default function ParamArrayFormItem({ param }: ParamProps) {
                 <ArrayItem
                   param={param}
                   onChange={handleChangeItem(item, onChange)}
+                  initialValue={item.value}
                 />
                 <button
                   className="openapi-explorer__delete-btn"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
@@ -271,7 +271,7 @@ function setHeaders(
         if (param.style === "simple") {
           if (param.explode) {
             // Each item in the array is a separate header
-            param.value.forEach((val) => {
+            jsonResult.forEach((val: any) => {
               postman.addHeader({ key: param.name, value: val });
             });
           } else {
@@ -287,7 +287,7 @@ function setHeaders(
           if (param.explode) {
             // Each key-value pair in the object is a separate header
             Object.entries(jsonResult).forEach(([key, val]) => {
-              postman.addHeader({ key, value: val });
+              postman.addHeader({ key: param.name, value: `${key}=${val}` });
             });
           } else {
             // Object is serialized as a single header with key-value pairs joined by commas

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
@@ -28,6 +28,17 @@ function setQueryParams(postman: sdk.Request, queryParams: Param[]) {
       }
 
       if (Array.isArray(param.value)) {
+        // Manual support for handling exploded query params
+        if (param.explode) {
+          let queryStringArr = [];
+
+          for (let i = 0; i < param.value.length; i++) {
+            queryStringArr.push(`${param.name}=${param.value[i]}`);
+          }
+
+          return queryStringArr.join("&");
+        }
+
         return new sdk.QueryParam({
           key: param.name,
           value: param.value.join(","),


### PR DESCRIPTION
## Description

This PR consists of adding support for `explode` and correct example generation for array query parameters.

## Motivation and Context

See #1024 for context

## How Has This Been Tested?

Tested with OpenAPI example spec provided in #1024.

## Screenshots (if appropriate)

<img width="1362" alt="Screenshot 2025-01-30 at 1 57 21 PM" src="https://github.com/user-attachments/assets/e4995eb7-5476-4269-ad74-382d84a95bb7" />

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
