### PR TITLE
refactor(theme): migrate OpenAPI types from plugin to theme

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/slice.ts
@@ -7,14 +7,13 @@
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createStorage, hashArray } from "@theme/ApiExplorer/storage-utils";
-import {
-  SecurityRequirementObject,
-  SecuritySchemeObject,
-} from "docusaurus-plugin-openapi-docs/src/openapi/types";
-/* eslint-disable import/no-extraneous-dependencies*/
-import { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
 import { getAuthDataKeys } from "./auth-types";
+import type {
+  SecurityRequirementObject,
+  SecuritySchemeObject,
+  ThemeConfig,
+} from "../../../types";
 
 // The global definitions
 // "securitySchemes": {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
@@ -6,8 +6,10 @@
  * ========================================================================== */
 
 import React, { useState } from "react";
+
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
+
 import { FileContent, setFileArrayFormBody } from "../slice";
 
 interface FileArrayFormItemProps {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
@@ -6,14 +6,16 @@
  * ========================================================================== */
 
 import React from "react";
+
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import LiveApp from "@theme/ApiExplorer/LiveEditor";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { clearFormBodyKey, setFileFormBody, setStringFormBody } from "../slice";
+
+import type { SchemaObject } from "../../../../types";
 import FileArrayFormBodyItem from "../FileArrayFormBodyItem";
+import { clearFormBodyKey, setFileFormBody, setStringFormBody } from "../slice";
 
 interface FormBodyItemProps {
   schemaObject: SchemaObject;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -8,7 +8,6 @@
 import React, { useEffect, useMemo } from "react";
 
 import { translate } from "@docusaurus/Translate";
-
 import json2xml from "@theme/ApiExplorer/Body/json2xml";
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormItem from "@theme/ApiExplorer/FormItem";
@@ -18,13 +17,13 @@ import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_BODY, OPENAPI_REQUEST } from "@theme/translationIds";
-import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { sampleFromSchema } from "docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample";
+import { sampleFromSchema } from "docusaurus-plugin-openapi-docs/lib/openapi/createSchemaExample";
 import format from "xml-formatter";
 
-import { clearRawBody, setFileRawBody, setStringRawBody } from "./slice";
 import FormBodyItem from "./FormBodyItem";
 import { resolveSchemaWithSelections } from "./resolveSchemaWithSelections";
+import { clearRawBody, setFileRawBody, setStringRawBody } from "./slice";
+import type { RequestBodyObject } from "../../../types";
 
 export interface Props {
   jsonRequestBodyExample: string;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/resolveSchemaWithSelections.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/resolveSchemaWithSelections.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import merge from "lodash/merge";
+
+import type { SchemaObject } from "../../../types";
 
 export interface SchemaSelections {
   [schemaPath: string]: number;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
@@ -9,7 +9,6 @@ import React from "react";
 
 import { translate } from "@docusaurus/Translate";
 import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-
 import clsx from "clsx";
 
 export interface Props {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/slice.ts
@@ -6,7 +6,8 @@
  * ========================================================================== */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+
+import type { ParameterObject } from "../../../types";
 
 export type Param = ParameterObject & { value?: string[] | string };
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -27,13 +27,12 @@ import {
 import Server from "@theme/ApiExplorer/Server";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import { OPENAPI_REQUEST } from "@theme/translationIds";
-import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
-import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import * as sdk from "postman-collection";
 import { FormProvider, useForm } from "react-hook-form";
 
 import makeRequest, { RequestError, RequestErrorType } from "./makeRequest";
+import type { ParameterObject, ThemeConfig } from "../../../types";
 
 function Request({ item }: { item: ApiItem }) {
   const postman = new sdk.Request(item.postman);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -17,10 +17,10 @@ import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_RESPONSE } from "@theme/translationIds";
 import clsx from "clsx";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
-import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 import { clearResponse, clearCode, clearHeaders } from "./slice";
+import type { ThemeConfig } from "../../../types";
 
 // TODO: We probably shouldn't attempt to format XML...
 function formatXml(xml: string) {
@@ -47,8 +47,7 @@ function Response({ item }: { item: ApiItem }) {
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const hideSendButton = metadata.frontMatter.hide_send_button;
-  const proxy =
-    metadata.frontMatter.proxy ?? themeConfig.api?.proxy;
+  const proxy = metadata.frontMatter.proxy ?? themeConfig.api?.proxy;
   const prismTheme = usePrismTheme();
   const code = useTypedSelector((state: any) => state.response.code);
   const headers = useTypedSelector((state: any) => state.response.headers);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
@@ -7,11 +7,10 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
-
 import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
 
 function SecuritySchemes(props: any) {
   const options = useTypedSelector((state: any) => state.auth.options);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/slice.ts
@@ -6,7 +6,8 @@
  * ========================================================================== */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { ServerObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+
+import type { ServerObject } from "../../../types";
 // TODO: we might want to export this
 
 export interface State {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
@@ -7,12 +7,10 @@
 
 import { AuthState, Scheme } from "@theme/ApiExplorer/Authorization/slice";
 import { Body, Content } from "@theme/ApiExplorer/Body/slice";
-import {
-  ParameterObject,
-  ServerObject,
-} from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import cloneDeep from "lodash/cloneDeep";
 import * as sdk from "postman-collection";
+
+import type { ParameterObject, ServerObject } from "../../types";
 
 type Param = {
   value?: string | string[];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
@@ -12,7 +12,7 @@ import CodeSnippets from "@theme/ApiExplorer/CodeSnippets";
 import Request from "@theme/ApiExplorer/Request";
 import Response from "@theme/ApiExplorer/Response";
 import SecuritySchemes from "@theme/ApiExplorer/SecuritySchemes";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import * as sdk from "postman-collection";
 
 function ApiExplorer({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/persistenceMiddleware.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/persistenceMiddleware.ts
@@ -11,10 +11,9 @@ import {
   setSelectedAuth,
 } from "@theme/ApiExplorer/Authorization/slice";
 import type { AppDispatch, RootState } from "@theme/ApiItem/store";
-import type { ServerObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
 import { createStorage, hashArray } from "./storage-utils";
+import type { ServerObject, ThemeConfig } from "../../types";
 
 export function createPersistenceMiddleware(options: ThemeConfig["api"]) {
   const persistenceMiddleware: Middleware<{}, RootState, AppDispatch> =

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -22,19 +22,17 @@ import type { Props } from "@theme/DocItem";
 import DocItemMetadata from "@theme/DocItem/Metadata";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import clsx from "clsx";
-import {
-  ParameterObject,
-  ServerObject,
-} from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import type { ApiItem as ApiItemType } from "docusaurus-plugin-openapi-docs/src/types";
-import type {
-  DocFrontMatter,
-  ThemeConfig,
-} from "docusaurus-theme-openapi-docs/src/types";
 import { ungzip } from "pako";
 import { Provider } from "react-redux";
 
 import { createStoreWithoutState, createStoreWithState } from "./store";
+import type {
+  DocFrontMatter,
+  ParameterObject,
+  ServerObject,
+  ThemeConfig,
+} from "../../types";
 
 let ApiExplorer = (_: { item: any; infoPath: any }) => <div />;
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
@@ -7,13 +7,12 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
-
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import ParamsItem from "@theme/ParamsItem";
 import SkeletonLoader from "@theme/SkeletonLoader";
+import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
 
 interface Props {
   parameters: any[];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -7,17 +7,17 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
 import MimeTabs from "@theme/MimeTabs"; // Assume these components exist
 import SchemaNode from "@theme/Schema";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
-import { MediaTypeObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+import { OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
+
+import type { MediaTypeObject } from "../../types";
 
 interface Props {
   style?: React.CSSProperties;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -22,7 +22,8 @@ import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_SCHEMA, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-import { MediaTypeObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+
+import type { MediaTypeObject } from "../../types";
 
 interface Props {
   style?: React.CSSProperties;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -25,11 +25,9 @@ import {
   getQualifierMessage,
   getSchemaName,
 } from "docusaurus-plugin-openapi-docs/lib/markdown/schema";
-import {
-  SchemaObject,
-  SchemaType,
-} from "docusaurus-plugin-openapi-docs/lib/openapi/types";
 import isEmpty from "lodash/isEmpty";
+
+import type { SchemaObject, SchemaType } from "../../types";
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 // const jsonSchemaMergeAllOf = require("json-schema-merge-allof");

--- a/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
@@ -15,7 +15,7 @@ import ResponseHeaders from "@theme/ResponseHeaders";
 import ResponseSchema from "@theme/ResponseSchema";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_STATUS_CODES } from "@theme/translationIds";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 interface Props {
   id?: string;

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -6,7 +6,14 @@
  * ========================================================================== */
 
 import type { DocFrontMatter as DocusaurusDocFrontMatter } from "@docusaurus/plugin-content-docs";
-import type { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+import type {
+  JSONSchema4,
+  JSONSchema6,
+  JSONSchema7,
+  JSONSchema7TypeName,
+} from "json-schema";
+
+export type SchemaType = JSONSchema7TypeName;
 
 export interface ThemeConfig {
   api?: {
@@ -78,3 +85,116 @@ export interface DocFrontMatter extends DocusaurusDocFrontMatter {
   /** Provides OpenAPI Docs with a reference path to their respective Info Doc */
   info_path?: string;
 }
+
+// OpenAPI Server types
+export interface ServerObject {
+  url: string;
+  description?: string;
+  variables?: Record<string, ServerVariable>;
+}
+
+export interface ServerVariable {
+  enum?: string[];
+  default: string;
+  description?: string;
+}
+
+// OpenAPI Parameter types
+export interface ParameterObject {
+  name: string;
+  in: "query" | "header" | "path" | "cookie";
+  description?: string;
+  required?: boolean;
+  deprecated?: boolean;
+  allowEmptyValue?: boolean;
+  style?: string;
+  explode?: string;
+  allowReserved?: boolean;
+  schema?: SchemaObject;
+  example?: any;
+  examples?: Record<string, ExampleObject>;
+  content?: Record<string, MediaTypeObject>;
+  param?: object;
+  "x-enumDescriptions"?: Record<string, string>;
+}
+
+// OpenAPI Request Body types
+export interface RequestBodyObject {
+  description?: string;
+  content: Record<string, MediaTypeObject>;
+  required?: boolean;
+}
+
+export interface MediaTypeObject {
+  schema?: SchemaObject;
+  example?: any;
+  examples?: Record<string, ExampleObject>;
+  encoding?: Record<string, EncodingObject>;
+  type?: any;
+}
+
+export interface ExampleObject {
+  summary?: string;
+  description?: string;
+  value?: any;
+  externalValue?: string;
+}
+
+export interface EncodingObject {
+  contentType?: string;
+  headers?: Record<string, any>;
+  style?: string;
+  explode?: boolean;
+  allowReserved?: boolean;
+}
+
+// OpenAPI Security types
+export type SecuritySchemeObject =
+  | ApiKeySecuritySchemeObject
+  | HttpSecuritySchemeObject
+  | Oauth2SecuritySchemeObject
+  | OpenIdConnectSecuritySchemeObject;
+
+export interface ApiKeySecuritySchemeObject {
+  type: "apiKey";
+  description?: string;
+  name: string;
+  in: "query" | "header" | "cookie";
+}
+
+export interface HttpSecuritySchemeObject {
+  type: "http";
+  description?: string;
+  scheme: string;
+  bearerFormat?: string;
+  name?: string;
+  in?: string;
+}
+
+export interface Oauth2SecuritySchemeObject {
+  type: "oauth2";
+  description?: string;
+  flows: OAuthFlowsObject;
+}
+
+export interface OpenIdConnectSecuritySchemeObject {
+  type: "openIdConnect";
+  description?: string;
+  openIdConnectUrl: string;
+}
+
+export interface OAuthFlowsObject {
+  implicit?: OAuthFlowObject;
+  password?: OAuthFlowObject;
+  clientCredentials?: OAuthFlowObject;
+  authorizationCode?: OAuthFlowObject;
+}
+
+export interface OAuthFlowObject {
+  authorizationUrl?: string;
+  tokenUrl?: string;
+  refreshUrl?: string;
+  scopes: Record<string, string>;
+}
+
+export type SecurityRequirementObject = Record<string, string[]>;


### PR DESCRIPTION
Move OpenAPI type definitions (ServerObject, ParameterObject, RequestBodyObject, MediaTypeObject, SecuritySchemeObject, etc.) from the plugin to the theme's types.d.ts file. This reduces coupling between packages and addresses tech debt from when the plugin generated inline markdown.

Changes:
- Add OpenAPI types to theme's src/types.d.ts
- Update theme imports to use local types instead of plugin imports
- Keep ApiItem as import type from plugin (contract between packages)
- Keep runtime function imports (sampleFromSchema, etc.) from plugin lib/