### PR TITLE
fix: skip vendor extensions at the path level(#891)

### DIFF
--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -92,6 +92,8 @@ x-tagGroups:
       - store_model
 paths:
   /pet:
+    x-custom-string: hello
+    x-custom-bool: true
     parameters:
       - name: Accept-Language
         in: header

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -271,4 +271,41 @@ describe("openapi", () => {
       expect(templatedVerbItem.api.postman).toBeDefined();
     });
   });
+
+  describe("vendor extensions at path level", () => {
+    it("does not throw and skips x-* keys and unknown keys on path objects", async () => {
+      const openapiData = {
+        openapi: "3.0.0",
+        info: { title: "Vendor Ext API", version: "1.0.0" },
+        paths: {
+          "/items": {
+            "x-custom-string": "test",
+            "x-bool": true,
+            unknownKey: { someField: true },
+            get: {
+              summary: "List items",
+              operationId: "listItems",
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+      };
+
+      const options: APIOptions = {
+        specPath: "dummy",
+        outputDir: "build",
+      };
+      const sidebarOptions = {} as SidebarOptions;
+
+      const [items] = await processOpenapiFile(
+        openapiData as any,
+        options,
+        sidebarOptions
+      );
+
+      const apiItems = items.filter((item) => item.type === "api");
+      expect(apiItems).toHaveLength(1);
+      expect((apiItems[0] as any).api.method).toBe("get");
+    });
+  });
 });

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -280,7 +280,7 @@ describe("openapi", () => {
         paths: {
           "/items": {
             "x-custom-string": "test",
-            "x-bool": true,
+            "x-custom-bool": true,
             unknownKey: { someField: true },
             get: {
               summary: "List items",

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -143,6 +143,12 @@ function createItems(
     const { $ref, description, parameters, servers, summary, ...rest } =
       pathObject;
     for (let [method, operationObject] of Object.entries({ ...rest })) {
+      if (method.startsWith("x-")) {
+        // skip vendor extensions at the path level
+
+        continue;
+      }
+
       const title =
         operationObject.summary ??
         operationObject.operationId ??

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -139,13 +139,22 @@ function createItems(
     items.push(infoPage);
   }
 
+  const HTTP_METHODS = new Set([
+    "get",
+    "put",
+    "post",
+    "delete",
+    "options",
+    "head",
+    "patch",
+    "trace",
+  ]);
+
   for (let [path, pathObject] of Object.entries(openapiData.paths)) {
     const { $ref, description, parameters, servers, summary, ...rest } =
       pathObject;
     for (let [method, operationObject] of Object.entries({ ...rest })) {
-      if (method.startsWith("x-")) {
-        // skip vendor extensions at the path level
-
+      if (!HTTP_METHODS.has(method.toLowerCase())) {
         continue;
       }
 


### PR DESCRIPTION
## Description
The plugin fails when the OpenAPI spec file contains vendor extensions at the path level (e.g. x-* fields directly under a path object). This results in a runtime error during the build process.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
OpenAPI allows vendor extensions (x-*) at almost any level of the specification, including the path level. However, the current implementation assumes all path-level properties conform to expected schema objects and attempts to process vendor extensions as structured objects.

This leads to a crash when a primitive value (e.g. string or boolean) is encountered, as the code tries to assign properties like description to it.

This change ensures that vendor extensions at the path level are safely ignored or handled correctly, preventing the build from failing.

<!--- If it fixes an open issue, please link to the issue here. -->
Issue: [#891](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/891)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I modified the petstore.yaml example to include vendor extensions at the path level:

```yaml
paths:
    /pet:
       x-custom-string: hello
       x-custom-bool: true
       parameters:
                ....
       post:
                .....
```
### Before the fix

Running:
```shell
yarn build
```

Resulted in:

```
[ERROR] TypeError: Cannot create property 'description' on string 'hello'
```
### After the fix
Running:

```shell
yarn build
```
Produces:

```
....
Successfully created "docs/petstore_versioned/versions.json"
[INFO] [en] Creating an optimized production build...
● Client ██████████████████████████████████████████████████ (100%) emitting after emit                                                               
● Server ██████████████████████████████████████████████████ (100%) emitting after emit  
```
The build now completes successfully without errors.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
