### PR TITLE
Don't double encode application/json requestBody examples

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -233,9 +233,18 @@ function Body({
     }
     if (examples) {
       for (const [key, example] of Object.entries(examples)) {
+        let body = example.value;
+        try {
+          // If the value is already valid JSON we shouldn't double encode the value
+          JSON.parse(example.value);
+        }
+        catch (e) {
+          body = JSON.stringify(example.value, null, 2);
+        }
+
         examplesBodies.push({
           label: key,
-          body: JSON.stringify(example.value, null, 2),
+          body,
           summary: example.summary,
         });
       }


### PR DESCRIPTION
## Description

When providing examples of `application/json` request body content, docusaurus-theme-openapi-docs will double escape the content for display and for use in code samples.

## Motivation and Context

This pull request introduces changes to correctly render request body examples. This brings request body examples inline with response body examples which are already rendered correctly.

## How Has This Been Tested?
Minimal example

```yaml
openapi: 3.0.3
info:
  title: Minimal Example
  version: 1.0.0
servers:
  - url: http://example.com
paths:
  /demo:
    post:
      summary: Demo Endpoint
      description: Demo incorrect request body rendering
      requestBody:  
        content:
          application/json:
            schema: 
              type: object
              properties:
                test:
                  type: string
                  example: alpha
            examples:
              bravo:
                summary: Bravo
                value: |
                  {
                    "test": "bravo"
                  }
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema: 
                type: object
                properties: 
                  success:
                    type: boolean
              examples:
                ok:
                  summary: OK
                  value: |
                    {
                      "success": true
                    }

```

## Screenshots (if appropriate)

Before pull request:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/7ba9048e-5b7f-4ad4-8d7c-e2ec025df840" />

After pull request:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/14f03063-dd8a-49aa-938b-4acbe146771e" />


<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All ~new and~ existing tests passed.
