### PR TITLE
feat(theme): add initial i18n support

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
@@ -7,10 +7,12 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import FormItem from "@theme/ApiExplorer/FormItem";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_AUTH } from "@theme/translationIds";
 
 import { setAuthData, setSelectedAuth } from "./slice";
 
@@ -45,9 +47,18 @@ function Authorization() {
       {selectedAuth.map((a: any) => {
         if (a.type === "http" && a.scheme === "bearer") {
           return (
-            <FormItem label="Bearer Token" key={a.key + "-bearer"}>
+            <FormItem
+              label={translate({
+                id: OPENAPI_AUTH.BEARER_TOKEN,
+                message: "Bearer Token",
+              })}
+              key={a.key + "-bearer"}
+            >
               <FormTextInput
-                placeholder="Bearer Token"
+                placeholder={translate({
+                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  message: "Bearer Token",
+                })}
                 password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,9 +78,18 @@ function Authorization() {
 
         if (a.type === "oauth2") {
           return (
-            <FormItem label="Bearer Token" key={a.key + "-oauth2"}>
+            <FormItem
+              label={translate({
+                id: OPENAPI_AUTH.BEARER_TOKEN,
+                message: "Bearer Token",
+              })}
+              key={a.key + "-oauth2"}
+            >
               <FormTextInput
-                placeholder="Bearer Token"
+                placeholder={translate({
+                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  message: "Bearer Token",
+                })}
                 password
                 value={data[a.key].token ?? ""}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -90,9 +110,17 @@ function Authorization() {
         if (a.type === "http" && a.scheme === "basic") {
           return (
             <React.Fragment key={a.key + "-basic"}>
-              <FormItem label="Username">
+              <FormItem
+                label={translate({
+                  id: OPENAPI_AUTH.USERNAME,
+                  message: "Username",
+                })}
+              >
                 <FormTextInput
-                  placeholder="Username"
+                  placeholder={translate({
+                    id: OPENAPI_AUTH.USERNAME,
+                    message: "Username",
+                  })}
                   value={data[a.key].username ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const value = e.target.value;
@@ -106,9 +134,17 @@ function Authorization() {
                   }}
                 />
               </FormItem>
-              <FormItem label="Password">
+              <FormItem
+                label={translate({
+                  id: OPENAPI_AUTH.PASSWORD,
+                  message: "Password",
+                })}
+              >
                 <FormTextInput
-                  placeholder="Password"
+                  placeholder={translate({
+                    id: OPENAPI_AUTH.PASSWORD,
+                    message: "Password",
+                  })}
                   password
                   value={data[a.key].password ?? ""}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -7,6 +7,8 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+
 import json2xml from "@theme/ApiExplorer/Body/json2xml";
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormItem from "@theme/ApiExplorer/FormItem";
@@ -17,6 +19,7 @@ import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
+import { OPENAPI_BODY, OPENAPI_REQUEST } from "@theme/translationIds";
 import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
 
@@ -98,7 +101,10 @@ function Body({
     return (
       <FormItem>
         <FormFileUpload
-          placeholder={schema.description || "Body"}
+          placeholder={
+            schema.description ||
+            translate({ id: OPENAPI_REQUEST.BODY_TITLE, message: "Body" })
+          }
           onChange={(file: any) => {
             if (file === undefined) {
               dispatch(clearRawBody());
@@ -302,7 +308,10 @@ function Body({
         <SchemaTabs className="openapi-tabs__schema" lazy>
           {/* @ts-ignore */}
           <TabItem
-            label="Example (from schema)"
+            label={translate({
+              id: OPENAPI_BODY.EXAMPLE_FROM_SCHEMA,
+              message: "Example (from schema)",
+            })}
             value="Example (from schema)"
             default
           >
@@ -334,7 +343,10 @@ function Body({
         <SchemaTabs className="openapi-tabs__schema" lazy>
           {/* @ts-ignore */}
           <TabItem
-            label="Example (from schema)"
+            label={translate({
+              id: OPENAPI_BODY.EXAMPLE_FROM_SCHEMA,
+              message: "Example (from schema)",
+            })}
             value="Example (from schema)"
             default
           >

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormFileUpload/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormFileUpload/index.tsx
@@ -7,7 +7,9 @@
 
 import React, { useState } from "react";
 
+import { translate } from "@docusaurus/Translate";
 import FloatingButton from "@theme/ApiExplorer/FloatingButton";
+import { OPENAPI_FORM_FILE_UPLOAD } from "@theme/translationIds";
 import MagicDropzone from "react-magic-dropzone";
 
 type PreviewFile = { preview: string } & File;
@@ -102,7 +104,10 @@ function FormFileUpload({ placeholder, onChange }: Props) {
                 setAndNotifyFile(undefined);
               }}
             >
-              Clear
+              {translate({
+                id: OPENAPI_FORM_FILE_UPLOAD.CLEAR_BUTTON,
+                message: "Clear",
+              })}
             </button>
             <RenderPreview file={file} />
           </>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
@@ -7,6 +7,9 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
+
 import clsx from "clsx";
 
 export interface Props {
@@ -24,7 +27,11 @@ function FormItem({ label, type, required, children, className }: Props) {
         <label className="openapi-explorer__form-item-label">{label}</label>
       )}
       {type && <span style={{ opacity: 0.6 }}> — {type}</span>}
-      {required && <span className="openapi-schema__required">required</span>}
+      {required && (
+        <span className="openapi-schema__required">
+          {translate({ id: OPENAPI_SCHEMA_ITEM.REQUIRED, message: "required" })}
+        </span>
+      )}
       <div>{children}</div>
     </div>
   );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormTextInput/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormTextInput/index.tsx
@@ -8,7 +8,9 @@
 // @ts-nocheck
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import clsx from "clsx";
 import { useFormContext } from "react-hook-form";
 
@@ -41,7 +43,12 @@ function FormTextInput({
       {paramName ? (
         <input
           {...register(paramName, {
-            required: isRequired ? "This field is required" : false,
+            required: isRequired
+              ? translate({
+                  id: OPENAPI_FORM.FIELD_REQUIRED,
+                  message: "This field is required",
+                })
+              : false,
           })}
           className={clsx("openapi-explorer__form-item-input", {
             error: showErrorMessage,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
@@ -8,9 +8,11 @@
 import React, { type JSX, useEffect, useState } from "react";
 
 import { usePrismTheme } from "@docusaurus/theme-common";
+import { translate } from "@docusaurus/Translate";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import { ErrorMessage } from "@hookform/error-message";
 import { setStringRawBody } from "@theme/ApiExplorer/Body/slice";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import clsx from "clsx";
 import { Controller, useFormContext } from "react-hook-form";
 import { LiveProvider, LiveEditor, withLive } from "react-live";
@@ -85,7 +87,13 @@ function App({
         <Controller
           control={control}
           rules={{
-            required: isRequired && !code ? "This field is required" : false,
+            required:
+              isRequired && !code
+                ? translate({
+                    id: OPENAPI_FORM.FIELD_REQUIRED,
+                    message: "This field is required",
+                  })
+                : false,
           }}
           name="requestBody"
           render={({ field: { onChange, name } }) => (

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
@@ -7,12 +7,14 @@
 
 import React, { useEffect, useState } from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
 import { nanoid } from "@reduxjs/toolkit";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -121,7 +123,14 @@ export default function ParamArrayFormItem({ param }: ParamProps) {
     <>
       <Controller
         control={control}
-        rules={{ required: param.required ? "This field is required" : false }}
+        rules={{
+          required: param.required
+            ? translate({
+                id: OPENAPI_FORM.FIELD_REQUIRED,
+                message: "This field is required",
+              })
+            : false,
+        }}
         name="paramArray"
         render={({ field: { onChange, name } }) => (
           <>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem.tsx
@@ -7,10 +7,12 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -31,7 +33,14 @@ export default function ParamBooleanFormItem({ param }: ParamProps) {
     <>
       <Controller
         control={control}
-        rules={{ required: param.required ? "This field is required" : false }}
+        rules={{
+          required: param.required
+            ? translate({
+                id: OPENAPI_FORM.FIELD_REQUIRED,
+                message: "This field is required",
+              })
+            : false,
+        }}
         name="paramBoolean"
         render={({ field: { onChange, name } }) => (
           <FormSelect

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem.tsx
@@ -7,10 +7,12 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
 import FormMultiSelect from "@theme/ApiExplorer/FormMultiSelect";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -61,7 +63,14 @@ export default function ParamMultiSelectFormItem({ param }: ParamProps) {
     <>
       <Controller
         control={control}
-        rules={{ required: param.required ? "This field is required" : false }}
+        rules={{
+          required: param.required
+            ? translate({
+                id: OPENAPI_FORM.FIELD_REQUIRED,
+                message: "This field is required",
+              })
+            : false,
+        }}
         name="paramMultiSelect"
         render={({ field: { onChange, name } }) => (
           <FormMultiSelect

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem.tsx
@@ -7,10 +7,12 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
+import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -33,7 +35,14 @@ export default function ParamSelectFormItem({ param }: ParamProps) {
     <>
       <Controller
         control={control}
-        rules={{ required: param.required ? "This field is required" : false }}
+        rules={{
+          required: param.required
+            ? translate({
+                id: OPENAPI_FORM.FIELD_REQUIRED,
+                message: "This field is required",
+              })
+            : false,
+        }}
         name="paramSelect"
         render={({ field: { onChange, name } }) => (
           <FormSelect

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from "react";
 
+import { translate } from "@docusaurus/Translate";
 import FormItem from "@theme/ApiExplorer/FormItem";
 import ParamArrayFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem";
 import ParamBooleanFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem";
@@ -14,6 +15,7 @@ import ParamMultiSelectFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormI
 import ParamSelectFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem";
 import ParamTextFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_PARAM_OPTIONS } from "@theme/translationIds";
 
 import { Param } from "./slice";
 
@@ -119,8 +121,14 @@ function ParamOptions() {
               </span>
             </span>
             {showOptional
-              ? "Hide optional parameters"
-              : "Show optional parameters"}
+              ? translate({
+                  id: OPENAPI_PARAM_OPTIONS.HIDE_OPTIONAL,
+                  message: "Hide optional parameters",
+                })
+              : translate({
+                  id: OPENAPI_PARAM_OPTIONS.SHOW_OPTIONAL,
+                  message: "Show optional parameters",
+                })}
           </button>
 
           <div

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -119,7 +119,14 @@ function Request({ item }: { item: ApiItem }) {
   };
 
   const onSubmit = async (data) => {
-    dispatch(setResponse("Fetching..."));
+    dispatch(
+      setResponse(
+        translate({
+          id: OPENAPI_REQUEST.FETCHING_MESSAGE,
+          message: "Fetching...",
+        })
+      )
+    );
     try {
       await delay(1200);
       const res = await makeRequest(postmanRequest, proxy, body);
@@ -130,7 +137,14 @@ function Request({ item }: { item: ApiItem }) {
       }
     } catch (e) {
       console.log(e);
-      dispatch(setResponse("Connection failed"));
+      dispatch(
+        setResponse(
+          translate({
+            id: OPENAPI_REQUEST.CONNECTION_FAILED,
+            message: "Connection failed",
+          })
+        )
+      );
       dispatch(clearCode());
       dispatch(clearHeaders());
     }
@@ -180,20 +194,31 @@ function Request({ item }: { item: ApiItem }) {
         onSubmit={methods.handleSubmit(onSubmit)}
       >
         <div className="openapi-explorer__request-header-container">
-          <span className="openapi-explorer__request-title">Request </span>
+          <span className="openapi-explorer__request-title">
+            {translate({
+              id: OPENAPI_REQUEST.REQUEST_TITLE,
+              message: "Request",
+            })}
+          </span>
           {allDetailsExpanded ? (
             <span
               className="openapi-explorer__expand-details-btn"
               onClick={collapseAllDetails}
             >
-              Collapse all
+              {translate({
+                id: OPENAPI_REQUEST.COLLAPSE_ALL,
+                message: "Collapse all",
+              })}
             </span>
           ) : (
             <span
               className="openapi-explorer__expand-details-btn"
               onClick={expandAllDetails}
             >
-              Expand all
+              {translate({
+                id: OPENAPI_REQUEST.EXPAND_ALL,
+                message: "Expand all",
+              })}
             </span>
           )}
         </div>
@@ -210,7 +235,10 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandServer(!expandServer);
                 }}
               >
-                Base URL
+                {translate({
+                  id: OPENAPI_REQUEST.BASE_URL_TITLE,
+                  message: "Base URL",
+                })}
               </summary>
               <Server />
             </details>
@@ -227,7 +255,7 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandAuth(!expandAuth);
                 }}
               >
-                Auth
+                {translate({ id: OPENAPI_REQUEST.AUTH_TITLE, message: "Auth" })}
               </summary>
               <Authorization />
             </details>
@@ -246,7 +274,10 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandParams(!expandParams);
                 }}
               >
-                Parameters
+                {translate({
+                  id: OPENAPI_REQUEST.PARAMETERS_TITLE,
+                  message: "Parameters",
+                })}
               </summary>
               <ParamOptions />
             </details>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -9,6 +9,7 @@
 import React, { useState } from "react";
 
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import { translate } from "@docusaurus/Translate";
 import Accept from "@theme/ApiExplorer/Accept";
 import Authorization from "@theme/ApiExplorer/Authorization";
 import Body from "@theme/ApiExplorer/Body";
@@ -24,6 +25,7 @@ import {
 } from "@theme/ApiExplorer/Response/slice";
 import Server from "@theme/ApiExplorer/Server";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_REQUEST } from "@theme/translationIds";
 import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import * as sdk from "postman-collection";
@@ -261,10 +263,14 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandBody(!expandBody);
                 }}
               >
-                Body
+                {translate({ id: OPENAPI_REQUEST.BODY_TITLE, message: "Body" })}
                 {requestBodyRequired && (
                   <span className="openapi-schema__required">
-                    &nbsp;required
+                    &nbsp;
+                    {translate({
+                      id: OPENAPI_REQUEST.REQUIRED_LABEL,
+                      message: "required",
+                    })}
                   </span>
                 )}
               </summary>
@@ -290,14 +296,20 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandAccept(!expandAccept);
                 }}
               >
-                Accept
+                {translate({
+                  id: OPENAPI_REQUEST.ACCEPT_TITLE,
+                  message: "Accept",
+                })}
               </summary>
               <Accept />
             </details>
           )}
           {showRequestButton && item.method !== "event" && (
             <button className="openapi-explorer__request-btn" type="submit">
-              Send API Request
+              {translate({
+                id: OPENAPI_REQUEST.SEND_BUTTON,
+                message: "Send API Request",
+              })}
             </button>
           )}
         </div>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -9,10 +9,12 @@ import React from "react";
 
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import { usePrismTheme } from "@docusaurus/theme-common";
+import { translate } from "@docusaurus/Translate";
 import ApiCodeBlock from "@theme/ApiExplorer/ApiCodeBlock";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
+import { OPENAPI_RESPONSE } from "@theme/translationIds";
 import clsx from "clsx";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
@@ -74,7 +76,9 @@ function Response({ item }: { item: ApiItem }) {
   return (
     <div className="openapi-explorer__response-container">
       <div className="openapi-explorer__response-title-container">
-        <span className="openapi-explorer__response-title">Response</span>
+        <span className="openapi-explorer__response-title">
+          {translate({ id: OPENAPI_RESPONSE.TITLE, message: "Response" })}
+        </span>
         <span
           className="openapi-explorer__response-clear-btn"
           onClick={() => {
@@ -83,7 +87,7 @@ function Response({ item }: { item: ApiItem }) {
             dispatch(clearHeaders());
           }}
         >
-          Clear
+          {translate({ id: OPENAPI_RESPONSE.CLEAR, message: "Clear" })}
         </span>
       </div>
       <div
@@ -117,14 +121,23 @@ function Response({ item }: { item: ApiItem }) {
               >
                 {prettyResponse || (
                   <p className="openapi-explorer__response-placeholder-message">
-                    Click the <code>Send API Request</code> button above and see
-                    the response here!
+                    {translate({
+                      id: OPENAPI_RESPONSE.PLACEHOLDER,
+                      message:
+                        "Click the <code>Send API Request</code> button above and see the response here!",
+                    })}
                   </p>
                 )}
               </ApiCodeBlock>
             </TabItem>
             {/* @ts-ignore */}
-            <TabItem label="Headers" value="headers">
+            <TabItem
+              label={translate({
+                id: OPENAPI_RESPONSE.HEADERS_TAB,
+                message: "Headers",
+              })}
+              value="headers"
+            >
               {/* @ts-ignore */}
               <ApiCodeBlock
                 className="openapi-explorer__code-block openapi-response__status-headers"
@@ -145,8 +158,11 @@ function Response({ item }: { item: ApiItem }) {
           </div>
         ) : (
           <p className="openapi-explorer__response-placeholder-message">
-            Click the <code>Send API Request</code> button above and see the
-            response here!
+            {translate({
+              id: OPENAPI_RESPONSE.PLACEHOLDER,
+              message:
+                "Click the <code>Send API Request</code> button above and see the response here!",
+            })}
           </p>
         )}
       </div>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
@@ -7,6 +7,9 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
+
 import Link from "@docusaurus/Link";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
 
@@ -48,16 +51,31 @@ function SecuritySchemes(props: any) {
                   }}
                 >
                   <span>
-                    <strong>name:</strong>{" "}
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.NAME,
+                        message: "name:",
+                      })}
+                    </strong>{" "}
                     <Link to={infoAuthPath}>{name ?? key}</Link>
                   </span>
                   <span>
-                    <strong>type: </strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                        message: "type:",
+                      })}
+                    </strong>{" "}
                     {type}
                   </span>
                   {scopes && scopes.length > 0 && (
                     <span>
-                      <strong>scopes: </strong>
+                      <strong>
+                        {translate({
+                          id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                          message: "scopes:",
+                        })}
+                      </strong>{" "}
                       <code>
                         {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                       </code>
@@ -89,16 +107,31 @@ function SecuritySchemes(props: any) {
                   }}
                 >
                   <span>
-                    <strong>name:</strong>{" "}
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.NAME,
+                        message: "name:",
+                      })}
+                    </strong>{" "}
                     <Link to={infoAuthPath}>{name ?? key}</Link>
                   </span>
                   <span>
-                    <strong>type: </strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                        message: "type:",
+                      })}
+                    </strong>{" "}
                     {type}
                   </span>
                   {scopes && scopes.length > 0 && (
                     <span>
-                      <strong>scopes: </strong>
+                      <strong>
+                        {translate({
+                          id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                          message: "scopes:",
+                        })}
+                      </strong>{" "}
                       <code>
                         {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                       </code>
@@ -128,15 +161,30 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      message: "name:",
+                    })}
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{auth.name ?? auth.key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      message: "type:",
+                    })}
+                  </strong>{" "}
                   {auth.type}
                 </span>
                 <span>
-                  <strong>in: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.IN,
+                      message: "in:",
+                    })}
+                  </strong>{" "}
                   {auth.in}
                 </span>
               </pre>
@@ -156,16 +204,31 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      message: "name:",
+                    })}
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      message: "type:",
+                    })}
+                  </strong>{" "}
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        message: "scopes:",
+                      })}
+                    </strong>{" "}
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>
@@ -198,16 +261,31 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      message: "name:",
+                    })}
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      message: "type:",
+                    })}
+                  </strong>{" "}
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        message: "scopes:",
+                      })}
+                    </strong>{" "}
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>
@@ -226,7 +304,12 @@ function SecuritySchemes(props: any) {
                 {flows && (
                   <span>
                     <code>
-                      <strong>flows: </strong>
+                      <strong>
+                        {translate({
+                          id: OPENAPI_SECURITY_SCHEMES.FLOWS,
+                          message: "flows:",
+                        })}
+                      </strong>{" "}
                       {JSON.stringify(flows, null, 2)}
                     </code>
                   </span>
@@ -248,16 +331,31 @@ function SecuritySchemes(props: any) {
                 }}
               >
                 <span>
-                  <strong>name:</strong>{" "}
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      message: "name:",
+                    })}
+                  </strong>{" "}
                   <Link to={infoAuthPath}>{name ?? key}</Link>
                 </span>
                 <span>
