### PR TITLE
Increase visual diff concurrency

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -177,7 +177,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run visual diff
-        run: yarn ts-node scripts/sitemap-visual-diff.ts --preview-url ${{ needs.deploy.outputs.preview_url }} --summary-file visual_diffs/results.json --concurrency 2
+        run: yarn ts-node scripts/sitemap-visual-diff.ts --preview-url ${{ needs.deploy.outputs.preview_url }} --summary-file visual_diffs/results.json --concurrency 4 --paths "/tests/"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/scripts/sitemap-visual-diff.ts
+++ b/scripts/sitemap-visual-diff.ts
@@ -23,6 +23,7 @@ interface Options {
   concurrency: number;
   diffAlpha: number;
   summaryFile: string;
+  paths: string;
 }
 
 function parseArgs(): Options {
@@ -36,6 +37,7 @@ function parseArgs(): Options {
     concurrency: 4,
     diffAlpha: 1,
     summaryFile: "visual_diffs/results.json",
+    paths: "",
   };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -71,6 +73,10 @@ function parseArgs(): Options {
       case "-s":
       case "--summary-file":
         opts.summaryFile = args[++i];
+        break;
+      case "-P":
+      case "--paths":
+        opts.paths = args[++i];
         break;
     }
   }
@@ -168,7 +174,11 @@ async function run() {
   const sitemapXml = await fetchSitemap(
     "https://docusaurus-openapi.tryingpan.dev/sitemap.xml"
   );
-  const paths = parseUrlsFromSitemap(await sitemapXml);
+  let paths = parseUrlsFromSitemap(sitemapXml);
+  if (opts.paths) {
+    const regex = new RegExp(opts.paths);
+    paths = paths.filter((p) => regex.test(p));
+  }
   console.log(`Found ${paths.length} paths.`);
 
   const browser = await chromium.launch();


### PR DESCRIPTION
## Summary
- add `paths` option to `sitemap-visual-diff.ts` for filtering sitemap URLs
- update workflow to run visual diffs only on paths containing `/tests/`
- run the workflow with concurrency set to 4

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6863c9430bb483238644c06104c075dc