### PR TITLE
Fix response schema output not rendering when using allOf within array items

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -672,7 +672,7 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     );
   }
 
-  if (schema.items?.anyOf || schema.items?.oneOf) {
+  if (schema.items?.anyOf || schema.items?.oneOf || schema.items?.allOf) {
     return (
       <SchemaNodeDetails
         name={name}


### PR DESCRIPTION
This fixes an issue where the schema node was not rendered when using allOf within an array items

eg.


```
  '200':
    description: List of resources
    content:
      application/vnd.api+json:
        schema:
          type: object
          properties:
            data:
              type: array
              items:
                allOf:
                  - type: object
                     properties:
                      one:
                        type: string
                  - type: object
                     properties:
                      two:
                        type: string
```

## Description



## Motivation and Context

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1123

## How Has This Been Tested?

I have run:
```
npm run build
npm run test
```

The schema is now rendered correctly, tested with a number of examples including with refs

<details>

<summary>Example</summary>

```
responses:
  '200':
    description: List of client accounts
    content:
      application/vnd.api+json:
        schema:
          $ref: '#/CollectionResponse'

CollectionResponse:
  type: object
  properties:
    data:
      type: array
      items:
        allOf:
          - type: object
            required:
              - id
            properties:
              id:
                type: string
          - $ref: '#/ClientAccountBase'

ClientAccountBase:
  type: object
  required:
    - type
    - attributes
  properties:
    type:
      allOf:
        - type: string
          enum:
            - client_accounts
    attributes:
      properties:
        name:
          type: string
          description: "The client name"
        created_at:
          type: string
          format: date-time
          readOnly: true
        updated_at:
          type: string
          format: date-time
          readOnly: true

```

</details>

## Screenshots (if appropriate)

#### Before Change
![Screenshot 2025-07-03 at 10 50 23](https://github.com/user-attachments/assets/74d7b5f7-db76-4487-be3c-a618066548e0)

#### After Change

![Screenshot 2025-07-03 at 11 25 47](https://github.com/user-attachments/assets/c8bf6444-489c-4f20-b900-cd0dce00937d)

![Screenshot 2025-07-03 at 11 25 53](https://github.com/user-attachments/assets/6f6c7ff6-5b18-424a-b9be-9ba5696a6483)



## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
