### PR TITLE
Add generateSchemas option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
+| `generateSchemas`    | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages for all schemas referenced in the OpenAPI spec (not added in sidebar). |
 
 ### sidebarOptions
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -221,6 +221,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                     |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                            |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                    |
+| `generateSchemas`    | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages for all schemas referenced in the OpenAPI spec (not added in sidebar).                     |
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -174,6 +174,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                               |
+| `generateSchemas`    | `boolean` | `null`  | _Optional:_ If set to `true`, generates schema pages for all schemas referenced in the OpenAPI spec (not added in sidebar). |
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -423,6 +423,7 @@ function createItems(
 
   if (
     options?.showSchemas === true ||
+    options?.generateSchemas === true ||
     Object.entries(openapiData?.components?.schemas ?? {})
       .flatMap(([_, s]) => s["x-tags"])
       .filter((item) => !!item).length > 0
@@ -431,7 +432,11 @@ function createItems(
     for (let [schema, schemaObject] of Object.entries(
       openapiData?.components?.schemas ?? {}
     )) {
-      if (options?.showSchemas === true || schemaObject["x-tags"]) {
+      if (
+        options?.showSchemas === true ||
+        options?.generateSchemas === true ||
+        schemaObject["x-tags"]
+      ) {
         const baseIdSpaces =
           schemaObject?.title?.replace(" ", "-").toLowerCase() ?? "";
         const baseId = kebabCase(baseIdSpaces);

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -48,6 +48,7 @@ export const OptionsSchema = Joi.object({
         sidebarOptions: sidebarOptions,
         markdownGenerators: markdownGenerators,
         showSchemas: Joi.boolean(),
+        generateSchemas: Joi.boolean(),
         disableCompression: Joi.boolean(),
         version: Joi.string().when("versions", {
           is: Joi.exist(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -51,6 +51,7 @@ export interface APIOptions {
   proxy?: string;
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
+  generateSchemas?: boolean;
   disableCompression?: boolean;
 }
 


### PR DESCRIPTION
This works similar to showSchemas but it doesn't add the schemas to the sidebar. This is useful to generate the schemas and then embed them in other pages as needed.

## Description

This changes introduces a new configuration option `generateSchemas`, to generate openAPI schemas, while not including them in the sidebar.

## Motivation and Context

If you have a lot Schema and only selectively want to import the schemas in other pages this is helpful.

## How Has This Been Tested?

I manually patched the dependency, set the generateSchemas to true and checked that they were generated.


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
