### PR TITLE
[Bug Fix] Properly handle empty Discriminator Tab children

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
@@ -210,7 +210,11 @@ function TabsComponent(props: TabProps): React.JSX.Element {
 export default function DiscriminatorTabs(props: TabProps): React.JSX.Element {
   const isBrowser = useIsBrowser();
 
-  if (!props.length) return <React.Fragment />;
+  if (
+    !props.children ||
+    (Array.isArray(props.children) && props.children.length === 0)
+  )
+    return <React.Fragment />;
 
   return (
     <TabsComponent


### PR DESCRIPTION
## Description

This PR addresses a regression bug introduced in https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1099 which caused Discriminator Tabs to not render. The bug was caused by an invalid check against empty Discriminator `props` children.

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1106 for context.

## How Has This Been Tested?

Tested with example spec in [original issue](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1086) and navigating to `get-series-list`, as well as ensuring that Discriminator tabs are still rendering as expected under our available [Discriminator test examples](http://localhost:3002/tests/discriminator-variations-api).

## Screenshots (if appropriate)

![Screenshot 2025-03-10 at 6 52 28 PM](https://github.com/user-attachments/assets/9f704fcb-9dd4-4432-a486-e2c4aa7cd7a5)

![Screenshot 2025-03-11 at 11 07 38 AM](https://github.com/user-attachments/assets/0e8fcd0c-9df3-4dad-aff3-c1c39f22a920)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
