### PR TITLE
Perform visual diff following deploy preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -120,6 +120,8 @@ jobs:
     needs: build
     if: ${{ github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.deploy_preview.outputs.details_url }}
 
     steps:
       - name: Checkout repository
@@ -149,3 +151,61 @@ jobs:
           channelId: "pr${{ github.event.number }}"
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels
+
+  visual_diff:
+    name: Visual Diff
+    needs: deploy
+    if: ${{ github.repository == 'PaloAltoNetworks/docusaurus-openapi-docs' && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup node
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn --prefer-offline
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Run visual diff
+        run: ts-node scripts/sitemap-visual-diff.ts --preview-url ${{ needs.deploy.outputs.preview_url }} --summary-file visual_diffs/results.json
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: visual_diffs
+          path: visual_diffs
+
+      - name: Comment PR with results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync('visual_diffs/results.json', 'utf8'));
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let body = `### Visual Diff Summary\n\n[View Logs](${runUrl})\n\n`;
+            body += `Total: ${results.summary.total}, Matches: ${results.summary.matches}, Diffs: ${results.summary.mismatches}, Skipped: ${results.summary.skipped}\n\n`;
+            if (results.pages.length) {
+              body += '| Page | Status |\n| --- | --- |\n';
+              for (const p of results.pages) {
+                if (p.status !== 'match') {
+                  body += `| ${p.path} | ${p.status} |\n`;
+                }
+              }
+            }
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body
+            });

--- a/package.json
+++ b/package.json
@@ -72,7 +72,11 @@
     "start-server-and-test": "^1.14.0",
     "ts-jest": "^27.0.6",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1"
