### PR TITLE
fix: the current type module path confusing typescript `tsc`

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/plugin-content-docs-types.d.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/plugin-content-docs-types.d.ts
@@ -5,10 +5,42 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-declare module "@docusaurus/plugin-content-docs-types" {
-  // Makes all properties visible when hovering over the type
-  type Expand<T extends Record<string, unknown>> = { [P in keyof T]: T[P] };
+// Makes all properties visible when hovering over the type
+type Expand<T extends Record<string, unknown>> = { [P in keyof T]: T[P] };
 
+export type SidebarItemBase = {
+  className?: string;
+  customProps?: Record<string, unknown>;
+};
+
+export type SidebarItemLink = SidebarItemBase & {
+  type: "link";
+  href: string;
+  label: string;
+  docId: string;
+};
+
+type SidebarItemCategoryBase = SidebarItemBase & {
+  type: "category";
+  label: string;
+  collapsed: boolean;
+  collapsible: boolean;
+};
+
+export type PropSidebarItemCategory = Expand<
+  SidebarItemCategoryBase & {
+    items: PropSidebarItem[];
+  }
+>;
+
+export type PropSidebarItem = SidebarItemLink | PropSidebarItemCategory;
+export type PropSidebar = PropSidebarItem[];
+export type PropSidebars = {
+  [sidebarId: string]: PropSidebar;
+};
+
+// Also declare the module for backwards compatibility
+declare module "@docusaurus/plugin-content-docs-types" {
   export type SidebarItemBase = {
     className?: string;
     customProps?: Record<string, unknown>;

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -21,7 +21,8 @@ export type {
   SidebarItemLink,
   PropSidebar,
   PropSidebarItem,
-} from "@docusaurus/plugin-content-docs-types";
+} from "./plugin-content-docs-types";
+
 export interface PluginOptions {
   id?: string;
   docsPlugin?: string;


### PR DESCRIPTION
## Description
Resolves:
- https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1015 
- https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/974

<!--- Describe your changes in detail -->

## Motivation and Context
The type error: 
```
node_modules/docusaurus-plugin-openapi-docs/src/types.ts:24:8 - error TS2307: Cannot find module '@docusaurus/plugin-content-docs-types' or its corresponding type declarations.

24 } from "@docusaurus/plugin-content-docs-types";
```
is really confusing because it seems like an official `@docusaurus` package in https://github.com/facebook/docusaurus/tree/main/packages but it's not. It gives an extra hurdle for typescript to resolve types. 


NOTE: This PR does not address: 
```ts
node_modules/docusaurus-plugin-openapi-docs/src/types.ts:8:32 - error TS2307: Cannot find module '@docusaurus/plugin-content-docs/src/sidebars/types' or its corresponding type declarations.

8 import { SidebarItemDoc } from "@docusaurus/plugin-content-docs/src/sidebars/types";
```
as `"moduleResolution": "node"` can solve it.

## How Has This Been Tested?

Successfully ran commands to build the project and serve the demo

## Types of changes
Bug fix / cleanup

A simple path update
- `packages/docusaurus-plugin-openapi-docs/src/types.ts`
Directly export from the type file
- `packages/docusaurus-plugin-openapi-docs/src/plugin-content-docs-types.d.ts`

## Checklist

- [x] I have updated the documentation accordingly. (not needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate. (not needed)
- [x] All new and existing tests passed.
