### PR TITLE
fix: render inline enum values in anyOf schemas (#1285)

### DIFF
--- a/demo/examples/tests/anyOf.yaml
+++ b/demo/examples/tests/anyOf.yaml
@@ -20,7 +20,15 @@ paths:
           - type: integer
           - type: boolean
           - type: null
+          - enum:
+              - dealValue
+              - price
+              - userRating
+              - popularityScore
         ```
+
+        Note: The last option is an inline enum without an explicit type,
+        which is valid JSON Schema. The enum values should be displayed.
       responses:
         "200":
           description: Successful response
@@ -32,6 +40,11 @@ paths:
                   - type: integer
                   - type: boolean
                   - type: "null"
+                  - enum:
+                      - dealValue
+                      - price
+                      - userRating
+                      - popularityScore
 
   /anyof-oneof:
     get:

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
@@ -8,6 +8,12 @@
 import { SchemaObject } from "../openapi/types";
 
 function prettyName(schema: SchemaObject, circular?: boolean) {
+  // Handle enum-only schemas (valid in JSON Schema)
+  // When enum is present without explicit type, treat as string
+  if (schema.enum && !schema.type) {
+    return "string";
+  }
+
   if (schema.format) {
     if (schema.type) {
       return `${schema.type}<${schema.format}>`;

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
@@ -11,6 +11,12 @@ import { OPENAPI_SCHEMA_ITEM } from "../theme/translationIds";
 import { SchemaObject } from "../types";
 
 function prettyName(schema: SchemaObject, circular?: boolean) {
+  // Handle enum-only schemas (valid in JSON Schema)
+  // When enum is present without explicit type, treat as string
+  if (schema.enum && !schema.type) {
+    return "string";
+  }
+
   if (schema.format) {
     return schema.format;
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -999,5 +999,10 @@ const PRIMITIVE_TYPES: Record<PrimitiveSchemaType, true> = {
 } as const;
 
 const isPrimitive = (schema: SchemaObject) => {
+  // Enum-only schemas (without explicit type) should be treated as primitives
+  // This is valid JSON Schema where enum values define the constraints
+  if (schema.enum && !schema.type) {
+    return true;
+  }
   return PRIMITIVE_TYPES[schema.type as PrimitiveSchemaType];
 };


### PR DESCRIPTION
Handle enum-only schemas (without explicit type) in anyOf/oneOf by treating them as primitives. This ensures the enum values are displayed correctly in the schema documentation. Fixes #1285 