### PR TITLE
fix: generate correct examples for different request content types #1283

### DIFF
--- a/demo/examples/tests/examples.yaml
+++ b/demo/examples/tests/examples.yaml
@@ -549,3 +549,56 @@ paths:
                     examples:
                       - true
                       - false
+
+  /requestBody/multipleContentTypes:
+    post:
+      tags:
+        - examples
+      summary: multiple content types with different schemas
+      description: "This endpoint accepts either JSON or XML with different schemas"
+      security:
+        - BearerAuth: []
+      requestBody:
+        description: Example endpoint request
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - example_request_json_param
+              properties:
+                example_request_json_param:
+                  type: string
+                  description: This field should only appear in JSON requests
+                  example: "json_value"
+          application/xml:
+            schema:
+              type: object
+              required:
+                - example_request_xml_param
+              properties:
+                example_request_xml_param:
+                  type: string
+                  description: This field should only appear in XML requests
+                  example: "xml_value"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - example_response_param
+                properties:
+                  example_response_param:
+                    type: string
+                    description: The example response parameter
+                    example: "response_value"
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -45,7 +45,7 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
 
   if (mimeTypes.length > 1) {
     return (
-      <MimeTabs className="openapi-tabs__mime" schemaType="request">
+      <MimeTabs className="openapi-tabs__mime" schemaType="request" lazy>
         {mimeTypes.map((mimeType) => {
           const firstBody = body.content![mimeType].schema;
           if (
@@ -58,43 +58,45 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
           return (
             // @ts-ignore
             <TabItem key={mimeType} label={mimeType} value={mimeType}>
-              <Details
-                className="openapi-markdown__details mime"
-                data-collapsed={false}
-                open={true}
-                style={style}
-                summary={
-                  <>
-                    <summary>
-                      <h3 className="openapi-markdown__details-summary-header-body">
-                        {translate({
-                          id: OPENAPI_REQUEST.BODY_TITLE,
-                          message: title,
-                        })}
-                        {body.required === true && (
-                          <span className="openapi-schema__required">
-                            {translate({
-                              id: OPENAPI_SCHEMA_ITEM.REQUIRED,
-                              message: "required",
-                            })}
-                          </span>
-                        )}
-                      </h3>
-                    </summary>
-                  </>
-                }
-              >
-                <div style={{ textAlign: "left", marginLeft: "1rem" }}>
-                  {body.description && (
-                    <div style={{ marginTop: "1rem", marginBottom: "1rem" }}>
-                      <Markdown>{body.description}</Markdown>
-                    </div>
-                  )}
-                </div>
-                <ul style={{ marginLeft: "1rem" }}>
-                  <SchemaNode schema={firstBody} schemaType="request" />
-                </ul>
-              </Details>
+              <div style={{ marginTop: "1rem" }}>
+                <Details
+                  className="openapi-markdown__details mime"
+                  data-collapsed={false}
+                  open={true}
+                  style={style}
+                  summary={
+                    <>
+                      <summary>
+                        <h3 className="openapi-markdown__details-summary-header-body">
+                          {translate({
+                            id: OPENAPI_REQUEST.BODY_TITLE,
+                            message: title,
+                          })}
+                          {body.required === true && (
+                            <span className="openapi-schema__required">
+                              {translate({
+                                id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                message: "required",
+                              })}
+                            </span>
+                          )}
+                        </h3>
+                      </summary>
+                    </>
+                  }
+                >
+                  <div style={{ textAlign: "left", marginLeft: "1rem" }}>
+                    {body.description && (
+                      <div style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                        <Markdown>{body.description}</Markdown>
+                      </div>
+                    )}
+                  </div>
+                  <ul style={{ marginLeft: "1rem" }}>
+                    <SchemaNode schema={firstBody} schemaType="request" />
+                  </ul>
+                </Details>
+              </div>
             </TabItem>
           );
         })}


### PR DESCRIPTION
Code examples were showing incorrect request body parameters when switching between content types (e.g., JSON vs XML). This occurred because a single example was generated at build time and reused for all content types.

Changes:
- Dynamically generate request examples based on the current content type's schema
- Update body in Redux state when content type changes
- Add lazy loading to MimeTabs in RequestSchema to prevent rendering all schemas
- Force LiveApp components to remount when content type changes using key prop
- Add test case with different schemas for JSON and XML content types

Fixes #1283