### PR TITLE
Conditionally apply info template

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -383,11 +383,17 @@ custom_edit_url: null
         if (item.type === "info") {
           if (!fs.existsSync(`${outputDir}/${item.id}.info.mdx`)) {
             try {
-              fs.writeFileSync(
-                `${outputDir}/${item.id}.info.mdx`,
-                utils,
-                "utf8"
-              );
+              sidebarOptions?.categoryLinkSource === "info" || infoTemplate // Only use utils template if set to "info" or if infoTemplate is set
+                ? fs.writeFileSync(
+                    `${outputDir}/${item.id}.info.mdx`,
+                    utils,
+                    "utf8"
+                  )
+                : fs.writeFileSync(
+                    `${outputDir}/${item.id}.info.mdx`,
+                    view,
+                    "utf8"
+                  );
               console.log(
                 chalk.green(
                   `Successfully created "${outputDir}/${item.id}.info.mdx"`


### PR DESCRIPTION
## Description

A regression bug was introduced in #1122 that resulted in build errors in cases where info pages were not used as `categoryLinkSource`.

```
Error: /access/api/insights/palo-alto-networks-3-0-apis/ is not associated with a category. useCurrentSidebarCategory() should only be used on category index pages.
```

This PR adds conditions back to ensure the info template is only applied when either:
* `categoryLinkSource` is set to "info" or
* A user defined `infoTemplate` is provided

## Motivation and Context

The info template should only be applied in the cases mentioned above, otherwise fall back to just rendering the info page using the standard `view` template.

## How Has This Been Tested?

See deploy preview

## Screenshots (if appropriate)

See deploy preview

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
