### PR TITLE
fix: alias @faker-js/faker to false in webpack to reduce bundle size

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/index.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/index.ts
@@ -37,13 +37,11 @@ export default function docusaurusThemeOpenAPI(): Plugin<void> {
     ): Configuration {
       const { getStyleLoaders, currentBundler } = utils;
 
-      // --- Drop-in replacement for @faker-js/faker --------------------------
       const fakerAlias = { "@faker-js/faker": false } as const;
 
       const ignoreFaker = new currentBundler.instance.IgnorePlugin({
         resourceRegExp: /^@faker-js\/faker$/,
       });
-      // ----------------------------------------------------------------------
 
       const existingRules: any[] = config.module?.rules ?? [];
       const hasSassRule = existingRules.some(


### PR DESCRIPTION
The Postman code generator dependency includes @faker-js/faker, which isn't needed in the browser but adds significant bundle weight. This change uses a webpack alias and IgnorePlugin to exclude it from the client bundle.

## Description

Addresses #1205 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
