### PR TITLE
fix: handle undefined when outputDir doesn't contain docPath

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -353,9 +353,18 @@ custom_edit_url: null
                 .toString("base64"));
           let infoBasePath = `${outputDir}/${item.infoId}`;
           if (docRouteBasePath) {
-            infoBasePath = `${docRouteBasePath}/${outputDir
-              .split(docPath!)[1]
-              .replace(/^\/+/g, "")}/${item.infoId}`.replace(/^\/+/g, "");
+            // Safely extract path segment, handling cases where docPath may not be in outputDir
+            const outputSegment =
+              docPath && outputDir.includes(docPath)
+                ? (outputDir.split(docPath)[1]?.replace(/^\/+/g, "") ?? "")
+                : outputDir
+                    .slice(outputDir.indexOf("/", 1))
+                    .replace(/^\/+/g, "");
+            infoBasePath =
+              `${docRouteBasePath}/${outputSegment}/${item.infoId}`.replace(
+                /^\/+/g,
+                ""
+              );
           }
           if (item.infoId) item.infoPath = infoBasePath;
         }

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -125,9 +125,21 @@ function groupByTags(
     apiTags = uniq(apiTags.concat(operationTags, schemaTags));
   }
 
-  const basePath = docPath
-    ? outputDir.split(docPath!)[1].replace(/^\/+/g, "")
-    : outputDir.slice(outputDir.indexOf("/", 1)).replace(/^\/+/g, "");
+  // Extract base path from outputDir, handling cases where docPath may not be in outputDir
+  const getBasePathFromOutput = (
+    output: string,
+    doc: string | undefined
+  ): string => {
+    if (doc && output.includes(doc)) {
+      return output.split(doc)[1]?.replace(/^\/+/g, "") ?? "";
+    }
+    const slashIndex = output.indexOf("/", 1);
+    return slashIndex === -1
+      ? ""
+      : output.slice(slashIndex).replace(/^\/+/g, "");
+  };
+
+  const basePath = getBasePathFromOutput(outputDir, docPath);
 
   const createDocItemFnContext = {
     sidebarOptions,


### PR DESCRIPTION
Fixes TypeError when using multiple docs plugin instances with mismatched path configurations. The code now safely handles cases where outputDir.split(docPath) returns undefined.

Fixes both occurrences:
- sidebars/index.ts: basePath calculation
- index.ts: infoBasePath calculation

Closes #1224

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