+    "typescript": "^5.1",
+    "fast-xml-parser": "^4.5.1",
+    "playwright": "^1.40.0",
+    "pixelmatch": "^5.3.0",
+    "pngjs": "^7.0.0"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/scripts/sitemap-visual-diff.ts
+++ b/scripts/sitemap-visual-diff.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env ts-node
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import fs from "fs";
+import path from "path";
+
+import { XMLParser } from "fast-xml-parser";
+import pixelmatch from "pixelmatch";
+import { chromium } from "playwright";
+import { PNG } from "pngjs";
+
+interface Options {
+  previewUrl: string;
+  outputDir: string;
+  tolerance: number;
+  width: number;
+  viewHeight: number;
+  summaryFile: string;
+}
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  const opts: Options = {
+    previewUrl: "",
+    outputDir: "visual_diffs",
+    tolerance: 0,
+    width: 1280,
+    viewHeight: 1024,
+    summaryFile: "visual_diffs/results.json",
+  };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case "-p":
+      case "--preview-url":
+        opts.previewUrl = args[++i];
+        break;
+      case "-o":
+      case "--output-dir":
+        opts.outputDir = args[++i];
+        break;
+      case "-t":
+      case "--tolerance":
+        opts.tolerance = Number(args[++i]);
+        break;
+      case "-w":
+      case "--width":
+        opts.width = Number(args[++i]);
+        break;
+      case "-v":
+      case "--view-height":
+        opts.viewHeight = Number(args[++i]);
+        break;
+      case "-s":
+      case "--summary-file":
+        opts.summaryFile = args[++i];
+        break;
+    }
+  }
+  return opts;
+}
+
+async function fetchSitemap(url: string): Promise<string> {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Failed to fetch ${url}: ${resp.status}`);
+  return resp.text();
+}
+
+function parseUrlsFromSitemap(xml: string): string[] {
+  const parser = new XMLParser();
+  const result = parser.parse(xml);
+  const urls = result.urlset?.url || [];
+  const arr = Array.isArray(urls) ? urls : [urls];
+  return arr.map((u: any) => String(u.loc).trim()).filter(Boolean);
+}
+
+async function screenshotFullPage(page: any, url: string, outputPath: string) {
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.evaluate(() => {
+    document.querySelectorAll("details").forEach((d) => {
+      const summary = d.querySelector("summary");
+      if (!d.open && summary) (summary as HTMLElement).click();
+      (d as HTMLDetailsElement).open = true;
+      d.setAttribute("data-collapsed", "false");
+    });
+  });
+  await page.waitForTimeout(500);
+  await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
+  await page.screenshot({ path: outputPath, fullPage: true });
+}
+
+function compareImages(
+  prodPath: string,
+  prevPath: string,
+  diffPath: string,
+  tolerance: number
+): boolean {
+  const prod = PNG.sync.read(fs.readFileSync(prodPath));
+  const prev = PNG.sync.read(fs.readFileSync(prevPath));
+  if (prod.width !== prev.width || prod.height !== prev.height) {
+    console.warn(`Size mismatch for ${prevPath}`);
+    return false;
+  }
+  const diff = new PNG({ width: prod.width, height: prod.height });
+  const numDiff = pixelmatch(
+    prod.data,
+    prev.data,
+    diff.data,
+    prod.width,
+    prod.height,
+    {
+      threshold: tolerance,
+    }
+  );
+  if (numDiff > 0) {
+    fs.mkdirSync(path.dirname(diffPath), { recursive: true });
+    fs.writeFileSync(diffPath, PNG.sync.write(diff));
+    return false;
+  }
+  return true;
+}
+
+async function run() {
+  const opts = parseArgs();
+  if (!opts.previewUrl) {
+    throw new Error("Missing preview URL");
+  }
+  if (!opts.previewUrl.endsWith("/")) opts.previewUrl += "/";
+
+  const sitemapXml = await fetchSitemap("https://pan.dev/sitemap.xml");
+  const paths = parseUrlsFromSitemap(await sitemapXml);
+  console.log(`Found ${paths.length} paths.`);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: opts.width, height: opts.viewHeight },
+  });
+  const page = await context.newPage();
+
+  let total = 0;
+  let matches = 0;
+  let mismatches = 0;
+  let skipped = 0;
+  const pages: { path: string; status: string }[] = [];
+
+  for (const url of paths) {
+    total += 1;
+    const cleanPath =
+      new URL(url).pathname.replace(/^\//, "").replace(/\/$/, "") || "root";
+    const prodSnap = path.join(opts.outputDir, "prod", `${cleanPath}.png`);
+    const prevSnap = path.join(opts.outputDir, "preview", `${cleanPath}.png`);
+    const diffImg = path.join(opts.outputDir, "diff", `${cleanPath}.png`);
+    try {
+      await screenshotFullPage(page, url, prodSnap);
+      await screenshotFullPage(
+        page,
+        new URL(cleanPath, opts.previewUrl).toString(),
+        prevSnap
+      );
+      if (compareImages(prodSnap, prevSnap, diffImg, opts.tolerance)) {
+        console.log(`MATCH: /${cleanPath}`);
+        matches += 1;
+        pages.push({ path: `/${cleanPath}`, status: "match" });
+      } else {
+        console.warn(`DIFF: /${cleanPath}`);
+        mismatches += 1;
+        pages.push({ path: `/${cleanPath}`, status: "diff" });
+      }
+    } catch (e) {
+      console.warn(`SKIP: /${cleanPath} - ${e}`);
+      skipped += 1;
+      pages.push({ path: `/${cleanPath}`, status: "skip" });
+    }
+  }
+
+  await browser.close();
+  console.log(
+    `Total: ${total}, Matches: ${matches}, Diffs: ${mismatches}, Skipped: ${skipped}`
+  );
+
+  await fs.promises.mkdir(path.dirname(opts.summaryFile), { recursive: true });
+  await fs.promises.writeFile(
+    opts.summaryFile,
+    JSON.stringify(
+      { summary: { total, matches, mismatches, skipped }, pages },
+      null,
+      2
+    )
+  );
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8465,6 +8465,13 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
+fast-xml-parser@^4.5.1:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz#c54d6b35aa0f23dc1ea60b6c884340c006dc6efb"
+  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
+  dependencies:
+    strnum "^1.1.1"
+
 fastq@^1.6.0:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
@@ -8781,6 +8788,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
@@ -14149,6 +14161,13 @@ pixelmatch@^4.0.2:
   dependencies:
     pngjs "^3.0.0"
 
+pixelmatch@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-5.3.0.tgz#5e5321a7abedfb7962d60dbf345deda87cb9560a"
+  integrity sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==
+  dependencies:
+    pngjs "^6.0.0"
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -14162,6 +14181,20 @@ pkg-dir@^7.0.0:
   integrity sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==
   dependencies:
     find-up "^6.3.0"
+
+playwright-core@1.53.2:
+  version "1.53.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.53.2.tgz#78f71e2f727713daa8d360dc11c460022c13cf91"
+  integrity sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==
+
+playwright@^1.40.0:
+  version "1.53.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.53.2.tgz#cc2ef4a22da1ae562e0ed91edb9e22a7c4371305"
+  integrity sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==
+  dependencies:
+    playwright-core "1.53.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -14179,6 +14212,16 @@ pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
+pngjs@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-6.0.0.tgz#ca9e5d2aa48db0228a52c419c3308e87720da821"
+  integrity sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==
+
+pngjs@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
+  integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -16856,6 +16899,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
+strnum@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
+  integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
 strong-log-transformer@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary
- port screenshot diff script to TypeScript
- run the script automatically after deploy-preview
- save diff artifacts
- add PR summary comment for diff results

## Testing
- `yarn lint`
- `yarn test`

## Expected behavior

Visual diff to be performed against current sitemap.xml published on live site. The intended goal is to detect possible regression bugs, specifically those impacting how OpenAPI schemas are evaluated and rendered.


------
https://chatgpt.com/codex/tasks/task_e_6862fbb8627c832397ef77fc31806ebf