### PR TITLE
feat(plugin): add externalJsonProps option to improve build perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ demo/**/*.info.mdx
 demo/**/*.tag.mdx
 demo/**/*.schema.mdx
 demo/**/sidebar.ts
-demo/**/versions.json
+demo/**/*.json
 
 .idea
 .tool-versions

--- a/README.md
+++ b/README.md
@@ -155,25 +155,26 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `config` can be configured with the following options:
 
-| Name                 | Type      | Default | Description                                                                                                                                 |
-| -------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                 |
-| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                    |
-| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set. |
-| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                  |
-| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                  |
-| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                   |
-| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                |
-| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                             |
-| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                    |
-| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                    |
-| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                            |
-| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                         |
-| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                          |
-| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                   |
-| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                |
-| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                       |
-| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                               |
+| Name                 | Type      | Default | Description                                                                                                                                                    |
+| -------------------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                                    |
+| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                                       |
+| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set.                    |
+| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                                     |
+| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                                     |
+| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                                      |
+| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                                   |
+| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                                                |
+| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                                       |
+| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                                       |
+| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                                               |
+| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                                            |
+| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                                             |
+| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                                      |
+| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                                   |
+| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                                          |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                                  |
+| `externalJsonProps`  | `boolean` | `true`  | _Optional:_ If set to `false`, disables externalization of large JSON props. By default, large JSON is written to external files for better build performance. |
 
 ### sidebarOptions
 

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -221,6 +221,7 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                     |
 | `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                            |
 | `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                    |
+| `externalJsonProps`  | `boolean` | `true`  | _Optional:_ If set to `false`, disables externalization of large JSON props. By default, large JSON is written to external files for better build performance. |
 
 ### sidebarOptions
 

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -156,28 +156,29 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 
 `config` can be configured with the following options:
 
