### PR TITLE
Add support for default parameter values

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -93,6 +93,12 @@ x-tagGroups:
 paths:
   /pet:
     parameters:
+      - name: limit
+        in: query
+        required: true
+        schema:
+          type: integer
+          default: 10
       - name: Accept-Language
         in: header
         description: "The language you prefer for messages. Supported values are en-AU, en-CA, en-GB, en-US"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
@@ -17,22 +17,41 @@ export interface ParamProps {
 
 export default function ParamTextFormItem({ param }: ParamProps) {
   const dispatch = useTypedDispatch();
+  const [inputValue, setInputValue] = useState("");
+
+  useEffect(() => {
+    if (param.schema?.default) {
+      setInputValue(param.schema.default);
+      dispatch(
+        setParam({
+          ...param,
+          value: param.schema.default,
+        })
+      );
+    }
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue =
+      param.in === "path" || param.in === "query"
+        ? e.target.value.replace(/\s/g, "%20")
+        : e.target.value;
+    setInputValue(newValue);
+    dispatch(
+      setParam({
+        ...param,
+        value: newValue,
+      })
+    );
+  };
+
   return (
     <FormTextInput
       isRequired={param.required}
       paramName={param.name}
       placeholder={param.description || param.name}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-        dispatch(
-          setParam({
-            ...param,
-            value:
-              param.in === "path" || param.in === "query"
-                ? e.target.value.replace(/\s/g, "%20")
-                : e.target.value,
-          })
-        )
-      }
+      value={inputValue}
+      onChange={handleChange}
     />
   );
 }


### PR DESCRIPTION
## Description

This PR provides added support for pre-filling `example` values provided by an OpenAPI spec within the Request Panel.

## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1079 for context

## How Has This Been Tested?

Tested by adding a new query parameter to Petstore API containing a default value: 

```
paths:
  /pet:
    parameters:
      - name: limit
        in: query
        required: true
        schema:
          type: integer
          default: 10
```

## Screenshots (if appropriate)

![Screenshot 2025-02-24 at 3 35 23 PM](https://github.com/user-attachments/assets/e404bfcc-8f49-42d9-8c61-5aeb6bb26078)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
