### PR TITLE
feat: support schema.examples array in example generator

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.ts
@@ -91,7 +91,12 @@ function sampleFromProp(
 
   // TODO: handle discriminators
 
-  if (prop.oneOf) {
+  // Check for explicit example/examples first (OAS 3.1 support)
+  if (prop.example !== undefined) {
+    obj[name] = prop.example;
+  } else if (prop.examples !== undefined && prop.examples.length > 0) {
+    obj[name] = prop.examples[0];
+  } else if (prop.oneOf) {
     obj[name] = sampleFromSchema(prop.oneOf[0], context);
   } else if (prop.anyOf) {
     obj[name] = sampleFromSchema(prop.anyOf[0], context);
@@ -114,6 +119,7 @@ export const sampleFromSchema = (
     let {
       type,
       example,
+      examples,
       allOf,
       properties,
       items,
@@ -124,6 +130,11 @@ export const sampleFromSchema = (
 
     if (example !== undefined) {
       return example;
+    }
+
+    // OAS 3.1 / JSON Schema: examples is an array
+    if (examples !== undefined && examples.length > 0) {
+      return examples[0];
     }
 
     if (oneOf) {


### PR DESCRIPTION
Adds support for the OpenAPI 3.1 / JSON Schema 'examples' array in the schema example generator (createSchemaExample.ts):

- Check schema.examples after schema.example in sampleFromSchema
- Check property.examples after property.example in sampleFromProp
- Uses first example from array when examples is non-empty
- Guards against empty arrays to prevent fallback issues

Closes #1219

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
