### PR TITLE
fix(theme): handle nested discriminators in allOf structures

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -510,6 +510,39 @@ paths:
                   name:
                     type: string
 
+  /allof-empty-object-properties:
+    get:
+      tags:
+        - allOf
+      summary: allOf with explicit empty object properties
+      description: |
+        Demonstrates an intentional empty object schema (properties: {}) to ensure
+        the renderer still shows the object shape rather than hiding it.
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          metadata:
+            type: object
+            properties: {}
+          name:
+            type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  metadata:
+                    type: object
+                    properties: {}
+                  name:
+                    type: string
+
   /allof-multiple-oneof:
     post:
       tags:

--- a/demo/examples/tests/discriminator.yaml
+++ b/demo/examples/tests/discriminator.yaml
@@ -417,6 +417,32 @@ paths:
               schema:
                 $ref: "#/components/schemas/DoublyNestedBase"
 
+  /discriminator-deeply-nested-allof:
+    post:
+      tags:
+        - discriminator
+      summary: Deeply Nested Discriminator in allOf chains
+      description: |
+        Tests discriminator discovery through nested allOf chains:
+        - top-level allOf
+        - inner allOf
+        - oneOf with discriminator
+
+        This validates recursive discriminator lookup beyond first-level allOf items.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeepNestedDiscriminatorBase"
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeepNestedDiscriminatorBase"
+
 components:
   schemas:
     BaseBasic:
@@ -663,6 +689,57 @@ components:
             mapping:
               variant-a: "#/components/schemas/NestedVariantA"
               variant-b: "#/components/schemas/NestedVariantB"
+
+    DeepNestedDiscriminatorBase:
+      allOf:
+        - $ref: "#/components/schemas/CommonProps"
+        - allOf:
+            - $ref: "#/components/schemas/DeepLayerCommon"
+            - oneOf:
+                - $ref: "#/components/schemas/DeepNestedVariantA"
+                - $ref: "#/components/schemas/DeepNestedVariantB"
+              discriminator:
+                propertyName: deepVariantType
+                mapping:
+                  deep-a: "#/components/schemas/DeepNestedVariantA"
+                  deep-b: "#/components/schemas/DeepNestedVariantB"
+
+    DeepLayerCommon:
+      type: object
+      properties:
+        layer:
+          type: string
+          enum: ["inner"]
+      required:
+        - layer
+
+    DeepNestedVariantA:
+      type: object
+      properties:
+        deepVariantType:
+          type: string
+          enum: ["deep-a"]
+        deepAConfig:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+      required:
+        - deepVariantType
+
+    DeepNestedVariantB:
+      type: object
+      properties:
+        deepVariantType:
+          type: string
+          enum: ["deep-b"]
+        deepBConfig:
+          type: object
+          properties:
+            threshold:
+              type: number
+      required:
+        - deepVariantType
 
     NestedVariantA:
       type: object


### PR DESCRIPTION
Add support for discriminators nested within allOf schemas. Previously, discriminators inside allOf items were not properly detected, and the discriminator property lookup only checked top-level schema properties.

Changes:
- Add findProperty() helper to recursively search for properties in nested oneOf/anyOf/allOf structures
- Update DiscriminatorNode to use findProperty() for discriminator property lookup
- Update SchemaNode to check for discriminators in allOf items and merge schemas before processing
- Return null instead of empty "object" SchemaItem when properties are empty after discriminator processing
- Add test case for nested discriminator in allOf

This fixes scenarios like:
```yaml
allOf:
  - $ref: CommonProps
  - oneOf: [VariantA, VariantB]
    discriminator:
      propertyName: type
```

Fixes #1302