### PR TITLE
Prepare release v5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 5.0.2 (2026-05-01)
+
+Routine maintenance release. Bumps Docusaurus to `3.10.1` in the demo and the `create-docusaurus-openapi-docs` scaffolder template (picks up the upstream webpackbar/webpack bundler fix), plus a batch of dependency updates.
+
+#### :robot: Dependencies
+
+- chore(deps): bump @docusaurus/\* from 3.10.0 to 3.10.1 ([#1442](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1442))
+- chore(deps): bump postcss from 8.5.6 to 8.5.13 ([#1441](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1441))
+- chore(deps): bump @redocly/openapi-core from 2.25.4 to 2.29.0 ([#1430](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1430), [#1433](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1433))
+- chore(deps): bump react-hook-form from 7.72.1 to 7.73.1 ([#1436](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1436))
+- chore(deps): bump the react group with 2 updates ([#1426](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1426))
+- chore(deps): bump actions/setup-node from 6.3.0 to 6.4.0 ([#1438](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1438))
+- chore(deps): bump actions/cache from 5.0.4 to 5.0.5 ([#1431](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1431))
+- chore(deps): bump github/codeql-action from 4.35.1 to 4.35.2 ([#1439](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1439))
+
+#### :wrench: Maintenance
+
+- chore(deps-dev): bump fast-xml-parser from 5.5.10 to 5.7.1 ([#1429](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1429), [#1437](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1437))
+- chore(deps-dev): bump @types/node from 25.5.0 to 25.6.0 ([#1434](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1434))
+- chore(deps-dev): bump start-server-and-test from 3.0.0 to 3.0.2 ([#1428](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1428))
+- chore(deps-dev): bump eslint-plugin-react-hooks from 4.6.2 to 7.0.1 ([#1427](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1427))
+
+#### Committers: 2
+
+- dependabot[bot]
+- Steven Serrata
+
 ## 5.0.1 (2026-04-14)
 
 Patch release with a new scaffolding CLI, performance improvements, compatibility fixes for Docusaurus 3.10.0 strict admonition syntax, and a security fix for axios CVEs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 5.0.2 (2026-05-01)
 
-Routine maintenance release. Bumps Docusaurus to `3.10.1` in the demo and the `create-docusaurus-openapi-docs` scaffolder template (picks up the upstream webpackbar/webpack bundler fix), plus a batch of dependency updates.
+Routine maintenance release. Bumps Docusaurus to `3.10.1` in the demo and the `create-docusaurus-openapi-docs` scaffolder template (picks up the upstream webpackbar/webpack bundler fix), plus a batch of dependency updates. Also fixes a build error in scaffolded sites caused by an HTML comment in the sample blog post.
+
+#### :bug: Bug Fix
+
+- fix(template): replace `<!--truncate-->` with MDX-safe `{/* truncate */}` in sample blog post so scaffolded sites build under MDX 3 / Docusaurus 3.10
 
 #### :robot: Dependencies
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.0.1",
+  "version": "5.0.2",
   "npmClient": "yarn"
 }

--- a/packages/create-docusaurus-openapi-docs/package.json
+++ b/packages/create-docusaurus-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-docusaurus-openapi-docs",
   "description": "Create Docusaurus sites with OpenAPI docs.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/create-docusaurus-openapi-docs/templates/default/blog/2019-05-29-long-blog-post.md
+++ b/packages/create-docusaurus-openapi-docs/templates/default/blog/2019-05-29-long-blog-post.md
@@ -7,9 +7,9 @@ tags: [hello, docusaurus]
 
 This is the summary of a very long blog post,
 
-Use a `<!--` `truncate` `-->` comment to limit blog post size in the list view.
+Use a `{/* truncate */}` comment to limit blog post size in the list view.
 
-<!--truncate-->
+{/_ truncate _/}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 

--- a/packages/create-docusaurus-openapi-docs/templates/default/blog/2019-05-29-long-blog-post.mdx
+++ b/packages/create-docusaurus-openapi-docs/templates/default/blog/2019-05-29-long-blog-post.mdx
@@ -9,7 +9,7 @@ This is the summary of a very long blog post,
 
 Use a `{/* truncate */}` comment to limit blog post size in the list view.
 
-{/_ truncate _/}
+{/* truncate */}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dignissim ultricies. Fusce rhoncus ipsum tempor eros aliquam consequat. Lorem ipsum dolor sit amet
 

--- a/packages/create-docusaurus-openapi-docs/templates/default/package.json
+++ b/packages/create-docusaurus-openapi-docs/templates/default/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-openapi-docs": "5.0.1",
-    "docusaurus-theme-openapi-docs": "5.0.1",
+    "docusaurus-plugin-openapi-docs": "5.0.2",
+    "docusaurus-theme-openapi-docs": "5.0.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -38,7 +38,7 @@
     "@types/postman-collection": "^3.5.11",
     "@types/react-modal": "^3.16.3",
     "concurrently": "^9.2.0",
-    "docusaurus-plugin-openapi-docs": "^5.0.1",
+    "docusaurus-plugin-openapi-docs": "^5.0.2",
     "docusaurus-plugin-sass": "^0.2.6",
     "eslint-plugin-prettier": "^5.5.1"
   },


### PR DESCRIPTION
## Summary

Routine maintenance release. Highlights:

- **Demo + scaffolder template**: Docusaurus `3.10.0 → 3.10.1` (#1442) — picks up the upstream webpackbar/webpack bundler fix. Releasing so newly scaffolded projects get the patch.
- **Dependency updates**: `@redocly/openapi-core` 2.25.4 → 2.29.0, `react-hook-form`, `postcss`, plus several GitHub Actions and dev-dep bumps.

No breaking changes. peerDependency for `docusaurus-plugin-openapi-docs` stays pinned at `^5.0.0`.

See `CHANGELOG.md` for the full list.

## Test plan
- [x] `yarn install` clean
- [x] `yarn workspace demo build` succeeds
- [ ] CI passes