### PR TITLE
Fix TypeError when outputDir doesn't contain docPath

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -126,7 +126,7 @@ function groupByTags(
   }
 
   const basePath = docPath
-    ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")
+    ? (outputDir.split(docPath!)[1] || "").replace(/^\/+/g, "")
     : outputDir.slice(outputDir.indexOf("/", 1)).replace(/^\/+/g, "");
 
   const createDocItemFnContext = {


### PR DESCRIPTION
  Fix undefined reference error in basePath calculation when outputDir.split(docPath)[1] returns undefined. This
   occurs when using multiple docs plugin instances with mismatched path configurations.

  Add fallback to empty string to prevent .replace() call on undefined value.

  ## Description

  This PR fixes a `TypeError` that occurs during sidebar generation when `outputDir.split(docPath)[1]` returns
  `undefined`. The fix adds a fallback to an empty string using the logical OR operator (`|| ""`), preventing
  the subsequent `.replace()` call from being invoked on `undefined`.

  **Changed Line (index.ts:129)**:
  ```typescript
  // Before
  const basePath = docPath
    ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")
    : outputDir.slice(outputDir.indexOf("/", 1)).replace(/^\/+/g, "");

  // After
  const basePath = docPath
    ? (outputDir.split(docPath!)[1] || "").replace(/^\/+/g, "")
    : outputDir.slice(outputDir.indexOf("/", 1)).replace(/^\/+/g, "");

  Motivation and Context

  When configuring multiple @docusaurus/plugin-content-docs instances with different paths alongside
  docusaurus-plugin-openapi-docs, the plugin crashes with:

  TypeError: Cannot read properties of undefined (reading 'replace')
      at groupByTags (node_modules/docusaurus-plugin-openapi-docs/lib/sidebars/index.js:85:38)

  This occurs because outputDir.split(docPath)[1] returns undefined when the outputDir path doesn't contain
  docPath as expected. The code then attempts to call .replace() on undefined, causing the error.

  Example configuration that triggers the bug:
  plugins: [
    [
      '@docusaurus/plugin-content-docs',
      {
        id: 'WEDAApi',
        path: 'Weda/Api',
        routeBasePath: 'apis/weda',
        // ...
      },
    ],
    [
      'docusaurus-plugin-openapi-docs',
      {
        config: {
          weda: {
            specPath: "src/api/weda.yml",
            outputDir: "Weda/Api",
            sidebarOptions: {
              groupPathsBy: "tag",
            },
          }
        }
      }
    ],
  ]

  The fix allows the plugin to gracefully handle mismatched path configurations by defaulting to an empty string
   when the split operation fails.

  How Has This Been Tested?

  Testing Environment:
  - Node.js: v22.14.0
  - Docusaurus: 3.9.1
  - docusaurus-plugin-openapi-docs: 4.5.1
  - OS: Windows 11

  Test Steps:
  1. Configured multiple docs plugin instances with different paths
  2. Set up OpenAPI docs plugin with sidebarOptions.groupPathsBy: "tag"
  3. Ran npx docusaurus gen-api-docs weda
  4. Verified successful sidebar generation without errors
  5. Started dev server with npm start
  6. Confirmed API documentation displays correctly with proper tag-based categorization

  Test Results:
  - ✅ Sidebar generation completes without TypeError
  - ✅ Tag-based sidebar structure generated correctly
  - ✅ All API endpoints accessible and properly categorized
  - ✅ Development server starts without errors

  Before Fix: Command failed with TypeError: Cannot read properties of undefined (reading 'replace')

  After Fix: All commands execute successfully, sidebar generated with 90+ API endpoints properly organized by
  tags.

  Screenshots (if appropriate)

  N/A - This is a bug fix with no visual changes to the UI.

  Types of changes

  - Bug fix (non-breaking change which fixes an issue)