### PR TITLE
downloadUrl option is now available to all API entities, previously only "info" pages

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -311,10 +311,8 @@ custom_edit_url: null
       };
 
       loadedApi.map(async (item) => {
-        if (item.type === "info") {
-          if (downloadUrl) {
-            item.downloadUrl = downloadUrl;
-          }
+        if (downloadUrl) {
+          item.downloadUrl = downloadUrl;
         }
         const markdown = pageGeneratorByType[item.type](item as any);
         item.markdown = markdown;


### PR DESCRIPTION
## Description

When building pages, the `downloadUrl` configuration property was previously only available to 'info' pages. It is now available to all types of pages.

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1093

## Motivation and Context

I want to add a "download schema" option to individual API endpoint pages. It is currently not possible, as the config property is only provided to info pages.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
