### PR TITLE
Add httpbin.org spec to examples

### DIFF
--- a/demo/docusaurus.config.ts
+++ b/demo/docusaurus.config.ts
@@ -338,6 +338,14 @@ const config: Config = {
             },
             showSchemas: true,
           } satisfies OpenApiPlugin.Options,
+          httpbin: {
+            specPath: "examples/httpbin.yaml",
+            outputDir: "docs/httpbin",
+            sidebarOptions: {
+              groupPathsBy: "tag",
+            },
+            showSchemas: true,
+          } satisfies OpenApiPlugin.Options,
           tests: {
             specPath: "examples/tests",
             outputDir: "docs/tests",

--- a/demo/examples/httpbin.yaml
+++ b/demo/examples/httpbin.yaml
@@ -1,0 +1,1312 @@
+openapi: 3.1.0
+info:
+  description: "A simple HTTP Request & Response Service.<br/> <br/> <b>Run locally: </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>"
+  version: "0.9.2"
+  title: "httpbin.org"
+  contact:
+    email: "me@kennethreitz.org"
+    url: "https://kennethreitz.org"
+    name: "Kenneth Reitz"
+servers:
+  - url: "https://httpbin.org"
+paths:
+  /absolute-redirect/{n}:
+    get:
+      operationId: getAbsoluteRedirect
+      description: "Absolutely 302 Redirects n times."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "Absolutely 302 Redirects n times."
+      tags:
+        - "Redirects"
+  /anything:
+    delete:
+      operationId: deleteAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    get:
+      operationId: getAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    patch:
+      operationId: patchAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    post:
+      operationId: postAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    put:
+      operationId: putAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    trace:
+      operationId: traceAnything
+      description: "Returns anything passed in request data."
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+  /anything/{anything}:
+    delete:
+      operationId: deleteAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    get:
+      operationId: getAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    patch:
+      operationId: patchAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    post:
+      operationId: postAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    put:
+      operationId: putAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+    trace:
+      operationId: traceAnythingByPath
+      description: "Returns anything passed in request data."
+      parameters:
+        - in: "path"
+          name: "anything"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Anything passed in request"
+      summary: "Returns anything passed in request data."
+      tags:
+        - "Anything"
+  /base64/{value}:
+    get:
+      operationId: getBase64
+      description: "Decodes base64url-encoded string."
+      parameters:
+        - in: "path"
+          name: "value"
+          required: true
+          schema:
+            type: "string"
+            default: "SFRUUEJJTiBpcyBhd2Vzb21l"
+      responses:
+        "200":
+          description: "Decoded base64 content."
+      summary: "Decodes base64url-encoded string."
+      tags:
+        - "Dynamic data"
+  /basic-auth/{user}/{passwd}:
+    get:
+      operationId: getBasicAuth
+      description: "Prompts the user for authorization using HTTP Basic Auth."
+      parameters:
+        - in: "path"
+          name: "user"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "passwd"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "401":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using HTTP Basic Auth."
+      tags:
+        - "Auth"
+  /bearer:
+    get:
+      operationId: getBearerAuth
+      description: "Prompts the user for authorization using bearer authentication."
+      parameters:
+        - in: "header"
+          name: "Authorization"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "401":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using bearer authentication."
+      tags:
+        - "Auth"
+  /brotli:
+    get:
+      operationId: getBrotli
+      description: "Returns Brotli-encoded data."
+      responses:
+        "200":
+          description: "Brotli-encoded data."
+      summary: "Returns Brotli-encoded data."
+      tags:
+        - "Response formats"
+  /bytes/{n}:
+    get:
+      operationId: getBytes
+      description: "Returns n random bytes generated with given seed."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Bytes."
+      summary: "Returns n random bytes generated with given seed."
+      tags:
+        - "Dynamic data"
+  /cache:
+    get:
+      operationId: getCache
+      description: "Returns a 304 if an If-Modified-Since header or If-None-Match is present. Returns the same as a GET otherwise."
+      parameters:
+        - in: "header"
+          name: "If-Modified-Since"
+          schema:
+            type: "string"
+        - in: "header"
+          name: "If-None-Match"
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Cached response."
+          content:
+            application/json:
+              schema:
+                type: "object"
+        "304":
+          description: "Not modified."
+      summary: "Returns a 304 if an If-Modified-Since header or If-None-Match is present. Returns the same as a GET otherwise."
+      tags:
+        - "Response inspection"
+  /cache/{value}:
+    get:
+      operationId: getCacheValue
+      description: "Sets a Cache-Control header for n seconds."
+      parameters:
+        - in: "path"
+          name: "value"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Cache control set."
+      summary: "Sets a Cache-Control header for n seconds."
+      tags:
+        - "Response inspection"
+  /cookies:
+    get:
+      operationId: getCookies
+      description: "Returns cookie data."
+      responses:
+        "200":
+          description: "Set cookies."
+      summary: "Returns cookie data."
+      tags:
+        - "Cookies"
+  /cookies/delete:
+    get:
+      operationId: deleteCookies
+      description: "Deletes cookie(s) as provided by the query string and redirects to cookie list."
+      parameters:
+        - in: "query"
+          name: "freeform"
+          required: false
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+          style: "form"
+          explode: true
+      responses:
+        "200":
+          description: "Redirect to cookie list."
+      summary: "Deletes cookie(s) as provided by the query string and redirects to cookie list."
+      tags:
+        - "Cookies"
+  /cookies/set:
+    get:
+      operationId: setCookies
+      description: "Sets cookie(s) as provided by the query string and redirects to cookie list."
+      parameters:
+        - in: "query"
+          name: "freeform"
+          required: false
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+          style: "form"
+          explode: true
+      responses:
+        "200":
+          description: "Redirect to cookie list."
+      summary: "Sets cookie(s) as provided by the query string and redirects to cookie list."
+      tags:
+        - "Cookies"
+  /cookies/set/{name}/{value}:
+    get:
+      operationId: setCookieByName
+      description: "Sets a cookie and redirects to cookie list."
+      parameters:
+        - in: "path"
+          name: "name"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "value"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Set cookies and redirects to cookie list."
+      summary: "Sets a cookie and redirects to cookie list."
+      tags:
+        - "Cookies"
+  /deflate:
+    get:
+      operationId: getDeflate
+      description: "Returns Deflate-encoded data."
+      responses:
+        "200":
+          description: "Deflate-encoded data."
+      summary: "Returns Deflate-encoded data."
+      tags:
+        - "Response formats"
+  /delay/{delay}:
+    delete:
+      operationId: deleteDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+    get:
+      operationId: getDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+    patch:
+      operationId: patchDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+    post:
+      operationId: postDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+    put:
+      operationId: putDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+    trace:
+      operationId: traceDelay
+      description: "Returns a delayed response (max of 10 seconds)."
+      parameters:
+        - in: "path"
+          name: "delay"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "A delayed response."
+      summary: "Returns a delayed response (max of 10 seconds)."
+      tags:
+        - "Dynamic data"
+  /delete:
+    delete:
+      operationId: deleteRequest
+      description: "The request's DELETE parameters."
+      responses:
+        "200":
+          description: "The request's DELETE parameters."
+      summary: "The request's DELETE parameters."
+      tags:
+        - "HTTP Methods"
+  /deny:
+    get:
+      operationId: getDeny
+      description: "Returns page denied by robots.txt rules."
+      responses:
+        "200":
+          description: "Denied message."
+      summary: "Returns page denied by robots.txt rules."
+      tags:
+        - "Response formats"
+  /digest-auth/{qop}/{user}/{passwd}:
+    get:
+      operationId: getDigestAuth
+      description: "Prompts the user for authorization using Digest Auth."
+      parameters:
+        - in: "path"
+          name: "qop"
+          required: true
+          schema:
+            type: "string"
+          description: "auth or auth-int"
+        - in: "path"
+          name: "user"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "passwd"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "401":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using Digest Auth."
+      tags:
+        - "Auth"
+  /digest-auth/{qop}/{user}/{passwd}/{algorithm}:
+    get:
+      operationId: getDigestAuthWithAlgorithm
+      description: "Prompts the user for authorization using Digest Auth + Algorithm."
+      parameters:
+        - in: "path"
+          name: "qop"
+          required: true
+          schema:
+            type: "string"
+          description: "auth or auth-int"
+        - in: "path"
+          name: "user"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "passwd"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "algorithm"
+          required: true
+          schema:
+            type: "string"
+            enum: ["MD5", "SHA-256", "SHA-512"]
+          description: "MD5, SHA-256, SHA-512"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "401":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using Digest Auth + Algorithm."
+      tags:
+        - "Auth"
+  /digest-auth/{qop}/{user}/{passwd}/{algorithm}/{stale_after}:
+    get:
+      operationId: getDigestAuthWithAlgorithmAndStaleAfter
+      description: "Prompts the user for authorization using Digest Auth + Algorithm."
+      parameters:
+        - in: "path"
+          name: "qop"
+          required: true
+          schema:
+            type: "string"
+          description: "auth or auth-int"
+        - in: "path"
+          name: "user"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "passwd"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "algorithm"
+          required: true
+          schema:
+            type: "string"
+            enum: ["MD5", "SHA-256", "SHA-512"]
+          description: "MD5, SHA-256, SHA-512"
+        - in: "path"
+          name: "stale_after"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "401":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using Digest Auth + Algorithm."
+      tags:
+        - "Auth"
+  /drip:
+    get:
+      operationId: getDrip
+      description: "Drips data over a duration after an optional initial delay."
+      parameters:
+        - in: "query"
+          name: "duration"
+          required: false
+          schema:
+            type: "number"
+            default: 2
+          description: "The amount of time (in seconds) over which to drip each byte"
+        - in: "query"
+          name: "numbytes"
+          required: false
+          schema:
+            type: "integer"
+            default: 10
+          description: "The number of bytes to respond with"
+        - in: "query"
+          name: "code"
+          required: false
+          schema:
+            type: "integer"
+            default: 200
+          description: "The response code that will be returned"
+        - in: "query"
+          name: "delay"
+          required: false
+          schema:
+            type: "number"
+            default: 2
+          description: "The amount of time (in seconds) to delay before responding"
+      responses:
+        "200":
+          description: "A dripped response."
+      summary: "Drips data over a duration after an optional initial delay."
+      tags:
+        - "Dynamic data"
+  /encoding/utf8:
+    get:
+      operationId: getUtf8
+      description: "Returns a UTF-8 encoded body."
+      responses:
+        "200":
+          description: "Encoded UTF-8 content."
+      summary: "Returns a UTF-8 encoded body."
+      tags:
+        - "Response formats"
+  /etag/{etag}:
+    get:
+      operationId: getEtag
+      description: "Assumes the resource has the given etag and responds to If-None-Match and If-Match headers appropriately."
+      parameters:
+        - in: "path"
+          name: "etag"
+          required: true
+          schema:
+            type: "string"
+        - in: "header"
+          name: "If-None-Match"
+          required: false
+          schema:
+            type: "string"
+        - in: "header"
+          name: "If-Match"
+          required: false
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Normal response."
+        "412":
+          description: "Precondition failed."
+      summary: "Assumes the resource has the given etag and responds to If-None-Match and If-Match headers appropriately."
+      tags:
+        - "Response inspection"
+  /get:
+    get:
+      operationId: getRequest
+      description: "The request's query parameters."
+      responses:
+        "200":
+          description: "The request's query parameters."
+      summary: "The request's query parameters."
+      tags:
+        - "HTTP Methods"
+  /gzip:
+    get:
+      operationId: getGzip
+      description: "Returns GZip-encoded data."
+      responses:
+        "200":
+          description: "GZip-encoded data."
+      summary: "Returns GZip-encoded data."
+      tags:
+        - "Response formats"
+  /headers:
+    get:
+      operationId: getHeaders
+      description: "Returns the incoming request's HTTP headers."
+      responses:
+        "200":
+          description: "The request's headers."
+      summary: "Returns the incoming request's HTTP headers."
+      tags:
+        - "Request inspection"
+  /hidden-basic-auth/{user}/{passwd}:
+    get:
+      operationId: getHiddenBasicAuth
+      description: "Prompts the user for authorization using HTTP Basic Auth."
+      parameters:
+        - in: "path"
+          name: "user"
+          required: true
+          schema:
+            type: "string"
+        - in: "path"
+          name: "passwd"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Successful authentication."
+        "404":
+          description: "Unsuccessful authentication."
+      summary: "Prompts the user for authorization using HTTP Basic Auth."
+      tags:
+        - "Auth"
+  /html:
+    get:
+      operationId: getHtml
+      description: "Returns a simple HTML document."
+      responses:
+        "200":
+          description: "An HTML page."
+      summary: "Returns a simple HTML document."
+      tags:
+        - "Response formats"
+  /image:
+    get:
+      operationId: getImage
+      description: "Returns a simple image of the type suggested by the Accept header."
+      responses:
+        "200":
+          description: "An image."
+          content:
+            image/webp: {}
+            image/svg+xml: {}
+            image/jpeg: {}
+            image/png: {}
+            image/*: {}
+      summary: "Returns a simple image of the type suggested by the Accept header."
+      tags:
+        - "Images"
+  /image/jpeg:
+    get:
+      operationId: getJpegImage
+      description: "Returns a simple JPEG image."
+      responses:
+        "200":
+          description: "A JPEG image."
+          content:
+            image/jpeg: {}
+      summary: "Returns a simple JPEG image."
+      tags:
+        - "Images"
+  /image/png:
+    get:
+      operationId: getPngImage
+      description: "Returns a simple PNG image."
+      responses:
+        "200":
+          description: "A PNG image."
+          content:
+            image/png: {}
+      summary: "Returns a simple PNG image."
+      tags:
+        - "Images"
+  /image/svg:
+    get:
+      operationId: getSvgImage
+      description: "Returns a simple SVG image."
+      responses:
+        "200":
+          description: "An SVG image."
+          content:
+            image/svg+xml: {}
+      summary: "Returns a simple SVG image."
+      tags:
+        - "Images"
+  /image/webp:
+    get:
+      operationId: getWebpImage
+      description: "Returns a simple WEBP image."
+      responses:
+        "200":
+          description: "A WEBP image."
+          content:
+            image/webp: {}
+      summary: "Returns a simple WEBP image."
+      tags:
+        - "Images"
+  /ip:
+    get:
+      operationId: getIp
+      description: "Returns the requester's IP Address."
+      responses:
+        "200":
+          description: "The requester's IP Address."
+      summary: "Returns the requester's IP Address."
+      tags:
+        - "Request inspection"
+  /json:
+    get:
+      operationId: getJson
+      description: "Returns a simple JSON document."
+      responses:
+        "200":
+          description: "A JSON document."
+      summary: "Returns a simple JSON document."
+      tags:
+        - "Response formats"
+  /links/{n}/{offset}:
+    get:
+      operationId: getLinks
+      description: "Generate a page containing n links to other pages which do the same."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+        - in: "path"
+          name: "offset"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "HTML links."
+      summary: "Generate a page containing n links to other pages which do the same."
+      tags:
+        - "Dynamic data"
+  /patch:
+    patch:
+      operationId: patchRequest
+      description: "The request's PATCH parameters."
+      responses:
+        "200":
+          description: "The request's PATCH parameters."
+      summary: "The request's PATCH parameters."
+      tags:
+        - "HTTP Methods"
+  /post:
+    post:
+      operationId: postRequest
+      description: "The request's POST parameters."
+      responses:
+        "200":
+          description: "The request's POST parameters."
+      summary: "The request's POST parameters."
+      tags:
+        - "HTTP Methods"
+  /put:
+    put:
+      operationId: putRequest
+      description: "The request's PUT parameters."
+      responses:
+        "200":
+          description: "The request's PUT parameters."
+      summary: "The request's PUT parameters."
+      tags:
+        - "HTTP Methods"
+  /range/{numbytes}:
+    get:
+      operationId: getRangeBytes
+      description: "Streams n random bytes generated with given seed, at given chunk size per packet."
+      parameters:
+        - in: "path"
+          name: "numbytes"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Bytes."
+      summary: "Streams n random bytes generated with given seed, at given chunk size per packet."
+      tags:
+        - "Dynamic data"
+  /redirect-to:
+    delete:
+      operationId: deleteRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+    get:
+      operationId: getRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+    patch:
+      operationId: patchRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+    post:
+      operationId: postRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+    put:
+      operationId: putRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+    trace:
+      operationId: traceRedirectTo
+      description: "302/3XX Redirects to the given URL."
+      parameters:
+        - in: "query"
+          name: "url"
+          required: true
+          schema:
+            type: "string"
+        - in: "query"
+          name: "status_code"
+          required: false
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302/3XX Redirects to the given URL."
+      tags:
+        - "Redirects"
+  /redirect/{n}:
+    get:
+      operationId: getRedirect
+      description: "302 Redirects n times."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "302 Redirects n times."
+      tags:
+        - "Redirects"
+  /relative-redirect/{n}:
+    get:
+      operationId: getRelativeRedirect
+      description: "Relatively 302 Redirects n times."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "302":
+          description: "A redirection."
+      summary: "Relatively 302 Redirects n times."
+      tags:
+        - "Redirects"
+  /response-headers:
+    get:
+      operationId: getResponseHeaders
+      description: "Returns a set of response headers from the query string."
+      parameters:
+        - in: "query"
+          name: "freeform"
+          required: false
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+          style: "form"
+          explode: true
+      responses:
+        "200":
+          description: "Response headers."
+      summary: "Returns a set of response headers from the query string."
+      tags:
+        - "Response inspection"
+    post:
+      operationId: postResponseHeaders
+      description: "Returns a set of response headers from the query string."
+      parameters:
+        - in: "query"
+          name: "freeform"
+          required: false
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+          style: "form"
+          explode: true
+      responses:
+        "200":
+          description: "Response headers."
+      summary: "Returns a set of response headers from the query string."
+      tags:
+        - "Response inspection"
+  /robots.txt:
+    get:
+      operationId: getRobotsTxt
+      description: "Returns some robots.txt rules."
+      responses:
+        "200":
+          description: "Robots file."
+      summary: "Returns some robots.txt rules."
+      tags:
+        - "Response formats"
+  /status/{codes}:
+    delete:
+      operationId: deleteStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+    get:
+      operationId: getStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+    patch:
+      operationId: patchStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+    post:
+      operationId: postStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+    put:
+      operationId: putStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+    trace:
+      operationId: traceStatus
+      description: "Return status code or random status code if more than one are given."
+      parameters:
+        - in: "path"
+          name: "codes"
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "100":
+          description: "Informational responses."
+        "200":
+          description: "Success."
+        "300":
+          description: "Redirection."
+        "400":
+          description: "Client Errors."
+        "500":
+          description: "Server Errors."
+      summary: "Return status code or random status code if more than one are given."
+      tags:
+        - "Status codes"
+  /stream-bytes/{n}:
+    get:
+      operationId: getStreamBytes
+      description: "Streams n random bytes generated with given seed, at given chunk size per packet."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Bytes."
+      summary: "Streams n random bytes generated with given seed, at given chunk size per packet."
+      tags:
+        - "Dynamic data"
+  /stream/{n}:
+    get:
+      operationId: getStream
+      description: "Stream n JSON responses."
+      parameters:
+        - in: "path"
+          name: "n"
+          required: true
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Streamed JSON responses."
+      summary: "Stream n JSON responses."
+      tags:
+        - "Dynamic data"
+  /user-agent:
+    get:
+      operationId: getUserAgent
+      description: "Returns the incoming request's User-Agent header."
+      responses:
+        "200":
+          description: "The request's User-Agent header."
+      summary: "Returns the incoming request's User-Agent header."
+      tags:
+        - "Request inspection"
+  /uuid:
+    get:
+      operationId: getUuid
+      description: "Returns a UUID4."
+      responses:
+        "200":
+          description: "A UUID4."
+      summary: "Returns a UUID4."
+      tags:
+        - "Dynamic data"
+  /xml:
+    get:
+      operationId: getXml
+      description: "Returns a simple XML document."
+      responses:
+        "200":
+          description: "An XML document."
+      summary: "Returns a simple XML document."
+      tags:
+        - "Response formats"
+tags:
+  - name: "HTTP Methods"
+    description: "Testing different HTTP verbs"
+  - name: "Auth"
+    description: "Auth methods"
+  - name: "Status codes"
+    description: "Generates responses with given status code"
+  - name: "Request inspection"
+    description: "Inspect the request data"
+  - name: "Response inspection"
+    description: "Inspect the response data like caching and headers"
+  - name: "Response formats"
+    description: "Returns responses in different data formats"
+  - name: "Dynamic data"
+    description: "Generates random and dynamic data"
+  - name: "Cookies"
+    description: "Creates, reads and deletes Cookies"
+  - name: "Images"
+    description: "Returns different image formats"
+  - name: "Redirects"
+  - name: "Anything"

--- a/demo/sidebars.ts
+++ b/demo/sidebars.ts
@@ -135,6 +135,16 @@ const sidebars: SidebarsConfig = {
       },
       items: require("./docs/restaurant/sidebar.js"),
     },
+    {
+      type: "category",
+      label: "HTTPBin",
+      link: {
+        type: "generated-index",
+        title: "HTTPBin API",
+        slug: "/category/httpbin-api",
+      },
+      items: require("./docs/httpbin/sidebar.js"),
+    },
   ],
   "petstore-2.0.0": [
     {


### PR DESCRIPTION
## Description

Adds the HTTPBin spec to provide a more interactive experience for evaluating API Explorer across different operations.

> Note: the original v2 spec was upgraded and heavily cleaned up using gpt-4o