### PR TITLE
feat(theme): add sticky positioning to API Explorer right panel

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -166,6 +166,16 @@
   border-right: thin solid var(--ifm-toc-border-color);
 }
 
+@media (min-width: 997px) {
+  .openapi-right-panel__container {
+    position: sticky;
+    top: calc(var(--ifm-navbar-height) + 1rem);
+    max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
+    overflow-y: auto;
+    align-self: flex-start;
+  }
+}
+
 @media (max-width: 997px) {
   .schema {
     margin-bottom: 1rem;


### PR DESCRIPTION
Keep the right panel visible when scrolling long API documentation pages. The panel sticks below the navbar and allows internal scrolling when content exceeds viewport height.

