### PR TITLE
ci: upgrade node version to deploy live and deploy preview

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
 
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
 
       - name: Install dependencies
@@ -126,7 +126,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
 
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4


### PR DESCRIPTION
## Description

Updated the Node.js version in the CI workflow from v18.20.7 to v20.0.0 to ensure compatibility with Firebase CLI v14.0.1.

## Motivation and Context

The current CI workflow is failing due to a version mismatch between Node.js and the Firebase CLI. Firebase CLI v14.0.1 requires Node.js version >=20.0.0 || >=22.0.0, but our workflow was using Node.js v18.20.7. This update is necessary to resolve deployment failures and ensure proper CI/CD pipeline functionality.

## How Has This Been Tested?

1. Verified that the CI workflow runs successfully using Node.js v20.0.0  
2. Confirmed that Firebase deployment completes without version compatibility errors  
3. Validated that all other CI steps continue to function as expected  

## Types of Changes

- Bug fix (non-breaking change that resolves an issue)

## Checklist

- [x] I have updated the documentation accordingly  
- [x] I have read the **CONTRIBUTING** document  
- [x] I have added tests to cover my changes where appropriate  
- [x] All new and existing tests passed  