### PR TITLE
[UI] Add support for apiKey in query and cookie param

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createAuthentication.ts
@@ -13,8 +13,15 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
   if (!securitySchemes || !Object.keys(securitySchemes).length) return "";
 
   const createAuthenticationTable = (securityScheme: any) => {
-    const { bearerFormat, flows, name, scheme, type, openIdConnectUrl } =
-      securityScheme;
+    const {
+      bearerFormat,
+      flows,
+      name,
+      scheme,
+      type,
+      openIdConnectUrl,
+      in: paramIn,
+    } = securityScheme;
 
     const createSecuritySchemeTypeRow = () =>
       create("tr", {
@@ -70,7 +77,9 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
                   createSecuritySchemeTypeRow(),
                   create("tr", {
                     children: [
-                      create("th", { children: "Header parameter name:" }),
+                      create("th", {
+                        children: `${paramIn.charAt(0).toUpperCase() + paramIn.slice(1)} parameter name:`,
+                      }),
                       create("td", { children: name }),
                     ],
                   }),
@@ -142,7 +151,6 @@ export function createAuthentication(securitySchemes: SecuritySchemeObject) {
         return "";
     }
   };
-
   const formatTabLabel = (key: string, type: string, scheme: string) => {
     const formattedLabel = key
       .replace(/(_|-)/g, " ")


### PR DESCRIPTION
## Description

This PR consists of added support for allowing Security Schemes with the type of `apiKey` to be used for the following parameter types: 

- `in: query`
- `in: cookie`

Although the original issue proposes that the value should be shown in the UI, we will continue to mask credentials to align with best security practices - while still allowing the user to make the underlying request within the Request Demo Panel.

## Motivation and Context

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1150 for context.

## How Has This Been Tested?

Tested with the following spec and ensured that request can be made from Request Demo Panel: 

```
  openapi: 3.0.3
  info:
    title: Test API key in Header
    version: 1.0.0
  servers:
    - url: https://httpbingo.org
  tags:
    - name: Test
  paths:
    /get:
      get:
        operationId: getTest
        tags:
          - Test
        summary: Test the securityScheme
        responses:
          '200':
            content:
              application/json:
                schema:
                  type: object
                  properties:
                    args:
                      type: object
                      properties:
                        appId: # should be present, because it will be inserted as a query param
                          type: array
                          items:
                            type: string
                      additionalProperties:
                        type: array
                        items:
                          type: string
                  additionalProperties: true
  components:
    securitySchemes:
      App_ID:
        type: apiKey
        in: query
        name: appId
        description: Provided in the URL as a query parameter `?appId=<id>`, meant  to publicly identify your account, it is not a sensitive information.
  security:
    - App_ID: []
```

## Screenshots (if appropriate)

### Tested request from Demo Panel
![image](https://github.com/user-attachments/assets/a788ba31-6c7d-42ce-b3f8-3d83da1a62ca)

### Updated Authentication Table to reflect `in` parameter (previously hard coded to 'Header')
![Screenshot 2025-05-20 at 2 59 44 PM](https://github.com/user-attachments/assets/d96137dd-919b-4287-946c-6bbe99521976)



## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
