### PR TITLE
fix(theme): use matching auth scheme name in code snippet placeholders

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -76,7 +76,7 @@ function CodeSnippets({
               const authOptions =
                 clonedAuth?.options?.[key] ??
                 clonedAuth?.options?.[comboAuthId];
-              placeholder = authOptions?.[0]?.name;
+              placeholder = authOptions?.find((opt: any) => opt.key === key)?.name;
               obj[key] = cleanCredentials(obj[key]);
             } else {
               obj[key] = `<${placeholder ?? key}>`;


### PR DESCRIPTION
## Description

Changed `authOptions?.[0]?.name` to `authOptions?.find((opt: any) => opt.key === key)?.name` to find the correct auth scheme by key instead of always picking the first one.

## Motivation and Context

Fixes #1255

When an endpoint requires multiple auth schemes together (e.g. API Key + OAuth), the code snippet placeholder was always using the first scheme's name. This caused OAuth Bearer token to show `<X-API-Key>` instead of the OAuth scheme's configured name.

## How Has This Been Tested?

Tested locally with an OpenAPI spec that has both `APIKey` and `OAuth` security schemes required together on an endpoint. Verified the example now shows the correct placeholder for each scheme.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.