### PR TITLE
fix: Zero values for minimum or maximum were not rendered

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.test.ts
@@ -124,6 +124,18 @@ describe("getQualifierMessage", () => {
     expect(actual).toBe(expected);
   });
 
+  it("should render 0 minimum and maximum", () => {
+    const expected = "**Possible values:** `>= 0` and `<= 40`";
+    const actual = getQualifierMessage({ minimum: 0, maximum: 40 });
+    expect(actual).toBe(expected);
+  });
+
+  it("should render minimum and 0 maximum", () => {
+    const expected = "**Possible values:** `>= -10` and `<= 0`";
+    const actual = getQualifierMessage({ minimum: -10, maximum: 0 });
+    expect(actual).toBe(expected);
+  });
+
   it("should render boolean exclusiveMinimum and maximum", () => {
     const expected = "**Possible values:** `> 1` and `<= 40`";
     const actual = getQualifierMessage({

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
@@ -116,8 +116,8 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
   }
 
   if (
-    schema.minimum ||
-    schema.maximum ||
+    schema.minimum != null ||
+    schema.maximum != null ||
     typeof schema.exclusiveMinimum === "number" ||
     typeof schema.exclusiveMaximum === "number"
   ) {
@@ -126,16 +126,16 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
     let maximum;
     if (typeof schema.exclusiveMinimum === "number") {
       minimum = `\`> ${schema.exclusiveMinimum}\``;
-    } else if (schema.minimum && !schema.exclusiveMinimum) {
+    } else if (schema.minimum != null && !schema.exclusiveMinimum) {
       minimum = `\`>= ${schema.minimum}\``;
-    } else if (schema.minimum && schema.exclusiveMinimum === true) {
+    } else if (schema.minimum != null && schema.exclusiveMinimum === true) {
       minimum = `\`> ${schema.minimum}\``;
     }
     if (typeof schema.exclusiveMaximum === "number") {
       maximum = `\`< ${schema.exclusiveMaximum}\``;
-    } else if (schema.maximum && !schema.exclusiveMaximum) {
+    } else if (schema.maximum != null && !schema.exclusiveMaximum) {
       maximum = `\`<= ${schema.maximum}\``;
-    } else if (schema.maximum && schema.exclusiveMaximum === true) {
+    } else if (schema.maximum != null && schema.exclusiveMaximum === true) {
       maximum = `\`< ${schema.maximum}\``;
     }
 

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
@@ -112,8 +112,8 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
   }
 
   if (
-    schema.minimum ||
-    schema.maximum ||
+    schema.minimum != null ||
+    schema.maximum != null ||
     typeof schema.exclusiveMinimum === "number" ||
     typeof schema.exclusiveMaximum === "number"
   ) {
@@ -122,16 +122,16 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
     let maximum;
     if (typeof schema.exclusiveMinimum === "number") {
       minimum = `\`> ${schema.exclusiveMinimum}\``;
-    } else if (schema.minimum && !schema.exclusiveMinimum) {
+    } else if (schema.minimum != null && !schema.exclusiveMinimum) {
       minimum = `\`>= ${schema.minimum}\``;
-    } else if (schema.minimum && schema.exclusiveMinimum === true) {
+    } else if (schema.minimum != null && schema.exclusiveMinimum === true) {
       minimum = `\`> ${schema.minimum}\``;
     }
     if (typeof schema.exclusiveMaximum === "number") {
       maximum = `\`< ${schema.exclusiveMaximum}\``;
-    } else if (schema.maximum && !schema.exclusiveMaximum) {
+    } else if (schema.maximum != null && !schema.exclusiveMaximum) {
       maximum = `\`<= ${schema.maximum}\``;
-    } else if (schema.maximum && schema.exclusiveMaximum === true) {
+    } else if (schema.maximum != null && schema.exclusiveMaximum === true) {
       maximum = `\`< ${schema.maximum}\``;
     }
 


### PR DESCRIPTION
## Description

The check for maximum and minimum values missed the zero value, which is a falsy, so it was not rendered.

## Motivation and Context

I’m using this addon for my project, but it doesn’t render the minimum/maximum value. [#754](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/754) was supposed to fix the issue, but it still persists, so I decided to resolve it myself.

## How Has This Been Tested?

- Added more unit tests to cover all new cases and ensure both new and existing tests pass.
- Tested in the demo, and everything is working fine.

## Screenshots

![image](https://github.com/user-attachments/assets/cf818731-ecc3-48bb-89e4-77473e4cd19c)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