-| Name                 | Type      | Default | Description                                                                                                                                 |
-| -------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                 |
-| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                    |
-| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set. |
-| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                  |
-| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                  |
-| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                   |
-| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                |
-| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                             |
-| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                    |
-| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                    |
-| `maskCredentials`    | `boolean` | `true`  | _Optional:_ If set to `false`, disables credential masking in generated code snippets. By default, credentials are masked for security.     |
-| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                            |
-| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                         |
-| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                          |
-| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                   |
-| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                |
-| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                       |
-| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                               |
-| `showInfoPage`       | `boolean` | `true`  | _Optional:_ If set to `false`, disables generation of the info page (overview page with API title and description).                         |
-| `schemasOnly`        | `boolean` | `false` | _Optional:_ If set to `true`, generates only schema pages (no API endpoint pages). Also available as `--schemas-only` CLI flag.             |
+| Name                 | Type      | Default | Description                                                                                                                                                    |
+| -------------------- | --------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specPath`           | `string`  | `null`  | Designated URL or path to the source of an OpenAPI specification file or directory of multiple OpenAPI specification files.                                    |
+| `outputDir`          | `string`  | `null`  | Desired output path for generated MDX and sidebar files.                                                                                                       |
+| `proxy`              | `string`  | `null`  | _Optional:_ Proxy URL to prepend to base URL when performing API requests from browser. Overrides site-wide `themeConfig.api.proxy` if set.                    |
+| `template`           | `string`  | `null`  | _Optional:_ Customize MDX content with a desired template.                                                                                                     |
+| `infoTemplate`       | `string`  | `null`  | _Optional:_ Customize MDX content for **info** pages only.                                                                                                     |
+| `tagTemplate`        | `string`  | `null`  | _Optional:_ Customize MDX content for **tag** pages only.                                                                                                      |
+| `schemaTemplate`     | `string`  | `null`  | _Optional:_ Customize MDX content for **schema** pages only.                                                                                                   |
+| `downloadUrl`        | `string`  | `null`  | _Optional:_ Designated URL for downloading OpenAPI specification. (requires `info` section/doc)                                                                |
+| `hideSendButton`     | `boolean` | `null`  | _Optional:_ If set to `true`, hides the “Send API Request” button in the API demo panel.                                                                       |
+| `showExtensions`     | `boolean` | `null`  | _Optional:_ If set to `true`, renders operation‑level vendor‑extensions in descriptions.                                                                       |
+| `maskCredentials`    | `boolean` | `true`  | _Optional:_ If set to `false`, disables credential masking in generated code snippets. By default, credentials are masked for security.                        |
+| `sidebarOptions`     | `object`  | `null`  | _Optional:_ Set of options for sidebar configuration. See below for a list of supported options.                                                               |
+| `version`            | `string`  | `null`  | _Optional:_ Version assigned to a single or micro‑spec API specified in `specPath`.                                                                            |
+| `label`              | `string`  | `null`  | _Optional:_ Version label used when generating the version‑selector dropdown menu.                                                                             |
+| `baseUrl`            | `string`  | `null`  | _Optional:_ Base URL for versioned docs in the version‑selector dropdown.                                                                                      |
+| `versions`           | `object`  | `null`  | _Optional:_ Options for versioning configuration. See below for a list of supported options.                                                                   |
+| `markdownGenerators` | `object`  | `null`  | _Optional:_ Customize MDX content via generator functions. See below for a list of supported options.                                                          |
+| `showSchemas`        | `boolean` | `null`  | _Optional:_ If set to `true`, generates standalone schema pages and adds them to the sidebar.                                                                  |
+| `showInfoPage`       | `boolean` | `true`  | _Optional:_ If set to `false`, disables generation of the info page (overview page with API title and description).                                            |
+| `schemasOnly`        | `boolean` | `false` | _Optional:_ If set to `true`, generates only schema pages (no API endpoint pages). Also available as `--schemas-only` CLI flag.                                |
+| `externalJsonProps`  | `boolean` | `true`  | _Optional:_ If set to `false`, disables externalization of large JSON props. By default, large JSON is written to external files for better build performance. |
 
 ### sidebarOptions
 
@@ -225,6 +226,28 @@ The `docusaurus-plugin-openapi-docs` plugin can be configured with the following
 | Name            | Type       | Default | Description                                                                                                                                                                                                                                      |
 | --------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `createDocItem` | `function` | `null`  | Optional: Returns a `SidebarItemDoc` object containing metadata for a sidebar item.<br/><br/>**Function type:** `(item: ApiPageMetadata \| SchemaPageMetadata, context: { sidebarOptions: SidebarOptions; basePath: string }) => SidebarItemDoc` |
+
+### Performance Optimization
+
+By default, `externalJsonProps` is enabled to optimize Docusaurus build times. This externalizes large JSON objects to separate files, significantly improving build performance for large OpenAPI specs.
+
+**How it works:**
+
+- With `externalJsonProps: true` (default): Large JSON props are written to separate `.json` files and loaded via `require()`. This bypasses MDX AST processing entirely, allowing the bundler to handle JSON more efficiently.
+
+- With `externalJsonProps: false`: Large JSON objects (responses, request bodies, parameters) are embedded directly in the MDX. The MDX compiler must parse these into an AST and serialize them back, which can be slow for deeply nested schemas.
+
+**When to disable:**
+
+You may set `externalJsonProps: false` if you have custom tooling that depends on parsing the MDX files directly:
+
+```typescript
+petstore: {
+  specPath: "examples/petstore.yaml",
+  outputDir: "docs/petstore",
+  externalJsonProps: false, // Disable if needed for custom tooling
+} satisfies OpenApiPlugin.Options,
+```
 
 ## Theme Configuration Options
 

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/externalizeJsonProps.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/externalizeJsonProps.ts
@@ -1,0 +1,201 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+/**
+ * This module provides utilities for externalizing large JSON props in MDX files.
+ *
+ * The motivation is to improve MDX compilation performance. When large JSON objects
+ * are embedded directly as JSX props, MDX needs to parse them into AST and then
+ * serialize them back. By externalizing to JSON files and using require(), the
+ * MDX compiler can skip this expensive processing.
+ *
+ * @see https://github.com/facebook/docusaurus/discussions/11664
+ */
+
+export interface ExternalizedJsonFile {
+  /** The filename for the JSON file (without path) */
+  filename: string;
+  /** The JSON content to write */
+  content: string;
+}
+
+export interface ExternalizeResult {
+  /** The transformed MDX content with require() statements */
+  mdx: string;
+  /** List of JSON files that need to be written */
+  jsonFiles: ExternalizedJsonFile[];
+}
+
+/**
+ * Components and their props that should be externalized.
+ * These are the components that typically receive large JSON objects.
+ */
+const COMPONENTS_TO_EXTERNALIZE = [
+  { component: "StatusCodes", prop: "responses" },
+  { component: "ParamsDetails", prop: "parameters" },
+  { component: "RequestSchema", prop: "body" },
+  { component: "Schema", prop: "schema" },
+  { component: "SchemaItem", prop: "schema" },
+];
+
+/**
+ * Minimum size (in characters) for a JSON prop to be externalized.
+ * Props smaller than this threshold will remain inline.
+ */
+const MIN_SIZE_THRESHOLD = 500;
+
+/**
+ * Extracts the content between balanced braces starting at a given position.
+ * Returns the content (without outer braces) and the end position.
+ */
+function extractBalancedBraces(
+  str: string,
+  startIndex: number
+): { content: string; endIndex: number } | null {
+  if (str[startIndex] !== "{") {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let stringChar = "";
+  let escaped = false;
+
+  for (let i = startIndex; i < str.length; i++) {
+    const char = str[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === '"' || char === "'") {
+        inString = true;
+        stringChar = char;
+      } else if (char === "{") {
+        depth++;
+      } else if (char === "}") {
+        depth--;
+        if (depth === 0) {
+          // Found the matching closing brace
+          return {
+            content: str.substring(startIndex + 1, i),
+            endIndex: i,
+          };
+        }
+      }
+    } else {
+      if (char === stringChar) {
+        inString = false;
+      }
+    }
+  }
+
+  return null; // Unbalanced braces
+}
+
+/**
+ * Externalizes large JSON props from MDX content.
+ * Uses brace-counting to correctly handle deeply nested JSON.
+ *
+ * @param mdx - The original MDX content
+ * @param baseFilename - The base filename (without extension) for the MDX file
+ * @returns The transformed MDX and list of JSON files to write
+ */
+export function externalizeJsonPropsSimple(
+  mdx: string,
+  baseFilename: string
+): ExternalizeResult {
+  const jsonFiles: ExternalizedJsonFile[] = [];
+  let transformedMdx = mdx;
+
+  for (const { component, prop } of COMPONENTS_TO_EXTERNALIZE) {
+    // Find pattern: prop={
+    const propPattern = new RegExp(`${prop}=\\{`, "g");
+    let match;
+
+    // Keep searching until no more matches (need to restart after each replacement)
+    let searchStart = 0;
+    while (true) {
+      propPattern.lastIndex = searchStart;
+      match = propPattern.exec(transformedMdx);
+
+      if (!match) break;
+
+      const propStart = match.index;
+      const braceStart = propStart + prop.length + 1; // Position of '{'
+
+      // Extract the balanced content
+      const extracted = extractBalancedBraces(transformedMdx, braceStart);
+      if (!extracted) {
+        searchStart = braceStart + 1;
+        continue;
+      }
+
+      const jsonContent = extracted.content;
+      const propEnd = extracted.endIndex + 1; // Position after '}'
+
+      // Skip small or non-JSON content
+      const trimmed = jsonContent.trim();
+      if (
+        jsonContent.length < MIN_SIZE_THRESHOLD ||
+        trimmed === "undefined" ||
+        trimmed === "null" ||
+        trimmed === "true" ||
+        trimmed === "false" ||
+        trimmed.startsWith("require(")
+      ) {
+        searchStart = propEnd;
+        continue;
+      }
+
+      // Check if this is within the target component
+      // Look backwards for the component tag
+      const beforeProp = transformedMdx.substring(0, propStart);
+      const componentTagPattern = new RegExp(`<${component}[\\s\\S]*$`);
+      if (!componentTagPattern.test(beforeProp)) {
+        searchStart = propEnd;
+        continue;
+      }
+
+      // Generate filename
+      const existingCount = jsonFiles.filter((f) =>
+        f.filename.includes(`.${prop}`)
+      ).length;
+      const suffix = existingCount > 0 ? `.${existingCount + 1}` : "";
+      const jsonFilename = `${baseFilename}.${prop}${suffix}.json`;
+
+      // Store the JSON file
+      jsonFiles.push({
+        filename: jsonFilename,
+        content: jsonContent.trim(),
+      });
+
+      // Replace the prop value with require()
+      const newProp = `${prop}={require("./${jsonFilename}")}`;
+
+      transformedMdx =
+        transformedMdx.substring(0, propStart) +
+        newProp +
+        transformedMdx.substring(propEnd);
+
+      // Continue searching after the replacement
+      searchStart = propStart + newProp.length;
+    }
+  }
+
+  return {
+    mdx: transformedMdx,
+    jsonFiles,
+  };
+}

--- a/packages/docusaurus-plugin-openapi-docs/src/options.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/options.ts
@@ -52,6 +52,7 @@ export const OptionsSchema = Joi.object({
         schemasOnly: Joi.boolean(),
         disableCompression: Joi.boolean(),
         maskCredentials: Joi.boolean(),
+        externalJsonProps: Joi.boolean().default(true),
         version: Joi.string().when("versions", {
           is: Joi.exist(),
           then: Joi.required(),

--- a/packages/docusaurus-plugin-openapi-docs/src/types.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/types.ts
@@ -55,6 +55,13 @@ export interface APIOptions {
   schemasOnly?: boolean;
   disableCompression?: boolean;
   maskCredentials?: boolean;
+  /**
+   * When enabled, large JSON props in generated MDX are written to external
+   * files and loaded via require(). This can significantly improve MDX
+   * compilation performance for large OpenAPI specs.
+   * @see https://github.com/facebook/docusaurus/discussions/11664
+   */
+  externalJsonProps?: boolean;
 }
 
 export interface MarkdownGenerator {


### PR DESCRIPTION
## Description

Add new externalJsonProps configuration option that extracts large JSON props from MDX files into separate .json files loaded via require(). This bypasses MDX AST parsing for large JSON objects (>500 chars), significantly improving build times for large OpenAPI specs.

The option is enabled by default due to the significant performance benefits (up to 25x faster builds in benchmarks). Users can opt-out by setting externalJsonProps: false.

Changes:
- Add externalizeJsonProps.ts utility for JSON extraction
- Integrate with doc generation and cleanup flows
- Add TypeScript types and Joi validation (default: true)
- Update README with documentation and usage examples
- Update .gitignore to exclude generated JSON files

## Motivation and Context

Large json props can greatly increase build times. See https://github.com/facebook/docusaurus/discussions/11664#discussioncomment-15520809 for background.

## How Has This Been Tested?

Tested using the [Harvester OpenAPI spec](https://github.com/harvester/harvester/blob/master/api/openapi-spec/swagger.json)

