### PR TITLE
Prepare release v4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 4.5.1 (Jun 27, 2025)
+
+High level enhancements
+
+- Various bug fixes
+
+Other enhancements and bug fixes
+
+- Fix Postman request initialization ([#1181](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1181))
+- Add AGENTS guidelines ([#1179](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1179))
+
 ## 4.5.0 (Jun 27, 2025)
 
 High level enhancements

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -26,8 +26,8 @@
     "@docusaurus/plugin-google-gtag": "3.8.1",
     "@docusaurus/preset-classic": "3.8.1",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-openapi-docs": "^4.5.0",
-    "docusaurus-theme-openapi-docs": "^4.5.0",
+    "docusaurus-plugin-openapi-docs": "^4.5.1",
+    "docusaurus-theme-openapi-docs": "^4.5.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.5.0",
+  "version": "4.5.1",
   "npmClient": "yarn"
 }

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -38,7 +38,7 @@
     "@types/postman-collection": "^3.5.11",
     "@types/react-modal": "^3.16.3",
     "concurrently": "^5.2.0",
-    "docusaurus-plugin-openapi-docs": "^4.5.0",
+    "docusaurus-plugin-openapi-docs": "^4.5.1",
     "docusaurus-plugin-sass": "^0.2.3",
     "eslint-plugin-prettier": "^5.0.1"
   },


### PR DESCRIPTION
## Summary
- bump version to 4.5.1 across packages
- document release notes for v4.5.1

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_685f119829108323b7ca192b7510d016