### PR TITLE
feat: support const in example generation

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
@@ -1,0 +1,57 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { sampleFromSchema } from "./createSchemaExample";
+import { SchemaObject } from "./types";
+
+describe("sampleFromSchema", () => {
+  describe("const support", () => {
+    it("should return default string value when const is not present", () => {
+      const schema: SchemaObject = {
+        type: "string",
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("string");
+    });
+
+    it("should return const value when const is present", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        const: "example",
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("example");
+    });
+
+    it("should handle anyOf with const values", () => {
+      const schema: SchemaObject = {
+        type: "string",
+        anyOf: [
+          {
+            type: "string",
+            const: "dog",
+          },
+          {
+            type: "string",
+            const: "cat",
+          },
+        ],
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBe("dog");
+    });
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
@@ -111,7 +111,16 @@ export const sampleFromSchema = (
   try {
     // deep copy schema before processing
     let schemaCopy = JSON.parse(JSON.stringify(schema));
-    let { type, example, allOf, properties, items, oneOf, anyOf } = schemaCopy;
+    let {
+      type,
+      example,
+      allOf,
+      properties,
+      items,
+      oneOf,
+      anyOf,
+      const: constant,
+    } = schemaCopy;
 
     if (example !== undefined) {
       return example;
@@ -216,6 +225,10 @@ export const sampleFromSchema = (
 
     if (shouldExcludeProperty(schemaCopy, context)) {
       return undefined;
+    }
+
+    if (constant) {
+      return constant;
     }
 
     return primitive(schemaCopy);


### PR DESCRIPTION
## Description

Support `const` during example generation

Continuation of: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1143

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This helps produce better example code, which can be copy/pasted without manual modifications.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Both tested locally against my schema, and a added unit test.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
