### PR TITLE
Improve error handling when spec isn't valid

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -43,9 +43,15 @@ function jsonToCollection(data: OpenApiObject): Promise<Collection> {
       { schemaFaker: false }
     );
     schemaPack.computedOptions.schemaFaker = false;
+
+    // Make sure the schema was properly validated or reject with error
+    if (!schemaPack.validationResult?.result) {
+      return reject(schemaPack.validationResult?.reason);
+    }
+    
     schemaPack.convert((_err: any, conversionResult: any) => {
-      if (!conversionResult.result) {
-        return reject(conversionResult.reason);
+      if (_err || !conversionResult.result) {
+        return reject(_err || conversionResult.reason);
       }
       return resolve(new sdk.Collection(conversionResult.output[0].data));
     });


### PR DESCRIPTION
## Description

Check for validation results that will result in an error and reject with that error.

Also, add additional safety around the `conversionResult` handling to avoid generic errors on failure.

## Motivation and Context

When a spec is provided that was missing required fields (`title`, `version`) in the `info` section, the build process would fail with a generic `TypeError` due to `conversionResult` not existing.

## How Has This Been Tested?

Only locally in the compiled `node_modules` environment.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
