### PR TITLE
Fix deprecation notice for Docusaurus 3.10.0 strict admonition syntax

### DIFF
--- a/demo/examples/tests/xDeprecatedDescription.yaml
+++ b/demo/examples/tests/xDeprecatedDescription.yaml
@@ -1,0 +1,109 @@
+openapi: 3.1.1
+info:
+  title: Deprecated Description
+  description: Demonstrates x-deprecated-description extension.
+  version: 1.0.0
+tags:
+  - name: deprecated
+    description: deprecation tests
+paths:
+  /deprecated:
+    get:
+      tags:
+        - deprecated
+      summary: deprecated fields with x-deprecated-description
+      deprecated: true
+      x-deprecated-description: |
+        This endpoint is deprecated and will be removed in version 2.0. Please use the /new-endpoint instead.
+      description: |
+        Schema:
+        ```yaml
+        type: object
+        properties:
+          id:
+            type: string
+            description: Resource identifier
+          legacyField:
+            type: string
+            deprecated: true
+            x-deprecated-description: |
+              This field is deprecated. Use 'newField' instead.
+          newField:
+            type: string
+            description: |
+              Replacement for legacyField
+          status:
+            type: string
+            enum:
+              - active
+              - inactive
+              - deprecated
+            description: |
+              Resource status
+          metadata:
+            type: object
+            deprecated: true
+            x-deprecated-description: |
+              Metadata object is deprecated and will be removed in v2.0
+            properties:
+              tags:
+                type: array
+                items:
+                  type: string
+        required:
+          - id
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Resource identifier
+                  legacyField:
+                    type: string
+                    deprecated: true
+                    x-deprecated-description: |
+                      This field is deprecated and will be removed in version 2.0. Please use 'newField' instead.
+                  newField:
+                    type: string
+                    description: |
+                      Updated field that replaces legacyField
+                  status:
+                    type: string
+                    enum:
+                      - active
+                      - inactive
+                      - deprecated
+                    description: Resource status
+                  oldMetadata:
+                    type: object
+                    deprecated: true
+                    x-deprecated-description: |
+                      Legacy metadata object. Use the new 'attributes' field for future implementations.
+                    properties:
+                      version:
+                        type: string
+                        deprecated: true
+                        x-deprecated-description: Version tracking moved to header
+                      tags:
+                        type: array
+                        items:
+                          type: string
+                  attributes:
+                    type: object
+                    description: New attributes object replacing oldMetadata
+                    properties:
+                      category:
+                        type: string
+                      labels:
+                        type: array
+                        items:
+                          type: string
+                required:
+                  - id
+                  - status

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createDeprecationNotice.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createDeprecationNotice.ts
@@ -8,7 +8,7 @@
 import { clean, guard, Props, render } from "./utils";
 
 function createAdmonition({ children }: Props) {
-  return `:::caution deprecated\n\n${render(children)}\n\n:::`;
+  return `:::caution[deprecated]\n\n${render(children)}\n\n:::`;
 }
 
 interface DeprecationNoticeProps {


### PR DESCRIPTION
## Description

Updates the format of the `createAdmonition` used within `createDeprecationNotice` to use the new syntax required in Docusaurus v3.10.0.

## Motivation and Context

Docusaurus changed the available formats when writing admonition titles

```
-:::warning Pay Attention
+:::warning[Pay Attention]

 Content

 :::
```

[Source](https://docusaurus.io/blog/releases/3.10#strict-admonitions)

## How Has This Been Tested?

Run changes locally

## Screenshots (if appropriate)

Without changes 

<img width="239" height="136" alt="image" src="https://github.com/user-attachments/assets/de501cce-2e2d-4d4e-bb23-5284625b6ead" />

With changes

<img width="461" height="111" alt="image" src="https://github.com/user-attachments/assets/093dd02f-5b52-4593-bcad-f0f4e8a7ac0d" />


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
