### PR TITLE
fix: handle discriminator subschemas that only inherit via allOf without own properties

### DIFF
--- a/demo/examples/tests/discriminator.yaml
+++ b/demo/examples/tests/discriminator.yaml
@@ -321,6 +321,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BaseRequiredMapping"
+
+  /discriminator-empty-subschema:
+    get:
+      tags:
+        - discriminator
+      summary: Discriminator with Subschema Inheriting All Fields (No Extra Fields)
+      description: |
+        This schema reproduces a sub-schema that inherits all fields from the parent (via allOf) and does not define any new properties.
+        Schema:
+        ```yaml
+        type: object
+        discriminator: 
+          propertyName: type
+          mapping:
+            EmptyType: '#/components/schemas/EmptyType'
+        properties:
+          type:
+            type: string
+        oneOf:
+          - $ref: '#/components/schemas/EmptyType'
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseEmptySubschema"
+
 components:
   schemas:
     BaseBasic:
@@ -470,6 +499,18 @@ components:
         - $ref: "#/components/schemas/TypeA"
         - $ref: "#/components/schemas/TypeB"
 
+    BaseEmptySubschema:
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          EmptyType: "#/components/schemas/EmptyType"
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: "#/components/schemas/EmptyType"
+
     TypeA:
       type: object
       properties:
@@ -523,3 +564,8 @@ components:
               type: boolean
       required:
         - type
+
+    EmptyType:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/BaseEmptySubschema"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -352,7 +352,8 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
     }
 
     const subProperties = subSchema.properties || mergedSubSchema.properties;
-    if (subProperties[discriminator.propertyName]) {
+    // Add a safeguard check to avoid referencing subProperties if it's undefined
+    if (subProperties && subProperties[discriminator.propertyName]) {
       if (schema.properties) {
         schema.properties![discriminator.propertyName] = {
           ...schema.properties![discriminator.propertyName],


### PR DESCRIPTION
# Description

This PR addresses an issue where the OpenAPI spec defines a discriminator with a subschema that only inherits all fields from the parent (using allOf) and does not define any new properties. Previously, this pattern would cause a runtime error in the Docusaurus OpenAPI plugin due to an attempt to access properties of an undefined object.

See #1132 for more background.

## Motivation and Context

OpenAPI allows for discriminator mappings where a child schema inherits all properties from its parent via allOf and does not introduce any new properties. This is a valid and common pattern for modeling inheritance. Prior to this fix, such schemas would cause the documentation build or runtime to fail with a TypeError. This PR adds a safeguard to ensure the code handles these cases gracefully, allowing the documentation to render correctly for all valid OpenAPI discriminator patterns.

## How Has This Been Tested?
- Added a minimal test case in `demo/examples/tests/discriminator.yaml` under `/discriminator-empty-subschema` that uses a parent schema with a discriminator and a child schema that only inherits via `allOf`.
- Verified that the documentation renders without errors and the schema is displayed as expected.