### PR TITLE
fix(theme): use import type for plugin type imports

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/slice.ts
@@ -7,7 +7,7 @@
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { createStorage, hashArray } from "@theme/ApiExplorer/storage-utils";
-import {
+import type {
   SecurityRequirementObject,
   SecuritySchemeObject,
 } from "docusaurus-plugin-openapi-docs/src/openapi/types";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FileArrayFormBodyItem/index.tsx
@@ -6,8 +6,10 @@
  * ========================================================================== */
 
 import React, { useState } from "react";
+
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
+
 import { FileContent, setFileArrayFormBody } from "../slice";
 
 interface FileArrayFormItemProps {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/FormBodyItem/index.tsx
@@ -6,14 +6,16 @@
  * ========================================================================== */
 
 import React from "react";
+
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import LiveApp from "@theme/ApiExplorer/LiveEditor";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { clearFormBodyKey, setFileFormBody, setStringFormBody } from "../slice";
+import type { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+
 import FileArrayFormBodyItem from "../FileArrayFormBodyItem";
+import { clearFormBodyKey, setFileFormBody, setStringFormBody } from "../slice";
 
 interface FormBodyItemProps {
   schemaObject: SchemaObject;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -8,7 +8,6 @@
 import React, { useEffect, useMemo } from "react";
 
 import { translate } from "@docusaurus/Translate";
-
 import json2xml from "@theme/ApiExplorer/Body/json2xml";
 import FormFileUpload from "@theme/ApiExplorer/FormFileUpload";
 import FormItem from "@theme/ApiExplorer/FormItem";
@@ -18,13 +17,13 @@ import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_BODY, OPENAPI_REQUEST } from "@theme/translationIds";
-import { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { sampleFromSchema } from "docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample";
+import { sampleFromSchema } from "docusaurus-plugin-openapi-docs/lib/openapi/createSchemaExample";
+import type { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
 
-import { clearRawBody, setFileRawBody, setStringRawBody } from "./slice";
 import FormBodyItem from "./FormBodyItem";
 import { resolveSchemaWithSelections } from "./resolveSchemaWithSelections";
+import { clearRawBody, setFileRawBody, setStringRawBody } from "./slice";
 
 export interface Props {
   jsonRequestBodyExample: string;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/resolveSchemaWithSelections.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/resolveSchemaWithSelections.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import type { SchemaObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import merge from "lodash/merge";
 
 export interface SchemaSelections {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormItem/index.tsx
@@ -9,7 +9,6 @@ import React from "react";
 
 import { translate } from "@docusaurus/Translate";
 import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-
 import clsx from "clsx";
 
 export interface Props {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/slice.ts
@@ -6,7 +6,7 @@
  * ========================================================================== */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import type { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 export type Param = ParameterObject & { value?: string[] | string };
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -27,8 +27,8 @@ import {
 import Server from "@theme/ApiExplorer/Server";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import { OPENAPI_REQUEST } from "@theme/translationIds";
-import { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 import * as sdk from "postman-collection";
 import { FormProvider, useForm } from "react-hook-form";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -17,7 +17,7 @@ import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_RESPONSE } from "@theme/translationIds";
 import clsx from "clsx";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
 import { clearResponse, clearCode, clearHeaders } from "./slice";
@@ -47,8 +47,7 @@ function Response({ item }: { item: ApiItem }) {
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const hideSendButton = metadata.frontMatter.hide_send_button;
-  const proxy =
-    metadata.frontMatter.proxy ?? themeConfig.api?.proxy;
+  const proxy = metadata.frontMatter.proxy ?? themeConfig.api?.proxy;
   const prismTheme = usePrismTheme();
   const code = useTypedSelector((state: any) => state.response.code);
   const headers = useTypedSelector((state: any) => state.response.headers);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
@@ -7,11 +7,10 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
-
 import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
+import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
 
 function SecuritySchemes(props: any) {
   const options = useTypedSelector((state: any) => state.auth.options);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/slice.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/slice.ts
@@ -6,7 +6,7 @@
  * ========================================================================== */
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { ServerObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
+import type { ServerObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 // TODO: we might want to export this
 
 export interface State {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/buildPostmanRequest.ts
@@ -7,7 +7,7 @@
 
 import { AuthState, Scheme } from "@theme/ApiExplorer/Authorization/slice";
 import { Body, Content } from "@theme/ApiExplorer/Body/slice";
-import {
+import type {
   ParameterObject,
   ServerObject,
 } from "docusaurus-plugin-openapi-docs/src/openapi/types";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/index.tsx
@@ -12,7 +12,7 @@ import CodeSnippets from "@theme/ApiExplorer/CodeSnippets";
 import Request from "@theme/ApiExplorer/Request";
 import Response from "@theme/ApiExplorer/Response";
 import SecuritySchemes from "@theme/ApiExplorer/SecuritySchemes";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import * as sdk from "postman-collection";
 
 function ApiExplorer({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -22,7 +22,7 @@ import type { Props } from "@theme/DocItem";
 import DocItemMetadata from "@theme/DocItem/Metadata";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import clsx from "clsx";
-import {
+import type {
   ParameterObject,
   ServerObject,
 } from "docusaurus-plugin-openapi-docs/src/openapi/types";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
@@ -7,13 +7,12 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
-
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import ParamsItem from "@theme/ParamsItem";
 import SkeletonLoader from "@theme/SkeletonLoader";
+import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
 
 interface Props {
   parameters: any[];

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -7,17 +7,16 @@
 
 import React from "react";
 
-import { translate } from "@docusaurus/Translate";
-import { OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import Markdown from "@theme/Markdown";
 import MimeTabs from "@theme/MimeTabs"; // Assume these components exist
 import SchemaNode from "@theme/Schema";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
-import { MediaTypeObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+import { OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
+import type { MediaTypeObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 interface Props {
   style?: React.CSSProperties;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -22,7 +22,7 @@ import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_SCHEMA, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
-import { MediaTypeObject } from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+import type { MediaTypeObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 interface Props {
   style?: React.CSSProperties;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -25,10 +25,10 @@ import {
   getQualifierMessage,
   getSchemaName,
 } from "docusaurus-plugin-openapi-docs/lib/markdown/schema";
-import {
+import type {
   SchemaObject,
   SchemaType,
-} from "docusaurus-plugin-openapi-docs/lib/openapi/types";
+} from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import isEmpty from "lodash/isEmpty";
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
@@ -15,7 +15,7 @@ import ResponseHeaders from "@theme/ResponseHeaders";
 import ResponseSchema from "@theme/ResponseSchema";
 import TabItem from "@theme/TabItem";
 import { OPENAPI_STATUS_CODES } from "@theme/translationIds";
-import { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
+import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 interface Props {
   id?: string;

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -6,7 +6,14 @@
  * ========================================================================== */
 
 import type { DocFrontMatter as DocusaurusDocFrontMatter } from "@docusaurus/plugin-content-docs";
-import type { JSONSchema4, JSONSchema6, JSONSchema7 } from "json-schema";
+
+// Re-export types from plugin for consistency
+export type {
+  DiscriminatorObject,
+  ExternalDocumentationObject,
+  SchemaObject,
+  XMLObject,
+} from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 export interface ThemeConfig {
   api?: {
@@ -21,57 +28,6 @@ export interface ThemeConfig {
     /** Request timeout in milliseconds. Defaults to 30000 (30 seconds). */
     requestTimeout?: number;
   };
-}
-
-export type JSONSchema = JSONSchema4 | JSONSchema6 | JSONSchema7;
-export type SchemaObject = Omit<
-  JSONSchema,
-  | "type"
-  | "allOf"
-  | "oneOf"
-  | "anyOf"
-  | "not"
-  | "items"
-  | "properties"
-  | "additionalProperties"
-> & {
-  // OpenAPI specific overrides
-  type?: "string" | "number" | "integer" | "boolean" | "object" | "array";
-  allOf?: SchemaObject[];
-  oneOf?: SchemaObject[];
-  anyOf?: SchemaObject[];
-  not?: SchemaObject;
-  items?: SchemaObject;
-  properties?: Record<string, SchemaObject>;
-  additionalProperties?: boolean | SchemaObject;
-
-  // OpenAPI additions
-  nullable?: boolean;
-  discriminator?: DiscriminatorObject;
-  readOnly?: boolean;
-  writeOnly?: boolean;
-  xml?: XMLObject;
-  externalDocs?: ExternalDocumentationObject;
-  example?: any;
-  deprecated?: boolean;
-};
-
-export interface DiscriminatorObject {
-  propertyName: string;
-  mapping?: Record<string, string>;
-}
-
-export interface XMLObject {
-  name?: string;
-  namespace?: string;
-  prefix?: string;
-  attribute?: boolean;
-  wrapped?: boolean;
-}
-
-export interface ExternalDocumentationObject {
-  description?: string;
-  url: string;
 }
 
 export interface DocFrontMatter extends DocusaurusDocFrontMatter {


### PR DESCRIPTION
Fix webpack build error caused by importing TypeScript source files from the plugin's src/ directory without proper transpilation.

Changes:
- Add `import type` to all type imports from plugin src/ directories
- Move runtime import (sampleFromSchema) to use plugin's lib/ directory
- Re-export SchemaObject from plugin in theme's types.d.ts for consistency

Type-only imports are erased during TypeScript compilation, so they don't require webpack to process the source TypeScript files.
