### PR TITLE
[Enhancement] Add vendor extension support for positioning sidebar items

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -263,6 +263,7 @@ function createItems(
           jsonRequestBodyExample,
           info: openapiData.info,
         },
+        position: operationObject["x-position"] as number | undefined,
       };
 
       items.push(apiPage);
@@ -508,6 +509,22 @@ function createItems(
         items.push(tagPage);
       });
   }
+
+  items.sort((a, b) => {
+    // Items with position come first, sorted by position
+    if (a.position !== undefined && b.position !== undefined) {
+      return a.position - b.position;
+    }
+    // Items with position come before items without position
+    if (a.position !== undefined) {
+      return -1;
+    }
+    if (b.position !== undefined) {
+      return 1;
+    }
+    // If neither has position, maintain original order
+    return 0;
+  });
 
   return items as ApiMetadata[];
 }

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/types.ts
@@ -156,8 +156,8 @@ export interface OperationObject {
   deprecated?: boolean;
   security?: SecurityRequirementObject[];
   servers?: ServerObject[];
-
   // extensions
+  "x-position"?: number;
   "x-deprecated-description"?: string;
 }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/types.ts
@@ -89,6 +89,7 @@ export interface OpenAPIOperation {
   servers?: OpenAPIServer[];
   "x-codeSamples"?: OpenAPIXCodeSample[];
   "x-code-samples"?: OpenAPIXCodeSample[]; // deprecated
+  "x-position"?: number;
 }
 
 export interface OpenAPIParameter {

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -118,6 +118,7 @@ export interface ApiMetadataBase {
   frontMatter: Record<string, unknown>;
   method?: string;
   path?: string;
+  position?: number;
 }
 
 export interface ApiPageMetadata extends ApiMetadataBase {


### PR DESCRIPTION
## Description

This PR consists of added support for allowing users to add a `x-position` vendor extension for positioning sidebar items accordingly. The `x-position`: `number` can be defined at the endpoint/method level and can be used for the following scenarios: 

1. Multiple methods with a defined `x-position` will be positioned in ascending order, followed by any other sidebar items in their original order.
2. Single method with a defined `x-position` will take precedence followed by other sidebar items in their original order.

## Motivation and Context.

See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1147 for context.

## How Has This Been Tested?

Tested by defining a `x-position` for the following Petstore methods: 
1. ``` 
    put:
      tags:
        - pet
      summary: Update an existing pet
      description: ""
      operationId: updatePet
      responses:
        "400":
          description: Invalid ID supplied
        "404":
          description: Pet not found
        "405":
          description: Validation exception
      security:
        - petstore_auth:
            - "write:pets"
            - "read:pets"
      x-position: 1
      ```
2. ```
    post:
      tags:
        - pet
      summary: Updates a pet in the store with form data
      description: ""
      operationId: updatePetWithForm
      parameters:
        - name: petId
          in: path
          description: ID of pet that needs to be updated
          required: true
          schema:
            type: integer
            format: int64
      responses:
        "405":
          description: Invalid input
      security:
        - petstore_auth:
            - "write:pets"
            - "read:pets"
      x-position: 2
```

## Screenshots (if appropriate)

<img width="341" alt="Screenshot 2025-06-10 at 5 17 27 PM" src="https://github.com/user-attachments/assets/4d91b80c-6f69-419b-8050-3c63a03abbc8" />

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
