### PR TITLE
fix: #994 Enable custom verbs in path

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -95,4 +95,133 @@ describe("openapi", () => {
       expect(schemaItems[0].id).toBe("without-tags");
     });
   });
+
+  describe("path parameter and custom verb handling", () => {
+    it("correctly converts path parameters and preserves custom verbs during postman binding", async () => {
+      const openapiData = {
+        openapi: "3.0.0",
+        info: {
+          title: "Path Parameter API",
+          version: "1.0.0",
+        },
+        paths: {
+          "/api/resource:customVerb": {
+            post: {
+              summary: "Custom verb endpoint",
+              operationId: "customVerbOperation",
+              responses: {
+                "200": {
+                  description: "OK",
+                },
+              },
+            },
+          },
+          "/api/users/{id}": {
+            get: {
+              summary: "Get user by ID",
+              operationId: "getUserById",
+              parameters: [
+                {
+                  name: "id",
+                  in: "path",
+                  required: true,
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  description: "OK",
+                },
+              },
+            },
+          },
+          "/api/users/{userId}/posts/{postId}": {
+            get: {
+              summary: "Get user post",
+              operationId: "getUserPost",
+              parameters: [
+                {
+                  name: "userId",
+                  in: "path",
+                  required: true,
+                  schema: {
+                    type: "string",
+                  },
+                },
+                {
+                  name: "postId",
+                  in: "path",
+                  required: true,
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  description: "OK",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const options: APIOptions = {
+        specPath: "dummy",
+        outputDir: "build",
+      };
+
+      const sidebarOptions = {} as SidebarOptions;
+
+      const [items] = await processOpenapiFile(
+        openapiData as any,
+        options,
+        sidebarOptions
+      );
+
+      const apiItems = items.filter((item) => item.type === "api");
+      expect(apiItems).toHaveLength(3);
+
+      // Test 1: Custom verb path should be preserved (NOT converted to {customVerb})
+      // The path /api/resource:customVerb should remain unchanged
+      const customVerbItem = apiItems.find(
+        (item) => item.type === "api" && item.id === "custom-verb-operation"
+      );
+      expect(customVerbItem).toBeDefined();
+      expect(customVerbItem?.type).toBe("api");
+      const customVerbApiItem = customVerbItem as any;
+      expect(customVerbApiItem.api.path).toBe("/api/resource:customVerb");
+      expect(customVerbApiItem.api.method).toBe("post");
+      expect(customVerbApiItem.api.postman).toBeDefined();
+      expect(customVerbApiItem.api.postman).not.toEqual({});
+
+      // Test 2: Standard path parameter should work (/:id -> /{id} conversion)
+      // OpenAPI format {id} -> Postman format /:id -> Regex converts back to {id} -> Match succeeds
+      const standardItem = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-user-by-id"
+      );
+      expect(standardItem).toBeDefined();
+      expect(standardItem?.type).toBe("api");
+      const standardApiItem = standardItem as any;
+      expect(standardApiItem.api.path).toBe("/api/users/{id}");
+      expect(standardApiItem.api.method).toBe("get");
+      expect(standardApiItem.api.postman).toBeDefined();
+      expect(standardApiItem.api.postman).not.toEqual({});
+
+      // Test 3: Multiple path parameters should all be converted (/:userId/:postId -> /{userId}/{postId})
+      const multiParamItem = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-user-post"
+      );
+      expect(multiParamItem).toBeDefined();
+      expect(multiParamItem?.type).toBe("api");
+      const multiParamApiItem = multiParamItem as any;
+      expect(multiParamApiItem.api.path).toBe("/api/users/{userId}/posts/{postId}");
+      expect(multiParamApiItem.api.method).toBe("get");
+      expect(multiParamApiItem.api.postman).toBeDefined();
+      expect(multiParamApiItem.api.postman).not.toEqual({});
+    });
+  });
 });

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -569,7 +569,7 @@ function bindCollectionToApiItems(
     const method = item.request.method.toLowerCase();
     const path = item.request.url
       .getPath({ unresolved: true }) // unresolved returns "/:variableName" instead of "/<type>"
-      .replace(/(?<![a-z0-9-_]+):([a-z0-9-_]+)/gi, "{$1}"); // replace "/:variableName" with "/{variableName}"
+      .replace(/\/:([a-z0-9-_]+)/gi, "/{$1}"); // replace "/:variableName" with "/{variableName}" (only path parameters, not custom verbs like /path:verb)
     const apiItem = items.find((item) => {
       if (
         item.type === "info" ||


### PR DESCRIPTION
## Description

All the description and what we need is in the issue that was created a while ago.

https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/994

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We use Docusaurus to generate API on our documentation page. One of them is not working. 

You can see the issue here on our documentation page: https://www.pdf-tools.com/docs/conversion-service/api/advanced-api/start-job/

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
