### PR TITLE
feat(theme): add requestCredentials option for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,12 @@ petstore: {
 
 The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
 
-| Name              | Type     | Default | Description                                                                                                                        |
-| ----------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `proxy`           | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
-| `authPersistance` | `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
-| `requestTimeout`  | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+| Name                 | Type     | Default         | Description                                                                                                                        |
+| -------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`              | `string` | `null`          | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
+| `authPersistance`    | `string` | `null`          | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
+| `requestTimeout`     | `number` | `30000`         | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+| `requestCredentials` | `string` | `"same-origin"` | _Optional:_ Controls cookie behavior for API requests. Options: `"omit"`, `"same-origin"`, or `"include"`.                         |
 
 Example:
 
@@ -267,6 +268,7 @@ Example:
       proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
       authPersistance: "localStorage",
       requestTimeout: 60000, // 60 seconds
+      requestCredentials: "omit", // Prevent cookies from being sent with requests
     },
   },
 }

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -315,11 +315,12 @@ petstore: {
 
 The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
 
-| Name             | Type     | Default | Description                                                                                                                                         |
-| ---------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `proxy`          | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config.                  |
-| `authPersistance`| `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.                    |
-| `requestTimeout` | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                                         |
+| Name                 | Type     | Default         | Description                                                                                                                        |
+| -------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`              | `string` | `null`          | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
+| `authPersistance`    | `string` | `null`          | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
+| `requestTimeout`     | `number` | `30000`         | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+| `requestCredentials` | `string` | `"same-origin"` | _Optional:_ Controls cookie behavior for API requests. Options: `"omit"`, `"same-origin"`, or `"include"`.                         |
 
 Example:
 
@@ -331,6 +332,7 @@ Example:
       proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
       authPersistance: "localStorage",
       requestTimeout: 60000, // 60 seconds
+      requestCredentials: "omit", // Prevent cookies from being sent with requests
     },
   },
 }

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -253,11 +253,12 @@ petstore: {
 
 The `docusaurus-theme-openapi-docs` theme can be configured with the following options in `themeConfig.api`:
 
-| Name              | Type     | Default | Description                                                                                                                        |
-| ----------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `proxy`           | `string` | `null`  | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
-| `authPersistance` | `string` | `null`  | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
-| `requestTimeout`  | `number` | `30000` | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+| Name                 | Type     | Default         | Description                                                                                                                        |
+| -------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `proxy`              | `string` | `null`          | _Optional:_ Site-wide proxy URL to prepend to base URL when performing API requests. Can be overridden per-spec via plugin config. |
+| `authPersistance`    | `string` | `null`          | _Optional:_ Determines how auth credentials are persisted. Options: `"localStorage"`, `"sessionStorage"`, or `false` to disable.   |
+| `requestTimeout`     | `number` | `30000`         | _Optional:_ Request timeout in milliseconds for API requests made from the browser. Defaults to 30 seconds.                        |
+| `requestCredentials` | `string` | `"same-origin"` | _Optional:_ Controls cookie behavior for API requests. Options: `"omit"`, `"same-origin"`, or `"include"`.                         |
 
 Example:
 
@@ -269,6 +270,7 @@ Example:
       proxy: "https://cors.pan.dev",  // Site-wide proxy (can be overridden per-spec in plugin config)
       authPersistance: "localStorage",
       requestTimeout: 60000, // 60 seconds
+      requestCredentials: "omit", // Prevent cookies from being sent with requests
     },
   },
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -43,6 +43,7 @@ function Request({ item }: { item: ApiItem }) {
   const { siteConfig } = useDocusaurusContext();
   const themeConfig = siteConfig.themeConfig as ThemeConfig;
   const requestTimeout = themeConfig.api?.requestTimeout;
+  const requestCredentials = themeConfig.api?.requestCredentials;
   // Frontmatter proxy (per-spec) takes precedence over theme config proxy (site-wide)
   const proxy = frontMatterProxy ?? themeConfig.api?.proxy;
 
@@ -171,7 +172,8 @@ function Request({ item }: { item: ApiItem }) {
         postmanRequest,
         proxy,
         body,
-        requestTimeout
+        requestTimeout,
+        requestCredentials
       );
       if (res.headers.get("content-type")?.includes("text/event-stream")) {
         await handleEventStream(res);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/makeRequest.ts
@@ -114,7 +114,8 @@ async function makeRequest(
   request: sdk.Request,
   proxy: string | undefined,
   _body: Body,
-  timeout: number = DEFAULT_REQUEST_TIMEOUT
+  timeout: number = DEFAULT_REQUEST_TIMEOUT,
+  credentials?: RequestCredentials
 ) {
   const headers = request.toJSON().header;
 
@@ -252,6 +253,7 @@ async function makeRequest(
     method: request.method,
     headers: myHeaders,
     body: myBody,
+    ...(credentials && { credentials }),
   };
 
   let finalUrl = request.url.toString();

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -27,6 +27,13 @@ export interface ThemeConfig {
     authPersistence?: false | "sessionStorage" | "localStorage";
     /** Request timeout in milliseconds. Defaults to 30000 (30 seconds). */
     requestTimeout?: number;
+    /**
+     * Controls whether cookies and credentials are sent with API requests.
+     * - `"omit"`: Never send cookies (useful when docs are on same domain as app)
+     * - `"same-origin"`: Send cookies for same-origin requests (default browser behavior)
+     * - `"include"`: Always send cookies, even for cross-origin requests
+     */
+    requestCredentials?: "omit" | "same-origin" | "include";
   };
 }
 


### PR DESCRIPTION
Add a new `requestCredentials` configuration option to control cookie and credential behavior in ApiExplorer requests. This is useful when API documentation is hosted on the same domain as the application, where browsers automatically include session cookies.

Options:
- "omit": Never send cookies
- "same-origin": Send cookies for same-origin requests (browser default)
- "include": Always send cookies, even for cross-origin

Usage in docusaurus.config.js:
```js
themeConfig: {
  api: {
    requestCredentials: "omit",
  },
},
```

Fixes #1296