### PR TITLE
Support null type

### DIFF
--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -19,6 +19,7 @@ paths:
           - type: string
           - type: integer
           - type: boolean
+          - type: null
         ```
       responses:
         "200":
@@ -30,6 +31,7 @@ paths:
                   - type: string
                   - type: integer
                   - type: boolean
+                  - type: "null"
 
   /anyof-oneof:
     get:

--- a/demo/examples/tests/oneOf.yaml
+++ b/demo/examples/tests/oneOf.yaml
@@ -22,6 +22,7 @@ paths:
               - type: string
               - type: number
               - type: boolean
+              - type: null
         ```
       responses:
         "200":
@@ -36,6 +37,7 @@ paths:
                       - type: string
                       - type: number
                       - type: boolean
+                      - type: "null"
 
   /oneof-complex-types:
     get:

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createRequestExample.ts
@@ -18,6 +18,7 @@ interface OASTypeToTypeMap {
   boolean: boolean;
   object: any;
   array: any[];
+  null: string | null;
 }
 
 type Primitives = {
@@ -50,6 +51,9 @@ const primitives: Primitives = {
   },
   object: {},
   array: {},
+  null: {
+    default: () => "null",
+  },
 };
 
 function sampleRequestFromProp(name: string, prop: any, obj: any): any {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createResponseExample.ts
@@ -18,6 +18,7 @@ interface OASTypeToTypeMap {
   boolean: boolean;
   object: any;
   array: any[];
+  null: string | null;
 }
 
 type Primitives = {
@@ -50,6 +51,9 @@ const primitives: Primitives = {
   },
   object: {},
   array: {},
+  null: {
+    default: () => "null",
+  },
 };
 
 function sampleResponseFromProp(name: string, prop: any, obj: any): any {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import type { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+import type {
+  JSONSchema4,
+  JSONSchema6,
+  JSONSchema7,
+  JSONSchema7TypeName,
+} from "json-schema";
 
 interface Map<T> {
   [key: string]: T;
@@ -325,6 +330,7 @@ export interface ReferenceObject {
 }
 
 export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
+export type SchemaType = JSONSchema7TypeName;
 export type SchemaObject = Omit<
   JSONSchema,
   | "type"
@@ -337,7 +343,7 @@ export type SchemaObject = Omit<
   | "additionalProperties"
 > & {
   // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  type?: SchemaType;
   allOf?: SchemaObject[];
   oneOf?: SchemaObject[];
   anyOf?: SchemaObject[];
@@ -371,7 +377,7 @@ export type SchemaObjectWithRef = Omit<
   | "additionalProperties"
 > & {
   // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
+  type?: SchemaType;
   allOf?: (SchemaObject | ReferenceObject)[];
   oneOf?: (SchemaObject | ReferenceObject)[];
   anyOf?: (SchemaObject | ReferenceObject)[];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -21,7 +21,10 @@ import {
   getQualifierMessage,
   getSchemaName,
 } from "docusaurus-plugin-openapi-docs/lib/markdown/schema";
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+import {
+  SchemaObject,
+  SchemaType,
+} from "docusaurus-plugin-openapi-docs/lib/openapi/types";
 import isEmpty from "lodash/isEmpty";
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -122,10 +125,7 @@ const AnyOneOf: React.FC<SchemaProps> = ({ schema, schemaType }) => {
               value={`${index}-item-properties`}
             >
               {/* Handle primitive types directly */}
-              {(["string", "number", "integer", "boolean"].includes(
-                anyOneSchema.type
-              ) ||
-                anyOneSchema.const) && (
+              {(isPrimitive(anyOneSchema) || anyOneSchema.const) && (
                 <SchemaItem
                   collapsible={false}
                   name={undefined}
@@ -938,3 +938,17 @@ const SchemaNode: React.FC<SchemaProps> = ({ schema, schemaType }) => {
 };
 
 export default SchemaNode;
+
+type PrimitiveSchemaType = Exclude<SchemaType, "object" | "array">;
+
+const PRIMITIVE_TYPES: Record<PrimitiveSchemaType, true> = {
+  string: true,
+  number: true,
+  integer: true,
+  boolean: true,
+  null: true,
+} as const;
+
+const isPrimitive = (schema: SchemaObject) => {
+  return PRIMITIVE_TYPES[schema.type as PrimitiveSchemaType];
+};


### PR DESCRIPTION
## Description
Support for type: null added in OpenAPI Spec v3.1 has been implemented.

## Motivation and Context
This addresses the issue reported in #1152. For details, please refer to Issue #1152.  
Added `null` to the schema type so that it is displayed in `anyOf` and `oneOf` as well.

## How Has This Been Tested?

Added `null` to the demo tests for `anyOf` and `oneOf` primitives and confirmed that it is displayed.

## Screenshots (if appropriate)

Example with `null` added.
![スクリーンショット 2025-05-29 11 22 55](https://github.com/user-attachments/assets/eacd20b6-0356-479d-8458-b281a66a7e87)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
