### PR TITLE
feat: support const for OAS 3.1.1

### DIFF
--- a/demo/examples/tests/const.yaml
+++ b/demo/examples/tests/const.yaml
@@ -1,0 +1,93 @@
+openapi: 3.1.1
+info:
+  title: Const
+  description: Demonstrates various const.
+  version: 1.0.0
+tags:
+  - name: const
+    description: const tests
+paths:
+  /const:
+    get:
+      tags:
+        - const
+      summary: const with primitives
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          type:
+            type: string
+            const: example
+            title: Example
+            description: |
+              This is an example
+          quality:
+            type: string
+            oneOf:
+              - const: good
+                title: Good
+                description: |
+                  This is a good example
+              - const: bad
+                title: Bad
+                description: |
+                  This is a bad example
+          tags:
+            type: array
+            items:
+              anyOf:
+                - const: dog
+                  title: Dog
+                  description: |
+                    This is a dog
+                - const: cat
+                  title: Cat
+                  description: |
+                    This is a cat
+        required:
+          - type
+          - quality
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    const: constExample
+                    title: Const Example
+                    description: |
+                      Const example description
+                  quality:
+                    type: string
+                    oneOf:
+                      - const: good
+                        title: Good
+                        description: |
+                          This is a good example
+                      - const: bad
+                        title: Bad
+                        description: |
+                          This is a bad example
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                      anyOf:
+                        - const: dog
+                          title: Dog
+                          description: |
+                            This is a dog
+                        - const: cat
+                          title: Cat
+                          description: |
+                            This is a cat
+                required:
+                  - type
+                  - quality

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -122,9 +122,10 @@ const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
               value={`${index}-item-properties`}
             >
               {/* Handle primitive types directly */}
-              {["string", "number", "integer", "boolean"].includes(
+              {(["string", "number", "integer", "boolean"].includes(
                 anyOneSchema.type
-              ) && (
+              ) ||
+                anyOneSchema.const) && (
                 <SchemaItem
                   collapsible={false}
                   name={undefined}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -65,6 +65,7 @@ export default function SchemaItem(props: Props) {
   let example: string | undefined;
   let nullable;
   let enumDescriptions: [string, string][] = [];
+  let constValue: string | undefined;
 
   if (schema) {
     deprecated = schema.deprecated;
@@ -75,6 +76,7 @@ export default function SchemaItem(props: Props) {
     nullable =
       schema.nullable ||
       (Array.isArray(schema.type) && schema.type.includes("null")); // support JSON Schema nullable
+    constValue = schema.const;
   }
 
   const renderRequired = guard(
@@ -161,6 +163,30 @@ export default function SchemaItem(props: Props) {
     return undefined;
   }
 
+  function renderConstValue() {
+    if (constValue !== undefined) {
+      if (typeof constValue === "string") {
+        return (
+          <div>
+            <strong>Constant value: </strong>
+            <span>
+              <code>{constValue}</code>
+            </span>
+          </div>
+        );
+      }
+      return (
+        <div>
+          <strong>Constant value: </strong>
+          <span>
+            <code>{JSON.stringify(constValue)}</code>
+          </span>
+        </div>
+      );
+    }
+    return undefined;
+  }
+
   const schemaContent = (
     <div>
       <span className="openapi-schema__container">
@@ -184,6 +210,7 @@ export default function SchemaItem(props: Props) {
       {renderSchemaDescription}
       {renderEnumDescriptions}
       {renderQualifierMessage}
+      {renderConstValue()}
       {renderDefaultValue()}
       {renderExample()}
       {collapsibleSchemaContent ?? collapsibleSchemaContent}


### PR DESCRIPTION
## Description

Support `const` as described in OAS 3.1.1.

Resolves: #1142

## Motivation and Context

`const` allows you to declare a constant value.

It also helps compose annotated enumerations, as an improvement to the original `enum`.

REL: https://swagger.io/specification/#annotated-enumerations

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I added a test schema (as seen in PR), and I ran it locally. I did not see any unit/integration test patterns in the repository.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->
<img width="281" alt="Screenshot 2025-05-06 at 8 53 35 PM" src="https://github.com/user-attachments/assets/e0c5712a-1af7-4dc1-b350-b533ed8830e6" />

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
