### PR TITLE
Improve circular reference detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ yarn build-packages
 yarn watch:demo
 ```
 
+Whenever you modify the plugin or theme sources, run `yarn build-packages` again so the demo picks up your latest code.
+
 ## Credits
 
 Special thanks to [@bourdakos1](https://github.com/bourdakos1) (Nick Bourdakos), the author of [docusaurus-openapi](https://github.com/cloud-annotations/docusaurus-openapi), which this project is heavily based on.

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -69,7 +69,7 @@ The plugin extracts a number of vendor extensions from the OpenAPI spec to enric
 | `x-displayName`                            | Overrides tag display names. |
 | `x-enumDescription` / `x-enumDescriptions` | Documents enum values. |
 
-Other ReDoc specific extensions such as `x-circular-ref`, `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are ignored when extracting custom data.
+Circular references flagged with `x-circular-ref` or detected automatically are serialized as `circular(<title>)`. Other ReDoc specific extensions such as `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are ignored when extracting custom data.
 
 ---
 

--- a/demo/docs/vendor-extensions.mdx
+++ b/demo/docs/vendor-extensions.mdx
@@ -21,4 +21,4 @@ The OpenAPI plugin and theme recognize several [vendor extensions](https://swagg
 | `x-displayName` | Override tag names used for grouping. |
 | `x-enumDescription` / `x-enumDescriptions` | Document individual enum values. |
 
-Other ReDoc extensions such as `x-circular-ref`, `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are detected but ignored when extracting custom extensions.
+Circular references flagged with `x-circular-ref` or detected automatically are serialized as `circular(<title>)`. Other ReDoc extensions such as `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are detected but ignored when extracting custom extensions.

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -238,7 +238,7 @@ The plugin extracts a number of vendor extensions from the OpenAPI spec to enric
 | `x-displayName`                            | Overrides tag display names.                                          |
 | `x-enumDescription` / `x-enumDescriptions` | Documents enum values.                                                |
 
-Other ReDoc specific extensions such as `x-circular-ref`, `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are ignored when extracting custom data.
+Circular references flagged with `x-circular-ref` or detected automatically are serialized as `circular(<title>)`. Other ReDoc specific extensions such as `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are ignored when extracting custom data.
 
 ## CLI Usage
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -783,11 +783,11 @@ export function createNodes(
   }
 
   if (schema.allOf !== undefined) {
-    if (
-      schema.allOf.length &&
-      typeof schema.allOf[0] === "string" &&
-      (schema.allOf[0] as string).includes("circular")
-    ) {
+    const circularIndex = schema.allOf.findIndex((item: any) => {
+      return typeof item === "string" && item.includes("circular");
+    });
+
+    if (circularIndex !== -1) {
       nodes.push(
         create("div", {
           style: {
@@ -795,11 +795,14 @@ export function createNodes(
             marginBottom: ".5rem",
             marginLeft: "1rem",
           },
-          children: createDescription(schema.allOf[0]),
+          children: createDescription(schema.allOf[circularIndex] as string),
         })
       );
 
-      const rest = schema.allOf.slice(1);
+      const rest = schema.allOf
+        .slice(0, circularIndex)
+        .concat(schema.allOf.slice(circularIndex + 1));
+
       if (rest.length) {
         const mergedSchemas = mergeAllOf({ allOf: rest } as SchemaObject);
         if (

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -783,17 +783,49 @@ export function createNodes(
   }
 
   if (schema.allOf !== undefined) {
-    const mergedSchemas = mergeAllOf(schema) as SchemaObject;
-
     if (
-      mergedSchemas.oneOf !== undefined ||
-      mergedSchemas.anyOf !== undefined
+      schema.allOf.length &&
+      typeof schema.allOf[0] === "string" &&
+      (schema.allOf[0] as string).includes("circular")
     ) {
-      nodes.push(createAnyOneOf(mergedSchemas));
-    }
+      nodes.push(
+        create("div", {
+          style: {
+            marginTop: ".5rem",
+            marginBottom: ".5rem",
+            marginLeft: "1rem",
+          },
+          children: createDescription(schema.allOf[0]),
+        })
+      );
 
-    if (mergedSchemas.properties !== undefined) {
-      nodes.push(createProperties(mergedSchemas));
+      const rest = schema.allOf.slice(1);
+      if (rest.length) {
+        const mergedSchemas = mergeAllOf({ allOf: rest } as SchemaObject);
+        if (
+          mergedSchemas.oneOf !== undefined ||
+          mergedSchemas.anyOf !== undefined
+        ) {
+          nodes.push(createAnyOneOf(mergedSchemas));
+        }
+
+        if (mergedSchemas.properties !== undefined) {
+          nodes.push(createProperties(mergedSchemas));
+        }
+      }
+    } else {
+      const mergedSchemas = mergeAllOf(schema) as SchemaObject;
+
+      if (
+        mergedSchemas.oneOf !== undefined ||
+        mergedSchemas.anyOf !== undefined
+      ) {
+        nodes.push(createAnyOneOf(mergedSchemas));
+      }
+
+      if (mergedSchemas.properties !== undefined) {
+        nodes.push(createProperties(mergedSchemas));
+      }
     }
   }
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/examples/self-ref.yaml
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/__fixtures__/examples/self-ref.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+info:
+  title: Self Ref Example
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Node:
+      title: Node
+      type: object
+      properties:
+        name:
+          type: string
+        child:
+          $ref: "#/components/schemas/Node"

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/circular.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/circular.test.ts
@@ -1,0 +1,25 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import path from "path";
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { posixPath } from "@docusaurus/utils";
+
+import { loadAndResolveSpec } from "./utils/loadAndResolveSpec";
+
+describe("circular references", () => {
+  it("flags self referencing schemas", async () => {
+    const file = posixPath(
+      path.join(__dirname, "__fixtures__/examples/self-ref.yaml")
+    );
+    const spec: any = await loadAndResolveSpec(file);
+    expect(spec.components.schemas.Node.properties.child).toBe(
+      "circular(Node)"
+    );
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -123,7 +123,11 @@ async function resolveJsonRefs(specUrlOrObject: object | string) {
   }
 }
 
-function markCircularRefs(obj: any, stack: any[] = []): boolean | "circular" {
+function markCircularRefs(
+  obj: any,
+  stack: any[] = [],
+  key: string | undefined = undefined
+): boolean | "circular" {
   if (!obj || typeof obj !== "object") {
     return false;
   }
@@ -139,23 +143,29 @@ function markCircularRefs(obj: any, stack: any[] = []): boolean | "circular" {
     for (let i = 0; i < obj.length; i++) {
       const val = obj[i];
       if (typeof val === "object" && val !== null) {
-        const res = markCircularRefs(val, stack);
+        const res = markCircularRefs(val, stack, String(i));
         if (res) {
           if (res === "circular") {
-            obj[i] = { title: val.title, "x-circular-ref": true };
+            obj[i] = {
+              title: val.title ?? String(i),
+              "x-circular-ref": true,
+            };
           }
           foundCircular = true;
         }
       }
     }
   } else {
-    for (const key of Object.keys(obj)) {
-      const val = obj[key];
+    for (const k of Object.keys(obj)) {
+      const val = obj[k];
       if (typeof val === "object" && val !== null) {
-        const res = markCircularRefs(val, stack);
+        const res = markCircularRefs(val, stack, k);
         if (res) {
           if (res === "circular") {
-            obj[key] = { title: val.title, "x-circular-ref": true };
+            obj[k] = {
+              title: val.title ?? k,
+              "x-circular-ref": true,
+            };
           }
           foundCircular = true;
         }

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/utils/loadAndResolveSpec.ts
@@ -142,7 +142,7 @@ function markCircularRefs(obj: any, stack: any[] = []): boolean | "circular" {
         const res = markCircularRefs(val, stack);
         if (res) {
           if (res === "circular") {
-            obj[i] = { ...val, "x-circular-ref": true };
+            obj[i] = { title: val.title, "x-circular-ref": true };
           }
           foundCircular = true;
         }
@@ -155,7 +155,7 @@ function markCircularRefs(obj: any, stack: any[] = []): boolean | "circular" {
         const res = markCircularRefs(val, stack);
         if (res) {
           if (res === "circular") {
-            obj[key] = { ...val, "x-circular-ref": true };
+            obj[key] = { title: val.title, "x-circular-ref": true };
           }
           foundCircular = true;
         }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/_SchemaItem.scss
@@ -67,6 +67,17 @@
   background-color: transparent;
 }
 
+.openapi-schema__circular {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10.5px;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: var(--openapi-circular);
+  margin-left: 1%;
+  background-color: transparent;
+}
+
 .openapi-schema__strikethrough {
   text-decoration: line-through;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -92,6 +92,17 @@ export default function SchemaItem(props: Props) {
     <span className="openapi-schema__nullable">nullable</span>
   ));
 
+  const circularMatch =
+    typeof schemaName === "string" && schemaName.startsWith("circular(")
+      ? schemaName.match(/^circular\\(([^)]*)\\)/)
+      : null;
+
+  const renderCircular = guard(circularMatch, () => (
+    <span className="openapi-schema__circular">
+      {circularMatch ? `circular(${circularMatch[1]})` : "circular"}
+    </span>
+  ));
+
   const renderEnumDescriptions = guard(
     getEnumDescriptionMarkdown(enumDescriptions),
     (value) => {
@@ -206,6 +217,7 @@ export default function SchemaItem(props: Props) {
         {renderNullable}
         {renderRequired}
         {renderDeprecated}
+        {renderCircular}
       </span>
       {renderSchemaDescription}
       {renderEnumDescriptions}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -46,6 +46,7 @@
   --openapi-required: var(--ifm-color-danger);
   --openapi-deprecated: var(--ifm-color-warning);
   --openapi-nullable: var(--ifm-color-info);
+  --openapi-circular: var(--ifm-color-primary);
   --openapi-code-blue: var(--ifm-color-info);
   --openapi-code-red: var(--ifm-color-danger);
   --openapi-code-orange: var(--ifm-color-warning);


### PR DESCRIPTION
## Summary
- ensure objects flagged with `x-circular-ref` render as `circular(<title>)`
- auto-detect circular references during spec loading
- improve circular reference detection

Intended to address #157 

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686beb69cfd08323b5047347651b7ddc