### PR TITLE
feat: add showInfoPage option to disable info page generation

### DIFF
--- a/demo/docusaurus.config.ts
+++ b/demo/docusaurus.config.ts
@@ -352,6 +352,7 @@ const config: Config = {
               groupPathsBy: "tag",
             },
             showSchemas: true,
+            showInfoPage: false, // Disable info page generation
           } satisfies OpenApiPlugin.Options,
           tests: {
             specPath: "examples/tests",

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -176,6 +176,8 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                       |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                               |
+| `showInfoPage`       | `boolean` | `true`  | _Optional:_ If set to `false`, disables generation of the info page (overview page with API title and description).                         |
+| `schemasOnly`        | `boolean` | `false` | _Optional:_ If set to `true`, generates only schema pages (no API endpoint pages). Also available as `--schemas-only` CLI flag.             |
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -97,8 +97,11 @@ function createItems(
   const infoId = kebabCase(infoIdSpaces);
   const schemasOnly = options?.schemasOnly === true;
 
-  if (openapiData.info.description || openapiData.info.title) {
-    // Only create an info page if we have a description.
+  // Only create an info page if we have a description/title AND showInfoPage is not false
+  if (
+    (openapiData.info.description || openapiData.info.title) &&
+    options?.showInfoPage !== false
+  ) {
     const infoDescription = openapiData.info?.description;
     let splitDescription: any;
     if (infoDescription) {

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -48,6 +48,8 @@ export const OptionsSchema = Joi.object({
         sidebarOptions: sidebarOptions,
         markdownGenerators: markdownGenerators,
         showSchemas: Joi.boolean(),
+        showInfoPage: Joi.boolean(),
+        schemasOnly: Joi.boolean(),
         disableCompression: Joi.boolean(),
         maskCredentials: Joi.boolean(),
         version: Joi.string().when("versions", {

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -51,6 +51,7 @@ export interface APIOptions {
   proxy?: string;
   markdownGenerators?: MarkdownGenerator;
   showSchemas?: boolean;
+  showInfoPage?: boolean;
   schemasOnly?: boolean;
   disableCompression?: boolean;
   maskCredentials?: boolean;


### PR DESCRIPTION
- Add showInfoPage boolean option (default: true) to disable info page
- Follows existing showSchemas pattern for consistency
- Also documents schemasOnly as a config option (was CLI-only before)

Closes #1103

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