-                  <strong>type: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      message: "type:",
+                    })}
+                  </strong>{" "}
                   {type}
                 </span>
                 {scopes && scopes.length > 0 && (
                   <span>
-                    <strong>scopes: </strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        message: "scopes:",
+                      })}
+                    </strong>{" "}
                     <code>
                       {auth.scopes.length > 0 ? auth.scopes.toString() : "[]"}
                     </code>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/index.tsx
@@ -7,11 +7,13 @@
 
 import React, { useState } from "react";
 
+import { translate } from "@docusaurus/Translate";
 import FloatingButton from "@theme/ApiExplorer/FloatingButton";
 import FormItem from "@theme/ApiExplorer/FormItem";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_SERVER } from "@theme/translationIds";
 
 import { setServer, setServerVariable } from "./slice";
 
@@ -57,7 +59,10 @@ function Server() {
       }
     }
     return (
-      <FloatingButton onClick={() => setIsEditing(true)} label="Edit">
+      <FloatingButton
+        onClick={() => setIsEditing(true)}
+        label={translate({ id: OPENAPI_SERVER.EDIT_BUTTON, message: "Edit" })}
+      >
         <FormItem>
           <span className="openapi-explorer__server-url" title={url}>
             {url}
@@ -68,7 +73,10 @@ function Server() {
   }
   return (
     <div className="openapi-explorer__server-container">
-      <FloatingButton onClick={() => setIsEditing(false)} label="Hide">
+      <FloatingButton
+        onClick={() => setIsEditing(false)}
+        label={translate({ id: OPENAPI_SERVER.HIDE_BUTTON, message: "Hide" })}
+      >
         <FormItem>
           <FormSelect
             options={options.map((s: any) => s.url)}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -20,8 +20,10 @@ import {
   useTabs,
 } from "@docusaurus/theme-common/internal";
 import { TabItemProps } from "@docusaurus/theme-common/lib/utils/tabsUtils";
+import { translate } from "@docusaurus/Translate";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import Heading from "@theme/Heading";
+import { OPENAPI_TABS } from "@theme/translationIds";
 import clsx from "clsx";
 
 export interface TabListProps extends TabProps {
@@ -35,7 +37,10 @@ function TabList({
   selectedValue,
   selectValue,
   tabValues,
-  label = "Responses",
+  label = translate({
+    id: OPENAPI_TABS.RESPONSES_LABEL,
+    message: "Responses",
+  }),
   id = "responses",
 }: TabListProps & ReturnType<typeof useTabs>) {
   const tabRefs: (HTMLLIElement | null)[] = [];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
@@ -7,6 +7,9 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
+
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Details from "@theme/Details";
 import ParamsItem from "@theme/ParamsItem";
@@ -31,7 +34,13 @@ const ParamsDetailsComponent: React.FC<Props> = ({ parameters }) => {
         const summaryElement = (
           <summary>
             <h3 className="openapi-markdown__details-summary-header-params">
-              {`${type.charAt(0).toUpperCase() + type.slice(1)} Parameters`}
+              {translate(
+                {
+                  id: OPENAPI_PARAMS_DETAILS.PARAMETERS_TITLE,
+                  message: "{type} Parameters",
+                },
+                { type: type.charAt(0).toUpperCase() + type.slice(1) }
+              )}
             </h3>
           </summary>
         );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
@@ -7,11 +7,14 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+
 import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 /* eslint-disable import/no-extraneous-dependencies*/
 import clsx from "clsx";
+import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
 import { guard, toString } from "../../markdown/utils";
@@ -87,11 +90,15 @@ function ParamsItem({ param, ...rest }: Props) {
   ));
 
   const renderSchemaRequired = guard(required, () => (
-    <span className="openapi-schema__required">required</span>
+    <span className="openapi-schema__required">
+      {translate({ id: OPENAPI_SCHEMA_ITEM.REQUIRED, message: "required" })}
+    </span>
   ));
 
   const renderDeprecated = guard(deprecated, () => (
-    <span className="openapi-schema__deprecated">deprecated</span>
+    <span className="openapi-schema__deprecated">
+      {translate({ id: OPENAPI_SCHEMA_ITEM.DEPRECATED, message: "deprecated" })}
+    </span>
   ));
 
   const renderQualifier = guard(getQualifierMessage(schema), (qualifier) => (
@@ -118,7 +125,12 @@ function ParamsItem({ param, ...rest }: Props) {
       if (typeof defaultValue === "string") {
         return (
           <div>
-            <strong>Default value: </strong>
+            <strong>
+              {translate({
+                id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+                message: "Default value:",
+              })}{" "}
+            </strong>
             <span>
               <code>{defaultValue}</code>
             </span>
@@ -127,7 +139,12 @@ function ParamsItem({ param, ...rest }: Props) {
       }
       return (
         <div>
-          <strong>Default value: </strong>
+          <strong>
+            {translate({
+              id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+              message: "Default value:",
+            })}{" "}
+          </strong>
           <span>
             <code>{JSON.stringify(defaultValue)}</code>
           </span>
@@ -139,7 +156,12 @@ function ParamsItem({ param, ...rest }: Props) {
 
   const renderExample = guard(toString(example), (example) => (
     <div>
-      <strong>Example: </strong>
+      <strong>
+        {translate({
+          id: OPENAPI_SCHEMA_ITEM.EXAMPLE,
+          message: "Example:",
+        })}{" "}
+      </strong>
       {example}
     </div>
   ));
@@ -148,7 +170,12 @@ function ParamsItem({ param, ...rest }: Props) {
     const exampleEntries = Object.entries(examples);
     return (
       <>
-        <strong>Examples:</strong>
+        <strong>
+          {translate({
+            id: OPENAPI_SCHEMA_ITEM.EXAMPLES,
+            message: "Examples:",
+          })}
+        </strong>
         <SchemaTabs>
           {exampleEntries.map(([exampleName, exampleProperties]) => (
             // @ts-ignore
@@ -156,12 +183,22 @@ function ParamsItem({ param, ...rest }: Props) {
               {exampleProperties.summary && <p>{exampleProperties.summary}</p>}
               {exampleProperties.description && (
                 <p>
-                  <strong>Description: </strong>
+                  <strong>
+                    {translate({
+                      id: OPENAPI_SCHEMA_ITEM.DESCRIPTION,
+                      message: "Description:",
+                    })}{" "}
+                  </strong>
                   <span>{exampleProperties.description}</span>
                 </p>
               )}
               <p>
-                <strong>Example: </strong>
+                <strong>
+                  {translate({
+                    id: OPENAPI_SCHEMA_ITEM.EXAMPLE,
+                    message: "Example:",
+                  })}{" "}
+                </strong>
                 <code>{exampleProperties.value}</code>
               </p>
             </TabItem>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -7,6 +7,9 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
+
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
@@ -67,7 +70,10 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                         {title}
                         {body.required === true && (
                           <span className="openapi-schema__required">
-                            required
+                            {translate({
+                              id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                              message: "required",
+                            })}
                           </span>
                         )}
                       </h3>
@@ -120,7 +126,10 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                   )}
                   {body.required && (
                     <strong className="openapi-schema__required">
-                      required
+                      {translate({
+                        id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                        message: "required",
+                      })}
                     </strong>
                   )}
                 </h3>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseExamples/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseExamples/index.tsx
@@ -7,9 +7,11 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import CodeSamples from "@theme/CodeSamples";
 import Markdown from "@theme/Markdown";
 import TabItem from "@theme/TabItem";
+import { OPENAPI_RESPONSE_EXAMPLES } from "@theme/translationIds";
 import { sampleResponseFromSchema } from "docusaurus-plugin-openapi-docs/lib/openapi/createResponseExample";
 import format from "xml-formatter";
 
@@ -111,7 +113,13 @@ export const ResponseExample: React.FC<ResponseExampleProps> = ({
 
   return (
     // @ts-ignore
-    <TabItem label="Example" value="Example">
+    <TabItem
+      label={translate({
+        id: OPENAPI_RESPONSE_EXAMPLES.EXAMPLE,
+        message: "Example",
+      })}
+      value="Example"
+    >
       {responseExample.summary && (
         <Markdown className="openapi-example__summary">
           {responseExample.summary}
@@ -163,7 +171,13 @@ export const ExampleFromSchema: React.FC<ExampleFromSchemaProps> = ({
       }
       return (
         // @ts-ignore
-        <TabItem label="Example (auto)" value="Example (auto)">
+        <TabItem
+          label={translate({
+            id: OPENAPI_RESPONSE_EXAMPLES.AUTO_EXAMPLE,
+            message: "Example (auto)",
+          })}
+          value="Example (auto)"
+        >
           <CodeSamples example={xmlExample} language="xml" />
         </TabItem>
       );
@@ -176,7 +190,13 @@ export const ExampleFromSchema: React.FC<ExampleFromSchemaProps> = ({
   ) {
     return (
       // @ts-ignore
-      <TabItem label="Example (auto)" value="Example (auto)">
+      <TabItem
+        label={translate({
+          id: OPENAPI_RESPONSE_EXAMPLES.AUTO_EXAMPLE,
+          message: "Example (auto)",
+        })}
+        value="Example (auto)"
+      >
         <CodeSamples
           example={JSON.stringify(responseExample, null, 2)}
           language="json"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -7,6 +7,9 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
+
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
@@ -86,7 +89,10 @@ const ResponseSchemaComponent: React.FC<Props> = ({
                               {title}
                               {body.required === true && (
                                 <span className="openapi-schema__required">
-                                  required
+                                  {translate({
+                                    id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                    message: "required",
+                                  })}
                                 </span>
                               )}
                             </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -9,6 +9,8 @@ import React, { ReactNode } from "react";
 
 import Markdown from "@theme/Markdown";
 import clsx from "clsx";
+import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 
 import { guard } from "../../markdown/utils";
 
@@ -81,15 +83,23 @@ export default function SchemaItem(props: Props) {
 
   const renderRequired = guard(
     Array.isArray(required) ? required.includes(name) : required,
-    () => <span className="openapi-schema__required">required</span>
+    () => (
+      <span className="openapi-schema__required">
+        {translate({ id: OPENAPI_SCHEMA_ITEM.REQUIRED, message: "required" })}
+      </span>
+    )
   );
 
   const renderDeprecated = guard(deprecated, () => (
-    <span className="openapi-schema__deprecated">deprecated</span>
+    <span className="openapi-schema__deprecated">
+      {translate({ id: OPENAPI_SCHEMA_ITEM.DEPRECATED, message: "deprecated" })}
+    </span>
   ));
 
   const renderNullable = guard(nullable, () => (
-    <span className="openapi-schema__nullable">nullable</span>
+    <span className="openapi-schema__nullable">
+      {translate({ id: OPENAPI_SCHEMA_ITEM.NULLABLE, message: "nullable" })}
+    </span>
   ));
 
   const renderEnumDescriptions = guard(
@@ -120,7 +130,12 @@ export default function SchemaItem(props: Props) {
       if (typeof defaultValue === "string") {
         return (
           <div>
-            <strong>Default value: </strong>
+            <strong>
+              {translate({
+                id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+                message: "Default value:",
+              })}{" "}
+            </strong>
             <span>
               <code>{defaultValue}</code>
             </span>
@@ -129,7 +144,12 @@ export default function SchemaItem(props: Props) {
       }
       return (
         <div>
-          <strong>Default value: </strong>
+          <strong>
+            {translate({
+              id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+              message: "Default value:",
+            })}{" "}
+          </strong>
           <span>
             <code>{JSON.stringify(defaultValue)}</code>
           </span>
@@ -144,7 +164,12 @@ export default function SchemaItem(props: Props) {
       if (typeof example === "string") {
         return (
           <div>
-            <strong>Example: </strong>
+            <strong>
+              {translate({
+                id: OPENAPI_SCHEMA_ITEM.EXAMPLE,
+                message: "Example:",
+              })}{" "}
+            </strong>
             <span>
               <code>{example}</code>
             </span>
@@ -153,7 +178,12 @@ export default function SchemaItem(props: Props) {
       }
       return (
         <div>
-          <strong>Example: </strong>
+          <strong>
+            {translate({
+              id: OPENAPI_SCHEMA_ITEM.EXAMPLE,
+              message: "Example:",
+            })}{" "}
+          </strong>
           <span>
             <code>{JSON.stringify(example)}</code>
           </span>
@@ -168,7 +198,12 @@ export default function SchemaItem(props: Props) {
       if (typeof constValue === "string") {
         return (
           <div>
-            <strong>Constant value: </strong>
+            <strong>
+              {translate({
+                id: OPENAPI_SCHEMA_ITEM.CONSTANT_VALUE,
+                message: "Constant value:",
+              })}{" "}
+            </strong>
             <span>
               <code>{constValue}</code>
             </span>
@@ -177,7 +212,12 @@ export default function SchemaItem(props: Props) {
       }
       return (
         <div>
-          <strong>Constant value: </strong>
+          <strong>
+            {translate({
+              id: OPENAPI_SCHEMA_ITEM.CONSTANT_VALUE,
+              message: "Constant value:",
+            })}{" "}
+          </strong>
           <span>
             <code>{JSON.stringify(constValue)}</code>
           </span>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
@@ -7,12 +7,15 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
+
 import ApiTabs from "@theme/ApiTabs";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
 import ResponseHeaders from "@theme/ResponseHeaders";
 import ResponseSchema from "@theme/ResponseSchema";
 import TabItem from "@theme/TabItem";
+import { OPENAPI_STATUS_CODES } from "@theme/translationIds";
 import { ApiItem } from "docusaurus-plugin-openapi-docs/lib/types";
 
 interface Props {
@@ -51,7 +54,12 @@ const StatusCodes: React.FC<Props> = ({ label, id, responses }: any) => {
                 style={{ textAlign: "left", marginBottom: "1rem" }}
                 summary={
                   <summary>
-                    <strong>Response Headers</strong>
+                    <strong>
+                      {translate({
+                        id: OPENAPI_STATUS_CODES.RESPONSE_HEADERS,
+                        message: "Response Headers",
+                      })}
+                    </strong>
                   </summary>
                 }
               >
@@ -59,7 +67,10 @@ const StatusCodes: React.FC<Props> = ({ label, id, responses }: any) => {
               </Details>
             )}
             <ResponseSchema
-              title="Schema"
+              title={translate({
+                id: OPENAPI_STATUS_CODES.SCHEMA_TITLE,
+                message: "Schema",
+              })}
               body={{ content: response.content }}
             />
           </TabItem>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -1,0 +1,24 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+export const OPENAPI_RESPONSE = {
+  TITLE: "theme.openapi.response.title",
+  CLEAR: "theme.openapi.response.clear",
+  PLACEHOLDER: "theme.openapi.response.placeholder",
+  HEADERS_TAB: "theme.openapi.response.headersTab",
+};
+
+export const OPENAPI_TABS = {
+  RESPONSES_LABEL: "theme.openapi.tabs.responses.label",
+};
+
+export const OPENAPI_REQUEST = {
+  BODY_TITLE: "theme.openapi.request.body.title",
+  ACCEPT_TITLE: "theme.openapi.request.accept.title",
+  SEND_BUTTON: "theme.openapi.request.sendButton",
+  REQUIRED_LABEL: "theme.openapi.request.requiredLabel",
+};

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -21,4 +21,41 @@ export const OPENAPI_REQUEST = {
   ACCEPT_TITLE: "theme.openapi.request.accept.title",
   SEND_BUTTON: "theme.openapi.request.sendButton",
   REQUIRED_LABEL: "theme.openapi.request.requiredLabel",
+  REQUEST_TITLE: "theme.openapi.request.title",
+  COLLAPSE_ALL: "theme.openapi.request.collapseAll",
+  EXPAND_ALL: "theme.openapi.request.expandAll",
+  BASE_URL_TITLE: "theme.openapi.request.baseUrl.title",
+  AUTH_TITLE: "theme.openapi.request.auth.title",
+  PARAMETERS_TITLE: "theme.openapi.request.parameters.title",
+  FETCHING_MESSAGE: "theme.openapi.request.fetchingMessage",
+  CONNECTION_FAILED: "theme.openapi.request.connectionFailed",
+};
+
+export const OPENAPI_SERVER = {
+  EDIT_BUTTON: "theme.openapi.server.editButton",
+  HIDE_BUTTON: "theme.openapi.server.hideButton",
+};
+
+export const OPENAPI_PARAM_OPTIONS = {
+  SHOW_OPTIONAL: "theme.openapi.paramOptions.showOptional",
+  HIDE_OPTIONAL: "theme.openapi.paramOptions.hideOptional",
+};
+
+export const OPENAPI_FORM_FILE_UPLOAD = {
+  CLEAR_BUTTON: "theme.openapi.formFileUpload.clearButton",
+};
+
+export const OPENAPI_FORM = {
+  FIELD_REQUIRED: "theme.openapi.form.fieldRequired",
+};
+
+export const OPENAPI_AUTH = {
+  BEARER_TOKEN: "theme.openapi.auth.bearerToken",
+  USERNAME: "theme.openapi.auth.username",
+  PASSWORD: "theme.openapi.auth.password",
+};
+
+export const OPENAPI_RESPONSE_EXAMPLES = {
+  EXAMPLE: "theme.openapi.responseExamples.example",
+  AUTO_EXAMPLE: "theme.openapi.responseExamples.autoExample",
 };

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -59,3 +59,35 @@ export const OPENAPI_RESPONSE_EXAMPLES = {
   EXAMPLE: "theme.openapi.responseExamples.example",
   AUTO_EXAMPLE: "theme.openapi.responseExamples.autoExample",
 };
+
+export const OPENAPI_BODY = {
+  EXAMPLE_FROM_SCHEMA: "theme.openapi.body.exampleFromSchema",
+};
+
+export const OPENAPI_STATUS_CODES = {
+  RESPONSE_HEADERS: "theme.openapi.statusCodes.responseHeaders",
+  SCHEMA_TITLE: "theme.openapi.statusCodes.schemaTitle",
+};
+
+export const OPENAPI_SCHEMA_ITEM = {
+  REQUIRED: "theme.openapi.schemaItem.required",
+  DEPRECATED: "theme.openapi.schemaItem.deprecated",
+  NULLABLE: "theme.openapi.schemaItem.nullable",
+  DEFAULT_VALUE: "theme.openapi.schemaItem.defaultValue",
+  EXAMPLE: "theme.openapi.schemaItem.example",
+  EXAMPLES: "theme.openapi.schemaItem.examples",
+  DESCRIPTION: "theme.openapi.schemaItem.description",
+  CONSTANT_VALUE: "theme.openapi.schemaItem.constantValue",
+};
+
+export const OPENAPI_PARAMS_DETAILS = {
+  PARAMETERS_TITLE: "theme.openapi.paramsDetails.parametersTitle",
+};
+
+export const OPENAPI_SECURITY_SCHEMES = {
+  NAME: "theme.openapi.securitySchemes.name",
+  TYPE: "theme.openapi.securitySchemes.type",
+  SCOPES: "theme.openapi.securitySchemes.scopes",
+  IN: "theme.openapi.securitySchemes.in",
+  FLOWS: "theme.openapi.securitySchemes.flows",
+};


### PR DESCRIPTION
## Summary
- add translation id constants

Covered components:

- ApiTabs
- ApiExplorer/Authorization
- ApiExplorer/Body
- ApiExplorer/FormFileUpload
- ApiExplorer/FormItem
- ApiExplorer/FormTextInput
- ApiExplorer/LiveEditor
- ApiExplorer/ParamOptions along with its form item variants (ParamArrayFormItem, ParamBooleanFormItem, ParamMultiSelectFormItem, ParamSelectFormItem)
- ApiExplorer/Request
- ApiExplorer/Response
- ApiExplorer/SecuritySchemes
- ApiExplorer/Server
- ParamsDetails
- ParamsItem
- RequestSchema
- ResponseExamples
- ResponseSchema
- SchemaItem
- StatusCodes

Addresses #1146 and #319 

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6865400bebe483238103ef34d718fea3