### PR TITLE
fix: handle allOf with incompatible types

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -475,6 +475,41 @@ paths:
                     priority:
                       $ref: "#/components/schemas/Priority"
 
+  /allof-incompatible-types:
+    get:
+      tags:
+        - allOf
+      summary: allOf with Incompatible Types
+      description: |
+        Schema with a property whose allOf contains incompatible primitive types
+        (string and integer).
+
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          numero:
+            allOf:
+              - type: string
+              - type: integer
+          name:
+            type: string
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  numero:
+                    allOf:
+                      - type: string
+                      - type: integer
+                  name:
+                    type: string
+
   /allof-multiple-oneof:
     post:
       tags:

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -32,7 +32,7 @@ export function mergeAllOf(allOf: SchemaObject) {
   };
 
   const mergedSchemas = merge(allOf, { onMergeError }) as SchemaObject;
-  return mergedSchemas;
+  return mergedSchemas ?? ({} as SchemaObject);
 }
 
 /**

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/createSchemaExample.test.ts
@@ -54,4 +54,36 @@ describe("sampleFromSchema", () => {
       expect(result).toBe("dog");
     });
   });
+
+  describe("allOf with incompatible types", () => {
+    it("should return undefined when allOf contains incompatible types", () => {
+      const schema: SchemaObject = {
+        allOf: [{ type: "string" }, { type: "integer" }],
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle incompatible allOf types in a property", () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          numero: {
+            allOf: [{ type: "string" }, { type: "integer" }],
+          },
+          name: {
+            type: "string",
+          },
+        },
+      };
+      const context = { type: "request" as const };
+
+      const result = sampleFromSchema(schema, context);
+
+      expect(result.name).toBe("string");
+    });
+  });
 });

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -41,7 +41,7 @@ const mergeAllOf = (allOf: any) => {
 
   const mergedSchemas = merge(allOf, { onMergeError });
 
-  return mergedSchemas;
+  return mergedSchemas ?? {};
 };
 
 interface MarkdownProps {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

When an allOf contains sub-schemas with incompatible primitive types (e.g. string + integer), the `allof-merge` library returns `undefined`. The code then tries to access `.readOnly` on that and craches. Fixed by falling back to an empty object `{}` in both the plugin and theme `mergeAllOf` wrappers. All call sites already handle empty objects fine.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Pages with these kinds of allOf schemas crash on load. This comes up when an API spec overrides a property type through allOf composition, like changing an integer field to a string enum.

Fixes #1231

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added two unit tests for `sampleFromSchema` with incompatible allOf (top-level and inside a property)
- Added a test endpoint in `demo/examples/tests/allOf.yaml`

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

N/A

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.