### PR TITLE
Prepare release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 5.0.1 (2026-04-14)
+
+Patch release with a new scaffolding CLI, performance improvements, compatibility fixes for Docusaurus 3.10.0 strict admonition syntax, and a security fix for axios CVEs.
+
+#### :rocket: New Feature
+
+- feat: add create-docusaurus-openapi-docs CLI package ([#1413](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1413))
+
+#### :bug: Bug Fix
+
+- Fix deprecation notice for Docusaurus 3.10.0 strict admonition syntax ([#1423](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1423))
+- fix: rename experimental_faster to faster, remove --ignore from canary ([#1415](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1415))
+- fix: update axios resolution to ^1.15.0 to address critical CVEs
+
+#### :running_woman: Performance
+
+- perf: use Clipboard API ([#1416](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1416))
+
+#### :robot: Dependencies
+
+- chore(deps): bump follow-redirects from 1.15.11 to 1.16.0 ([#1424](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1424))
+- chore(deps): bump unist-util-visit from 5.0.0 to 5.1.0 ([#1422](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1422))
+- chore(deps): bump commander from 12.1.0 to 14.0.3 ([#1421](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1421))
+- chore(deps): bump react-hook-form from 7.72.0 to 7.72.1 ([#1409](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1409))
+
+#### :wrench: Maintenance
+
+- chore(deps-dev): bump @typescript-eslint/eslint-plugin ([#1419](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1419))
+- chore(deps-dev): bump eslint-plugin-cypress from 2.15.2 to 3.6.0 ([#1420](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1420))
+- chore(deps-dev): bump nodemon from 2.0.22 to 3.1.14 ([#1408](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1408))
+- chore(deps-dev): bump @types/lodash from 4.17.23 to 4.17.24 ([#1406](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1406))
+- chore(deps-dev): bump lint-staged from 11.2.6 to 16.4.0 ([#1411](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1411))
+- chore(deps-dev): bump eslint-plugin-testing-library from 6.5.0 to 7.16.2 ([#1410](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1410))
+
+#### Committers: 4
+
+- dependabot[bot]
+- Florian Lefebvre
+- Ollie Monk
+- Steven Serrata
+
 ## 5.0.0 (2026-04-08)
 
 **Breaking Change:** Minimum Docusaurus version is now `3.10.0`. Users on Docusaurus 3.5–3.9 must upgrade before updating to this release.

--- a/demo/docs/intro.mdx
+++ b/demo/docs/intro.mdx
@@ -85,26 +85,16 @@ Other ReDoc specific extensions such as `x-circular-ref`, `x-code-samples` (depr
 
 
 :::tip
-If you're building a Docusaurus site from scratch, the easiest way to get started is by [installing from template](#bootstrapping-from-template-new-docusaurus-site).
+If you're building a Docusaurus site from scratch, the easiest way to get started is with the [Quick Start](#quick-start-new-docusaurus-site) CLI.
 :::
 
-## Bootstrapping from Template (new Docusaurus site)
+## Quick Start (new Docusaurus site)
 
 Run the following to bootstrap a Docusaurus v3 site (classic theme) with `docusaurus-openapi-docs`:
 
 ```bash
-npx create-docusaurus@3.10.0 my-website --package-manager yarn
+npx create-docusaurus-openapi-docs my-website
 ```
-
-> When prompted to select a template choose `Git repository`.
-
-Template Repository URL:
-
-```bash
-https://github.com/PaloAltoNetworks/docusaurus-template-openapi-docs.git
-```
-
-> When asked how the template repo should be cloned choose "copy" (unless you know better).
 
 ```bash
 cd my-website
@@ -112,6 +102,13 @@ yarn start
 ```
 
 If all goes well, you should be greeted by a brand new Docusaurus site that includes API reference docs for the ubiquitous Petstore API!
+
+### CLI Options
+
+| Option                            | Description                                           |
+| --------------------------------- | ----------------------------------------------------- |
+| `-p, --package-manager <manager>` | Use a specific package manager (yarn, npm, pnpm, bun) |
+| `-s, --skip-install`              | Skip automatic dependency installation                |
 
 ## Installation (existing Docusaurus site)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.0.0",
+  "version": "5.0.1",
   "npmClient": "yarn"
 }

--- a/packages/create-docusaurus-openapi-docs/package.json
+++ b/packages/create-docusaurus-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-docusaurus-openapi-docs",
   "description": "Create Docusaurus sites with OpenAPI docs.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/create-docusaurus-openapi-docs/templates/default/package.json
+++ b/packages/create-docusaurus-openapi-docs/templates/default/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/preset-classic": "3.10.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-openapi-docs": "PLACEHOLDER",
-    "docusaurus-theme-openapi-docs": "PLACEHOLDER",
+    "docusaurus-plugin-openapi-docs": "5.0.1",
+    "docusaurus-theme-openapi-docs": "5.0.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/docusaurus-plugin-openapi-docs/README.md
+++ b/packages/docusaurus-plugin-openapi-docs/README.md
@@ -47,23 +47,13 @@ Key Features:
 | 2.2.3 (end-of-support)  | `2.4.1 - 2.4.3` |
 | 1.7.3 (end-of-support)  | `2.0.1 - 2.2.0` |
 
-## Bootstrapping from Template (new Docusaurus site)
+## Quick Start (new Docusaurus site)
 
 Run the following to bootstrap a Docusaurus v3 site (classic theme) with `docusaurus-openapi-docs`:
 
 ```bash
-npx create-docusaurus@3.10.0 my-website --package-manager yarn
+npx create-docusaurus-openapi-docs my-website
 ```
-
-> When prompted to select a template choose `Git repository`.
-
-Template Repository URL:
-
-```bash
-https://github.com/PaloAltoNetworks/docusaurus-template-openapi-docs.git
-```
-
-> When asked how the template repo should be cloned choose "copy".
 
 ```bash
 cd my-website
@@ -71,6 +61,13 @@ yarn start
 ```
 
 If all goes well, you should be greeted by a brand new Docusaurus site that includes API reference docs for the ubiquitous Petstore API!
+
+### CLI Options
+
+| Option                            | Description                                           |
+| --------------------------------- | ----------------------------------------------------- |
+| `-p, --package-manager <manager>` | Use a specific package manager (yarn, npm, pnpm, bun) |
+| `-s, --skip-install`              | Skip automatic dependency installation                |
 
 ## Installation (existing Docusaurus site)
 

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -38,7 +38,7 @@
     "@types/postman-collection": "^3.5.11",
     "@types/react-modal": "^3.16.3",
     "concurrently": "^9.2.0",
-    "docusaurus-plugin-openapi-docs": "^5.0.0",
+    "docusaurus-plugin-openapi-docs": "^5.0.1",
     "docusaurus-plugin-sass": "^0.2.6",
     "eslint-plugin-prettier": "^5.5.1"
   },


### PR DESCRIPTION
## Summary

- **feat:** New `create-docusaurus-openapi-docs` CLI scaffolding package (#1413)
- **perf:** Switch to Clipboard API for code block copying (#1416)
- **fix:** Deprecation notice for Docusaurus 3.10.0 strict admonition syntax (#1423)
- **fix:** Rename `experimental_faster` to `faster` in build config (#1415)
- **fix:** Update axios resolution to ^1.15.0 to address critical CVEs
- Dependency bumps: follow-redirects, unist-util-visit, commander, react-hook-form, and dev tooling

## Test plan

- [ ] CI checks pass (build, lint, tests)
- [ ] Verify version fields are `5.0.1` in lerna.json and both package.json files
- [ ] Verify cross-references remain `^5.0.0` for backward compatibility
- [ ] Merge triggers automated publish via release.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)