### PR TITLE
fix: improve path segment extraction for multi-instance docs

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -368,17 +368,25 @@ custom_edit_url: null
           let infoBasePath = `${outputDir}/${item.infoId}`;
           if (docRouteBasePath) {
             // Safely extract path segment, handling cases where docPath may not be in outputDir
-            const outputSegment =
-              docPath && outputDir.includes(docPath)
-                ? (outputDir.split(docPath)[1]?.replace(/^\/+/g, "") ?? "")
-                : outputDir
-                    .slice(outputDir.indexOf("/", 1))
-                    .replace(/^\/+/g, "");
-            infoBasePath =
-              `${docRouteBasePath}/${outputSegment}/${item.infoId}`.replace(
-                /^\/+/g,
-                ""
-              );
+            const normalize = (p: string): string =>
+              p.replace(/^\.\//, "").replace(/^\/+|\/+$/g, "");
+            const outputSegments = normalize(outputDir).split("/").filter(Boolean);
+            let outputSegment = outputSegments.slice(1).join("/"); // fallback
+            if (docPath) {
+              const docSegments = normalize(docPath).split("/").filter(Boolean);
+              for (let i = 0; i <= outputSegments.length - docSegments.length; i++) {
+                const match = docSegments.every(
+                  (seg, j) => outputSegments[i + j] === seg
+                );
+                if (match) {
+                  outputSegment = outputSegments.slice(i + docSegments.length).join("/");
+                  break;
+                }
+              }
+            }
+            infoBasePath = `${docRouteBasePath}/${outputSegment}/${item.infoId}`
+              .replace(/^\/+/g, "")
+              .replace(/\/+/g, "/");
           }
           if (item.infoId) item.infoPath = infoBasePath;
         }


### PR DESCRIPTION
Refactors the path extraction logic in both index.ts and sidebars/index.ts to use segment-by-segment matching instead of string splitting. This fixes edge cases where docPath appears multiple times in outputDir or when paths have inconsistent leading/trailing slashes.

Changes:
- Normalize paths by removing leading ./ and leading/trailing slashes
- Match docPath segments within outputDir segments sequentially
- Clean up double slashes in the resulting infoBasePath

Fixes #1305

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
