### PR TITLE
[Bug Fix] Render fragment for empty Discriminator Tabs children

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme-classic.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme-classic.d.ts
@@ -21,7 +21,9 @@ declare module "@docusaurus/theme-common/internal" {
   import { Props as ILineProps } from "@theme/CodeBlock/Line";
   import { PrismTheme } from "prism-react-renderer";
 
-  export interface TabProps extends ITabsProps {}
+  export interface TabProps extends ITabsProps {
+    length?: number;
+  }
 
   export interface CopyButtonProps extends ICopyButtonProps {}
   export interface LineProps extends ILineProps {}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
@@ -209,6 +209,9 @@ function TabsComponent(props: TabProps): React.JSX.Element {
 }
 export default function DiscriminatorTabs(props: TabProps): React.JSX.Element {
   const isBrowser = useIsBrowser();
+
+  if (!props.length) return <React.Fragment />;
+
   return (
     <TabsComponent
       // Remount tabs after hydration


### PR DESCRIPTION
## Description

This PR addresses the following issue for page crashes due to non-rendering `TabItem` components: 

![image](https://github.com/user-attachments/assets/72db00b9-1dba-41d3-95dc-95645c4034a2)


## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1086 for context. 
## How Has This Been Tested?

Tested with example spec provided in https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1086 and navigating to `/get-series-list` path.

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/578d3e87-64e3-4e0a-9e62-692f37875f67)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
