### PR TITLE
[Bug Fix]: Cannot read properties of undefined (reading 'endsWith')

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -191,7 +191,8 @@ function createItems(
 
       // Handle vendor JSON media types
       const bodyContent = operationObject.requestBody?.content;
-      if (bodyContent) {
+
+      if (bodyContent && Object.keys(bodyContent).length > 0) {
         const firstBodyContentKey = Object.keys(bodyContent)[0];
         if (firstBodyContentKey.endsWith("+json")) {
           const firstBody = bodyContent[firstBodyContentKey];


### PR DESCRIPTION
## Description

This PR addresses an issue in the event that an OpenAPI spec provides an empty request body, which causes the following error when running the `yarn gen-api` command: 

```
Loading of api failed for "/Users/blinda/Desktop/projects/docusaurus-openapi-docs/demo/examples/odinconnector.json"

[ERROR] TypeError: Cannot read properties of undefined (reading 'endsWith')
    at createItems (/Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/openapi/openapi.js:155:41)
    at processOpenapiFile (/Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/openapi/openapi.js:514:19)
    at async /Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/openapi/openapi.js:468:35
    at async Promise.all (index 0)
    at async processOpenapiFiles (/Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/openapi/openapi.js:479:22)
    at async generateApiDocs (/Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/index.js:95:44)
    at async /Users/blinda/Desktop/projects/docusaurus-openapi-docs/packages/docusaurus-plugin-openapi-docs/lib/index.js:500:15
```

## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1085 for context.

## How Has This Been Tested?

Tested locally with spec provided in https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1085

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/8403fa1c-5fd6-4339-8018-a9c1e298f3e2)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
