### PR TITLE
Add posibility to render file array and object example for 'multipart/form-data'

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
@@ -1,0 +1,77 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React, { useState } from "react";
+import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
+import { useTypedDispatch } from "@theme/ApiItem/hooks";
+import { FileContent, setFileArrayFormBody } from "../slice";
+
+interface FileArrayFormItemProps {
+  id: string;
+  description: string | undefined;
+}
+
+export default function FileArrayFormBodyItem({
+  id,
+  description,
+}: FileArrayFormItemProps): React.JSX.Element {
+  const dispatch = useTypedDispatch();
+  const [fileItems, setFileItems] = useState<
+    Map<number, FileContent["value"] | undefined>
+  >(new Map([[0, undefined]]));
+
+  const handleFileChange = (index: number, file: any) => {
+    const newItems = new Map(fileItems);
+
+    if (file === undefined) {
+      newItems.delete(index);
+
+      setFileItems(newItems);
+
+      dispatch(
+        setFileArrayFormBody({
+          key: id,
+          value: [...newItems.values()].filter((item) => item !== undefined),
+        })
+      );
+      return;
+    }
+
+    let maxIndex = 0;
+
+    newItems.keys().forEach((item) => {
+      maxIndex = item > maxIndex ? item : maxIndex;
+    });
+    newItems.set(index, {
+      src: `/path/to/${file.name}`,
+      content: file,
+    });
+    newItems.set(index + 1, undefined);
+
+    setFileItems(newItems);
+
+    dispatch(
+      setFileArrayFormBody({
+        key: id,
+        value: [...newItems.values()].filter((item) => item !== undefined),
+      })
+    );
+  };
+
+  return (
+    <div>
+      {[...fileItems.keys()].map((index) => (
+        <div key={index}>
+          <FormFileUpload
+            placeholder={description || id}
+            onChange={(file: any) => handleFileChange(index, file)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
@@ -1,0 +1,120 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React from "react";
+import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
+import FormSelect from "@theme/ApiExplorer/FormSelect";
+import FormTextInput from "@theme/ApiExplorer/FormTextInput";
+import LiveApp from "@theme/ApiExplorer/LiveEditor";
+import { useTypedDispatch } from "@theme/ApiItem/hooks";
+import { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import { clearFormBodyKey, setFileFormBody, setStringFormBody } from "../slice";
+import FileArrayFormBodyItem from "../FileArrayFormBodyItem";
+
+interface FormBodyItemProps {
+  schemaObject: SchemaObject;
+  id: string;
+  schema: SchemaObject;
+}
+
+export default function FormBodyItem({
+  schemaObject,
+  id,
+  schema,
+}: FormBodyItemProps): React.JSX.Element {
+  const dispatch = useTypedDispatch();
+
+  if (
+    schemaObject.type === "array" &&
+    schemaObject.items?.format === "binary"
+  ) {
+    return (
+      <FileArrayFormBodyItem id={id} description={schemaObject.description} />
+    );
+  }
+
+  if (schemaObject.format === "binary") {
+    return (
+      <FormFileUpload
+        placeholder={schemaObject.description || id}
+        onChange={(file: any) => {
+          if (file === undefined) {
+            dispatch(clearFormBodyKey(id));
+            return;
+          }
+          dispatch(
+            setFileFormBody({
+              key: id,
+              value: {
+                src: `/path/to/${file.name}`,
+                content: file,
+              },
+            })
+          );
+        }}
+      />
+    );
+  }
+
+  if (
+    schemaObject.type === "object" &&
+    (schemaObject.example || schemaObject.examples)
+  ) {
+    const objectExample = JSON.stringify(
+      schemaObject.example ?? schemaObject.examples[0],
+      null,
+      2
+    );
+
+    return (
+      <LiveApp
+        action={(code: string) =>
+          dispatch(setStringFormBody({ key: id, value: code }))
+        }
+      >
+        {objectExample}
+      </LiveApp>
+    );
+  }
+
+  if (
+    schemaObject.enum &&
+    schemaObject.enum.every((value) => typeof value === "string")
+  ) {
+    return (
+      <FormSelect
+        options={["---", ...schemaObject.enum]}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          const val = e.target.value;
+          if (val === "---") {
+            dispatch(clearFormBodyKey(id));
+          } else {
+            dispatch(
+              setStringFormBody({
+                key: id,
+                value: val,
+              })
+            );
+          }
+        }}
+      />
+    );
+  }
+  // TODO: support all the other types.
+  return (
+    <FormTextInput
+      paramName={id}
+      isRequired={
+        Array.isArray(schema.required) && schema.required.includes(id)
+      }
+      placeholder={schemaObject.description || id}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        dispatch(setStringFormBody({ key: id, value: e.target.value }));
+      }}
+    />
+  );
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -12,8 +12,6 @@ import { translate } from "@docusaurus/Translate";
 import json2xml from "@theme/ApiExplorer/Body/json2xml";
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormItem from "@theme/ApiExplorer/FormItem";
-import FormSelect from "@theme/ApiExplorer/FormSelect";
-import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import LiveApp from "@theme/ApiExplorer/LiveEditor";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import Markdown from "@theme/Markdown";
@@ -23,13 +21,8 @@ import { OPENAPI_BODY, OPENAPI_REQUEST } from "@theme/translationIds";
 import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
 
-import {
-  clearFormBodyKey,
-  clearRawBody,
-  setFileFormBody,
-  setFileRawBody,
-  setStringFormBody,
-} from "./slice";
+import { clearRawBody, setFileRawBody, setStringRawBody } from "./slice";
+import FormBodyItem from "./FormBodyItem";
 
 export interface Props {
   jsonRequestBodyExample: string;
@@ -128,96 +121,23 @@ function Body({
   ) {
     return (
       <FormItem className="openapi-explorer__form-item-body-container">
-        <div>
-          {Object.entries(schema.properties ?? {}).map(([key, val]: any) => {
-            if (val.format === "binary") {
-              return (
-                <FormItem
-                  key={key}
-                  label={key}
-                  required={
-                    Array.isArray(schema.required) &&
-                    schema.required.includes(key)
-                  }
-                >
-                  <FormFileUpload
-                    placeholder={val.description || key}
-                    onChange={(file: any) => {
-                      if (file === undefined) {
-                        dispatch(clearFormBodyKey(key));
-                        return;
-                      }
-                      dispatch(
-                        setFileFormBody({
-                          key: key,
-                          value: {
-                            src: `/path/to/${file.name}`,
-                            content: file,
-                          },
-                        })
-                      );
-                    }}
-                  />
-                </FormItem>
-              );
-            }
-
-            if (val.enum) {
-              return (
-                <FormItem
-                  key={key}
-                  label={key}
-                  required={
-                    Array.isArray(schema.required) &&
-                    schema.required.includes(key)
-                  }
-                >
-                  <FormSelect
-                    options={["---", ...val.enum]}
-                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-                      const val = e.target.value;
-                      if (val === "---") {
-                        dispatch(clearFormBodyKey(key));
-                      } else {
-                        dispatch(
-                          setStringFormBody({
-                            key: key,
-                            value: val,
-                          })
-                        );
-                      }
-                    }}
-                  />
-                </FormItem>
-              );
-            }
-            // TODO: support all the other types.
-            return (
-              <FormItem
-                key={key}
-                label={key}
-                required={
-                  Array.isArray(schema.required) &&
-                  schema.required.includes(key)
-                }
-              >
-                <FormTextInput
-                  paramName={key}
-                  isRequired={
-                    Array.isArray(schema.required) &&
-                    schema.required.includes(key)
-                  }
-                  placeholder={val.description || key}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    dispatch(
-                      setStringFormBody({ key: key, value: e.target.value })
-                    );
-                  }}
-                />
-              </FormItem>
-            );
-          })}
-        </div>
+        {Object.entries(schema.properties ?? {}).map(([key, val]: any) => {
+          return (
+            <FormItem
+              key={key}
+              label={key}
+              required={
+                Array.isArray(schema.required) && schema.required.includes(key)
+              }
+            >
+              <FormBodyItem
+                schemaObject={val}
+                id={key}
+                schema={schema}
+              ></FormBodyItem>
+            </FormItem>
+          );
+        })}
       </FormItem>
     );
   }
@@ -315,7 +235,11 @@ function Body({
             value="Example (from schema)"
             default
           >
-            <LiveApp action={dispatch} language={language} required={required}>
+            <LiveApp
+              action={(code: string) => dispatch(setStringRawBody(code))}
+              language={language}
+              required={required}
+            >
               {defaultBody}
             </LiveApp>
           </TabItem>
@@ -324,7 +248,7 @@ function Body({
             {example.summary && <Markdown>{example.summary}</Markdown>}
             {exampleBody && (
               <LiveApp
-                action={dispatch}
+                action={(code: string) => dispatch(setStringRawBody(code))}
                 language={language}
                 required={required}
               >
@@ -350,7 +274,11 @@ function Body({
             value="Example (from schema)"
             default
           >
-            <LiveApp action={dispatch} language={language} required={required}>
+            <LiveApp
+              action={(code: string) => dispatch(setStringRawBody(code))}
+              language={language}
+              required={required}
+            >
               {defaultBody}
             </LiveApp>
           </TabItem>
@@ -364,7 +292,10 @@ function Body({
               >
                 {example.summary && <Markdown>{example.summary}</Markdown>}
                 {example.body && (
-                  <LiveApp action={dispatch} language={language}>
+                  <LiveApp
+                    action={(code: string) => dispatch(setStringRawBody(code))}
+                    language={language}
+                  >
                     {example.body}
                   </LiveApp>
                 )}
@@ -378,7 +309,11 @@ function Body({
 
   return (
     <FormItem>
-      <LiveApp action={dispatch} language={language} required={required}>
+      <LiveApp
+        action={(code: string) => dispatch(setStringRawBody(code))}
+        language={language}
+        required={required}
+      >
         {defaultBody}
       </LiveApp>
     </FormItem>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/slice.ts
@@ -15,12 +15,24 @@ export interface FileContent {
   };
 }
 
+export interface FileArrayContent {
+  type: "file[]";
+  value: {
+    src: string;
+    content: Blob;
+  }[];
+}
+
 export interface StringContent {
   type: "string";
   value?: string;
 }
 
-export type Content = FileContent | StringContent | undefined;
+export type Content =
+  | FileContent
+  | FileArrayContent
+  | StringContent
+  | undefined;
 
 export interface FormBody {
   type: "form";
@@ -118,6 +130,32 @@ export const slice = createSlice({
       };
       return state;
     },
+    setFileArrayFormBody: (
+      state,
+      action: PayloadAction<{
+        key: string;
+        value: FileArrayContent["value"];
+      }>
+    ) => {
+      if (state?.type !== "form") {
+        return {
+          type: "form",
+          content: {
+            [action.payload.key]: {
+              type: "file[]",
+              value: action.payload.value,
+            },
+          },
+        };
+      }
+
+      state.content[action.payload.key] = {
+        type: "file[]",
+        value: action.payload.value,
+      };
+
+      return state;
+    },
   },
 });
 
@@ -128,6 +166,7 @@ export const {
   clearFormBodyKey,
   setStringFormBody,
   setFileFormBody,
+  setFileArrayFormBody,
 } = slice.actions;
 
 export default slice.reducer;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
@@ -11,7 +11,6 @@ import { usePrismTheme } from "@docusaurus/theme-common";
 import { translate } from "@docusaurus/Translate";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import { ErrorMessage } from "@hookform/error-message";
-import { setStringRawBody } from "@theme/ApiExplorer/Body/slice";
 import { OPENAPI_FORM } from "@theme/translationIds";
 import clsx from "clsx";
 import { Controller, useFormContext } from "react-hook-form";
@@ -56,8 +55,8 @@ function App({
   const [code, setCode] = React.useState(children.replace(/\n$/, ""));
 
   useEffect(() => {
-    action(setStringRawBody(code));
-  }, [action, code]);
+    action(code);
+  }, [code]);
 
   const {
     control,


### PR DESCRIPTION
## Description
- Added posibility to render array of binaries for `'multipart/form-data'`.
- Render object example via `<LiveApp/>`.
- Split FormBodyItem into two files (may be improved, but anyways better than now).
- Little changes around to support the enhancement.

## Motivation and Context

The commit makes it possible to render an array of files and examples for objects, similar to how swagger UI does it.

## How Has This Been Tested?

- Locally with my own .yaml files.
- Checked all demos for issues.
- `yarn test`

## Screenshots (if appropriate)
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/20e0004a-4329-4335-b171-5b38d38f73d8" />
<img width="1919" height="1030" alt="image" src="https://github.com/user-attachments/assets/1d623ddc-d1fe-4061-80e0-fd5354275c3b" />
<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/636b5905-a493-47f4-9b1f-7cdc33d6f8eb" />


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
