### PR TITLE
feat(theme): configurable schema expansion level (#1222)

### DIFF
--- a/demo/docusaurus.config.ts
+++ b/demo/docusaurus.config.ts
@@ -271,6 +271,13 @@ const config: Config = {
       id: "announcementBar_2",
       content: "v5.0.0 is now available! Requires Docusaurus 3.10.0+",
     },
+    api: {
+      schemaExpansion: {
+        enabled: true,
+        default: 1,
+        max: 4,
+      },
+    },
   } satisfies Preset.ThemeConfig,
 
   plugins: [

--- a/demo/examples/tests/schemaExpansion.yaml
+++ b/demo/examples/tests/schemaExpansion.yaml
@@ -1,0 +1,140 @@
+openapi: 3.0.0
+info:
+  title: Schema Expansion Demo API
+  version: 1.0.0
+  description: |
+    Exercises the configurable schema expansion control. Endpoints below return
+    deeply nested envelope-wrapped payloads where the useful fields live a few
+    levels under `data`. The expansion pill control on each page should let
+    readers reveal those fields without manual clicking.
+
+    Tracks: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1222
+
+tags:
+  - name: expansion
+    description: Default schema expansion level demos
+
+paths:
+  /users/{id}:
+    get:
+      tags:
+        - expansion
+      summary: Get user (envelope-wrapped)
+      description: |
+        Wrapped in a typical `{ status, meta, data }` envelope where `data`
+        itself contains a nested `profile` object. With expansion level `1`,
+        `data` opens automatically; with level `2`, `profile` opens too.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A wrapped user payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserEnvelope"
+  /users:
+    post:
+      tags:
+        - expansion
+      summary: Create user (nested request body)
+      description: |
+        The request body is also envelope-wrapped, exercising the expansion
+        control on the request side.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserEnvelope"
+      responses:
+        "201":
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserEnvelope"
+
+components:
+  schemas:
+    Status:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+
+    Meta:
+      type: object
+      properties:
+        requestId:
+          type: string
+          format: uuid
+        timestamp:
+          type: string
+          format: date-time
+
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        country:
+          type: string
+
+    Profile:
+      type: object
+      properties:
+        displayName:
+          type: string
+        bio:
+          type: string
+        address:
+          $ref: "#/components/schemas/Address"
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+          format: email
+        profile:
+          $ref: "#/components/schemas/Profile"
+
+    UserEnvelope:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/Status"
+        meta:
+          $ref: "#/components/schemas/Meta"
+        data:
+          $ref: "#/components/schemas/User"
+
+    CreateUserInput:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+        profile:
+          $ref: "#/components/schemas/Profile"
+
+    CreateUserEnvelope:
+      type: object
+      properties:
+        meta:
+          $ref: "#/components/schemas/Meta"
+        data:
+          $ref: "#/components/schemas/CreateUserInput"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -20,6 +20,7 @@ import DocItemLayout from "@theme/ApiItem/Layout";
 import CodeBlock from "@theme/CodeBlock";
 import type { Props } from "@theme/DocItem";
 import DocItemMetadata from "@theme/DocItem/Metadata";
+import { SchemaExpansionProvider } from "@theme/SchemaExpansion";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import clsx from "clsx";
 import type {
@@ -177,18 +178,20 @@ export default function ApiItem(props: Props): JSX.Element {
           <DocItemMetadata />
           <DocItemLayout>
             <Provider store={store2}>
-              <div className={clsx("row", "theme-api-markdown")}>
-                <div className="col col--7 openapi-left-panel__container">
-                  <MDXComponent />
+              <SchemaExpansionProvider>
+                <div className={clsx("row", "theme-api-markdown")}>
+                  <div className="col col--7 openapi-left-panel__container">
+                    <MDXComponent />
+                  </div>
+                  <div className="col col--5 openapi-right-panel__container">
+                    <BrowserOnly fallback={<SkeletonLoader size="lg" />}>
+                      {() => {
+                        return <ApiExplorer item={api} infoPath={infoPath} />;
+                      }}
+                    </BrowserOnly>
+                  </div>
                 </div>
-                <div className="col col--5 openapi-right-panel__container">
-                  <BrowserOnly fallback={<SkeletonLoader size="lg" />}>
-                    {() => {
-                      return <ApiExplorer item={api} infoPath={infoPath} />;
-                    }}
-                  </BrowserOnly>
-                </div>
-              </div>
+              </SchemaExpansionProvider>
             </Provider>
           </DocItemLayout>
         </HtmlClassNameProvider>
@@ -200,16 +203,18 @@ export default function ApiItem(props: Props): JSX.Element {
         <HtmlClassNameProvider className={docHtmlClassName}>
           <DocItemMetadata />
           <DocItemLayout>
-            <div className={clsx("row", "theme-api-markdown")}>
-              <div className="col col--7 openapi-left-panel__container schema">
-                <MDXComponent />
+            <SchemaExpansionProvider>
+              <div className={clsx("row", "theme-api-markdown")}>
+                <div className="col col--7 openapi-left-panel__container schema">
+                  <MDXComponent />
+                </div>
+                <div className="col col--5 openapi-right-panel__container">
+                  <CodeBlock language="json" title={`${frontMatter.title}`}>
+                    {JSON.stringify(sample, null, 2)}
+                  </CodeBlock>
+                </div>
               </div>
-              <div className="col col--5 openapi-right-panel__container">
-                <CodeBlock language="json" title={`${frontMatter.title}`}>
-                  {JSON.stringify(sample, null, 2)}
-                </CodeBlock>
-              </div>
-            </div>
+            </SchemaExpansionProvider>
           </DocItemLayout>
         </HtmlClassNameProvider>
       </DocProvider>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -18,6 +18,7 @@ import {
   ResponseExamples,
 } from "@theme/ResponseExamples";
 import SchemaNode from "@theme/Schema";
+import SchemaExpansionControl from "@theme/SchemaExpansion";
 import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
@@ -77,24 +78,23 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                       open={true}
                       style={style}
                       summary={
-                        <>
-                          <summary>
-                            <h3 className="openapi-markdown__details-summary-header-body">
-                              {translate({
-                                id: OPENAPI_REQUEST.BODY_TITLE,
-                                message: title,
-                              })}
-                              {body.required === true && (
-                                <span className="openapi-schema__required">
-                                  {translate({
-                                    id: OPENAPI_SCHEMA_ITEM.REQUIRED,
-                                    message: "required",
-                                  })}
-                                </span>
-                              )}
-                            </h3>
-                          </summary>
-                        </>
+                        <summary className="openapi-markdown__details-summary--with-control">
+                          <h3 className="openapi-markdown__details-summary-header-body">
+                            {translate({
+                              id: OPENAPI_REQUEST.BODY_TITLE,
+                              message: title,
+                            })}
+                            {body.required === true && (
+                              <span className="openapi-schema__required">
+                                {translate({
+                                  id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                  message: "required",
+                                })}
+                              </span>
+                            )}
+                          </h3>
+                          <SchemaExpansionControl />
+                        </summary>
                       }
                     >
                       <div style={{ textAlign: "left", marginLeft: "1rem" }}>
@@ -164,27 +164,26 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
               open={true}
               style={style}
               summary={
-                <>
-                  <summary>
-                    <h3 className="openapi-markdown__details-summary-header-body">
-                      {translate({
-                        id: OPENAPI_REQUEST.BODY_TITLE,
-                        message: title,
-                      })}
-                      {firstBody.type === "array" && (
-                        <span style={{ opacity: "0.6" }}> array</span>
-                      )}
-                      {body.required && (
-                        <strong className="openapi-schema__required">
-                          {translate({
-                            id: OPENAPI_SCHEMA_ITEM.REQUIRED,
-                            message: "required",
-                          })}
-                        </strong>
-                      )}
-                    </h3>
-                  </summary>
-                </>
+                <summary className="openapi-markdown__details-summary--with-control">
+                  <h3 className="openapi-markdown__details-summary-header-body">
+                    {translate({
+                      id: OPENAPI_REQUEST.BODY_TITLE,
+                      message: title,
+                    })}
+                    {firstBody.type === "array" && (
+                      <span style={{ opacity: "0.6" }}> array</span>
+                    )}
+                    {body.required && (
+                      <strong className="openapi-schema__required">
+                        {translate({
+                          id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                          message: "required",
+                        })}
+                      </strong>
+                    )}
+                  </h3>
+                  <SchemaExpansionControl />
+                </summary>
               }
             >
               <div style={{ textAlign: "left", marginLeft: "1rem" }}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -18,6 +18,7 @@ import {
   ResponseExamples,
 } from "@theme/ResponseExamples";
 import SchemaNode from "@theme/Schema";
+import SchemaExpansionControl from "@theme/SchemaExpansion";
 import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
@@ -91,21 +92,20 @@ const ResponseSchemaComponent: React.FC<Props> = ({
                     open={true}
                     style={style}
                     summary={
-                      <>
-                        <summary>
-                          <strong className="openapi-markdown__details-summary-response">
-                            {title}
-                            {body.required === true && (
-                              <span className="openapi-schema__required">
-                                {translate({
-                                  id: OPENAPI_SCHEMA_ITEM.REQUIRED,
-                                  message: "required",
-                                })}
-                              </span>
-                            )}
-                          </strong>
-                        </summary>
-                      </>
+                      <summary className="openapi-markdown__details-summary--with-control">
+                        <strong className="openapi-markdown__details-summary-response">
+                          {title}
+                          {body.required === true && (
+                            <span className="openapi-schema__required">
+                              {translate({
+                                id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                message: "required",
+                              })}
+                            </span>
+                          )}
+                        </strong>
+                        <SchemaExpansionControl />
+                      </summary>
                     }
                   >
                     <div style={{ textAlign: "left", marginLeft: "1rem" }}>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -14,6 +14,11 @@ import { ClosingArrayBracket, OpeningArrayBracket } from "@theme/ArrayBrackets";
 import Details from "@theme/Details";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import Markdown from "@theme/Markdown";
+import {
+  SchemaDepthProvider,
+  useSchemaDepth,
+  useSchemaExpansion,
+} from "@theme/SchemaExpansion";
 import SchemaItem from "@theme/SchemaItem";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
@@ -676,10 +681,15 @@ const SchemaNodeDetails: React.FC<SchemaEdgeProps> = ({
   schemaType,
   schemaPath,
 }) => {
+  const depth = useSchemaDepth();
+  const { level } = useSchemaExpansion();
+  const defaultOpen = depth < level;
   return (
     <SchemaItem collapsible={true}>
       <Details
+        key={`level-${level}`}
         className="openapi-markdown__details"
+        open={defaultOpen}
         summary={
           <Summary
             name={name}
@@ -694,11 +704,13 @@ const SchemaNodeDetails: React.FC<SchemaEdgeProps> = ({
           {getQualifierMessage(schema) && (
             <MarkdownWrapper text={getQualifierMessage(schema)} />
           )}
-          <SchemaNode
-            schema={schema}
-            schemaType={schemaType}
-            schemaPath={schemaPath}
-          />
+          <SchemaDepthProvider depth={depth + 1}>
+            <SchemaNode
+              schema={schema}
+              schemaType={schemaType}
+              schemaPath={schemaPath}
+            />
+          </SchemaDepthProvider>
         </div>
       </Details>
     </SchemaItem>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
@@ -17,7 +17,10 @@
   background: transparent;
   border: none;
   border-radius: var(--ifm-global-radius);
-  padding: 4px;
+  padding: 0;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
@@ -22,7 +22,6 @@
   align-items: center;
   justify-content: center;
   color: var(--ifm-color-emphasis-600);
-  cursor: pointer;
   line-height: 0;
   opacity: 0.7;
   transition:
@@ -74,7 +73,6 @@
   font-size: 0.8rem;
   line-height: 1.4;
   color: var(--ifm-color-emphasis-800);
-  cursor: pointer;
   transition:
     background-color 0.12s ease,
     color 0.12s ease;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
@@ -105,5 +105,9 @@
   > h3,
   > strong {
     margin-bottom: 0;
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
   }
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
@@ -1,0 +1,110 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+.openapi-schema-expansion {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.openapi-schema-expansion__trigger {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: var(--ifm-global-radius);
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ifm-color-emphasis-600);
+  cursor: pointer;
+  line-height: 0;
+  opacity: 0.7;
+  transition:
+    opacity 0.12s ease,
+    background-color 0.12s ease,
+    color 0.12s ease;
+
+  &:hover {
+    opacity: 1;
+    background-color: var(--ifm-color-emphasis-200);
+    color: var(--ifm-color-emphasis-900);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ifm-color-primary);
+    outline-offset: 2px;
+    opacity: 1;
+  }
+
+  &[aria-expanded="true"] {
+    opacity: 1;
+    background-color: var(--ifm-color-emphasis-200);
+    color: var(--ifm-color-emphasis-900);
+  }
+}
+
+.openapi-schema-expansion__popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  box-shadow: var(--ifm-global-shadow-md);
+  white-space: nowrap;
+}
+
+.openapi-schema-expansion__option {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--ifm-global-radius) - 2px);
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
+
+  &:hover {
+    background-color: var(--ifm-color-emphasis-200);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ifm-color-primary);
+    outline-offset: 1px;
+  }
+}
+
+.openapi-schema-expansion__option--active {
+  background-color: var(--ifm-color-primary);
+  color: var(--ifm-color-white);
+
+  &:hover {
+    background-color: var(--ifm-color-primary-dark);
+  }
+}
+
+.openapi-markdown__details-summary--with-control {
+  display: flex !important;
+  align-items: center;
+  gap: 0.5rem;
+
+  > h3,
+  > strong {
+    margin-bottom: 0;
+  }
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/_SchemaExpansion.scss
@@ -52,10 +52,8 @@
 }
 
 .openapi-schema-expansion__popover {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 10;
+  position: fixed;
+  z-index: 1000;
   display: inline-flex;
   align-items: center;
   gap: 2px;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/context.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/context.tsx
@@ -61,11 +61,16 @@ function readConfig(
 ): SchemaExpansionConfig {
   const raw = themeConfig?.api?.schemaExpansion;
   if (!raw) return DEFAULT_CONFIG;
+  const enabled = raw.enabled ?? false;
   return {
-    enabled: raw.enabled ?? false,
+    enabled,
     defaultLevel: normalizeLevel(raw.default),
     max: typeof raw.max === "number" && raw.max > 0 ? Math.floor(raw.max) : 4,
-    persist: raw.persist ?? true,
+    // Persistence only matters when the reader can change the level via the
+    // UI control. When the control is hidden, fall back to the configured
+    // default on every visit so it isn't shadowed by a stale localStorage
+    // value from a session where the control used to be enabled.
+    persist: enabled ? (raw.persist ?? true) : false,
   };
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/context.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/context.tsx
@@ -1,0 +1,149 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
+
+export const SCHEMA_EXPANSION_STORAGE_KEY =
+  "docusaurus-openapi-schema-expansion-level";
+
+export interface SchemaExpansionConfig {
+  enabled: boolean;
+  defaultLevel: number;
+  max: number;
+  persist: boolean;
+}
+
+interface SchemaExpansionContextValue {
+  config: SchemaExpansionConfig;
+  level: number;
+  setLevel: (next: number) => void;
+}
+
+const DEFAULT_CONFIG: SchemaExpansionConfig = {
+  enabled: false,
+  defaultLevel: 0,
+  max: 4,
+  persist: true,
+};
+
+const SchemaExpansionContext = createContext<SchemaExpansionContextValue>({
+  config: DEFAULT_CONFIG,
+  level: 0,
+  setLevel: () => {},
+});
+
+const SchemaDepthContext = createContext<number>(0);
+
+export function normalizeLevel(value: number | "all" | undefined): number {
+  if (value === "all") return Infinity;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return 0;
+}
+
+function readConfig(
+  themeConfig: ThemeConfig | undefined
+): SchemaExpansionConfig {
+  const raw = themeConfig?.api?.schemaExpansion;
+  if (!raw) return DEFAULT_CONFIG;
+  return {
+    enabled: raw.enabled ?? false,
+    defaultLevel: normalizeLevel(raw.default),
+    max: typeof raw.max === "number" && raw.max > 0 ? Math.floor(raw.max) : 4,
+    persist: raw.persist ?? true,
+  };
+}
+
+function readPersistedLevel(): number | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const stored = window.localStorage.getItem(SCHEMA_EXPANSION_STORAGE_KEY);
+    if (stored === null) return undefined;
+    if (stored === "all") return Infinity;
+    const parsed = parseInt(stored, 10);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writePersistedLevel(level: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    const value = level === Infinity ? "all" : String(level);
+    window.localStorage.setItem(SCHEMA_EXPANSION_STORAGE_KEY, value);
+  } catch {
+    // ignore quota / disabled storage
+  }
+}
+
+export const SchemaExpansionProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const { siteConfig } = useDocusaurusContext();
+  const themeConfig = siteConfig.themeConfig as ThemeConfig | undefined;
+  const config = useMemo(() => readConfig(themeConfig), [themeConfig]);
+
+  const [level, setLevelState] = useState<number>(config.defaultLevel);
+
+  useEffect(() => {
+    if (!config.persist) return;
+    const persisted = readPersistedLevel();
+    if (persisted !== undefined) {
+      setLevelState(persisted);
+    }
+  }, [config.persist]);
+
+  const setLevel = useCallback(
+    (next: number) => {
+      setLevelState(next);
+      if (config.persist) {
+        writePersistedLevel(next);
+      }
+    },
+    [config.persist]
+  );
+
+  const value = useMemo(
+    () => ({ config, level, setLevel }),
+    [config, level, setLevel]
+  );
+
+  return (
+    <SchemaExpansionContext.Provider value={value}>
+      {children}
+    </SchemaExpansionContext.Provider>
+  );
+};
+
+export const SchemaDepthProvider: React.FC<{
+  depth: number;
+  children: React.ReactNode;
+}> = ({ depth, children }) => (
+  <SchemaDepthContext.Provider value={depth}>
+    {children}
+  </SchemaDepthContext.Provider>
+);
+
+export function useSchemaExpansion(): SchemaExpansionContextValue {
+  return useContext(SchemaExpansionContext);
+}
+
+export function useSchemaDepth(): number {
+  return useContext(SchemaDepthContext);
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -8,12 +8,15 @@
 import React, {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 
 import { translate } from "@docusaurus/Translate";
+import { OPENAPI_SCHEMA_EXPANSION } from "@theme/translationIds";
 import clsx from "clsx";
 
 import { useSchemaExpansion } from "./context";
@@ -26,6 +29,8 @@ export {
   normalizeLevel,
   SCHEMA_EXPANSION_STORAGE_KEY,
 } from "./context";
+
+const ALL_VALUE = Number.POSITIVE_INFINITY;
 
 const ExpandIcon: React.FC = () => (
   <svg
@@ -53,6 +58,18 @@ const SchemaExpansionControl: React.FC = () => {
   );
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const popoverId = useId();
+
+  const options = useMemo(() => {
+    const numbers = Array.from({ length: config.max + 1 }, (_, i) => i);
+    return [...numbers, ALL_VALUE];
+  }, [config.max]);
+
+  const activeIndex = useMemo(() => {
+    const idx = options.indexOf(level);
+    return idx >= 0 ? idx : 0;
+  }, [options, level]);
 
   const updatePosition = useCallback(() => {
     if (!buttonRef.current || typeof window === "undefined") return;
@@ -77,6 +94,11 @@ const SchemaExpansionControl: React.FC = () => {
 
   useEffect(() => {
     if (!open) return;
+    optionRefs.current[activeIndex]?.focus();
+  }, [open, activeIndex]);
+
+  useEffect(() => {
+    if (!open) return;
     const handlePointer = (event: MouseEvent) => {
       const target = event.target as Node;
       if (buttonRef.current?.contains(target)) return;
@@ -85,6 +107,7 @@ const SchemaExpansionControl: React.FC = () => {
     };
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.stopPropagation();
         setOpen(false);
         buttonRef.current?.focus();
       }
@@ -106,16 +129,34 @@ const SchemaExpansionControl: React.FC = () => {
     [setLevel]
   );
 
+  const onMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+    event.preventDefault();
+    const current = optionRefs.current.findIndex(
+      (el) => el === document.activeElement
+    );
+    if (current < 0) return;
+    const next =
+      event.key === "ArrowRight"
+        ? (current + 1) % options.length
+        : (current - 1 + options.length) % options.length;
+    optionRefs.current[next]?.focus();
+  };
+
   if (!config.enabled) return null;
 
-  const levels = Array.from({ length: config.max + 1 }, (_, i) => i);
   const buttonLabel = translate({
-    id: "theme.openapi.schema.expansion.button",
+    id: OPENAPI_SCHEMA_EXPANSION.BUTTON_LABEL,
     message: "Schema expansion depth",
     description: "Aria/title tooltip for the schema expansion icon button",
   });
+  const menuLabel = translate({
+    id: OPENAPI_SCHEMA_EXPANSION.MENU_LABEL,
+    message: "Schema expansion depth options",
+    description: "Accessible label for the expansion options menu",
+  });
   const allLabel = translate({
-    id: "theme.openapi.schema.expansion.all",
+    id: OPENAPI_SCHEMA_EXPANSION.ALL,
     message: "All",
     description: "Label for the expand-all option",
   });
@@ -126,8 +167,9 @@ const SchemaExpansionControl: React.FC = () => {
         ref={buttonRef}
         type="button"
         className="openapi-schema-expansion__trigger"
-        aria-haspopup="true"
+        aria-haspopup="menu"
         aria-expanded={open}
+        aria-controls={open ? popoverId : undefined}
         aria-label={buttonLabel}
         title={buttonLabel}
         onClick={(event) => {
@@ -141,40 +183,51 @@ const SchemaExpansionControl: React.FC = () => {
       {open && coords && (
         <div
           ref={popoverRef}
+          id={popoverId}
           role="menu"
+          aria-label={menuLabel}
           className="openapi-schema-expansion__popover"
           style={{ top: coords.top, right: coords.right }}
+          onKeyDown={onMenuKeyDown}
           onClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
           }}
         >
-          {levels.map((n) => (
-            <button
-              key={n}
-              type="button"
-              role="menuitemradio"
-              aria-checked={level === n}
-              className={clsx("openapi-schema-expansion__option", {
-                "openapi-schema-expansion__option--active": level === n,
-              })}
-              onClick={() => choose(n)}
-            >
-              {n}
-            </button>
-          ))}
-          <button
-            type="button"
-            role="menuitemradio"
-            aria-checked={!Number.isFinite(level)}
-            className={clsx("openapi-schema-expansion__option", {
-              "openapi-schema-expansion__option--active":
-                !Number.isFinite(level),
-            })}
-            onClick={() => choose(Infinity)}
-          >
-            {allLabel}
-          </button>
+          {options.map((value, index) => {
+            const isAll = value === ALL_VALUE;
+            const label = isAll ? allLabel : String(value);
+            const optionAriaLabel = isAll
+              ? allLabel
+              : translate(
+                  {
+                    id: OPENAPI_SCHEMA_EXPANSION.DEPTH_OPTION,
+                    message: "Expand to depth {depth}",
+                    description: "Accessible label for a depth option",
+                  },
+                  { depth: value }
+                );
+            const isActive = level === value;
+            return (
+              <button
+                key={isAll ? "all" : value}
+                ref={(el) => {
+                  optionRefs.current[index] = el;
+                }}
+                type="button"
+                role="menuitemradio"
+                aria-checked={isActive}
+                aria-label={optionAriaLabel}
+                tabIndex={index === activeIndex ? 0 : -1}
+                className={clsx("openapi-schema-expansion__option", {
+                  "openapi-schema-expansion__option--active": isActive,
+                })}
+                onClick={() => choose(value)}
+              >
+                {label}
+              </button>
+            );
+          })}
         </div>
       )}
     </span>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -1,0 +1,152 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+import { translate } from "@docusaurus/Translate";
+import clsx from "clsx";
+
+import { useSchemaExpansion } from "./context";
+
+export {
+  SchemaExpansionProvider,
+  SchemaDepthProvider,
+  useSchemaExpansion,
+  useSchemaDepth,
+  normalizeLevel,
+  SCHEMA_EXPANSION_STORAGE_KEY,
+} from "./context";
+
+const ExpandIcon: React.FC = () => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    width="14"
+    height="14"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="4 6 8 2 12 6" />
+    <polyline points="4 10 8 14 12 10" />
+  </svg>
+);
+
+const SchemaExpansionControl: React.FC = () => {
+  const { config, level, setLevel } = useSchemaExpansion();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointer = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  const choose = useCallback(
+    (next: number) => {
+      setLevel(next);
+      setOpen(false);
+      buttonRef.current?.focus();
+    },
+    [setLevel]
+  );
+
+  if (!config.enabled) return null;
+
+  const levels = Array.from({ length: config.max + 1 }, (_, i) => i);
+  const buttonLabel = translate({
+    id: "theme.openapi.schema.expansion.button",
+    message: "Schema expansion depth",
+    description: "Aria/title for the schema expansion icon button",
+  });
+  const allLabel = translate({
+    id: "theme.openapi.schema.expansion.all",
+    message: "All",
+    description: "Label for the expand-all option",
+  });
+
+  return (
+    <div className="openapi-schema-expansion" ref={containerRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="openapi-schema-expansion__trigger"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={buttonLabel}
+        title={buttonLabel}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+      >
+        <ExpandIcon />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="openapi-schema-expansion__popover"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          {levels.map((n) => (
+            <button
+              key={n}
+              type="button"
+              role="menuitemradio"
+              aria-checked={level === n}
+              className={clsx("openapi-schema-expansion__option", {
+                "openapi-schema-expansion__option--active": level === n,
+              })}
+              onClick={() => choose(n)}
+            >
+              {n}
+            </button>
+          ))}
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={!Number.isFinite(level)}
+            className={clsx("openapi-schema-expansion__option", {
+              "openapi-schema-expansion__option--active":
+                !Number.isFinite(level),
+            })}
+            onClick={() => choose(Infinity)}
+          >
+            {allLabel}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SchemaExpansionControl;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -110,8 +110,8 @@ const SchemaExpansionControl: React.FC = () => {
   const levels = Array.from({ length: config.max + 1 }, (_, i) => i);
   const buttonLabel = translate({
     id: "theme.openapi.schema.expansion.button",
-    message: "Schema expansion depth",
-    description: "Aria/title for the schema expansion icon button",
+    message: "Set how deep schemas auto-expand",
+    description: "Aria/title tooltip for the schema expansion icon button",
   });
   const allLabel = translate({
     id: "theme.openapi.schema.expansion.all",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -15,7 +15,6 @@ import React, {
 
 import { translate } from "@docusaurus/Translate";
 import clsx from "clsx";
-import { createPortal } from "react-dom";
 
 import { useSchemaExpansion } from "./context";
 
@@ -56,7 +55,7 @@ const SchemaExpansionControl: React.FC = () => {
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
   const updatePosition = useCallback(() => {
-    if (!buttonRef.current) return;
+    if (!buttonRef.current || typeof window === "undefined") return;
     const rect = buttonRef.current.getBoundingClientRect();
     setCoords({
       top: rect.bottom + 4,
@@ -120,50 +119,6 @@ const SchemaExpansionControl: React.FC = () => {
     description: "Label for the expand-all option",
   });
 
-  const popover =
-    open && coords && typeof document !== "undefined"
-      ? createPortal(
-          <div
-            ref={popoverRef}
-            role="menu"
-            className="openapi-schema-expansion__popover"
-            style={{ top: coords.top, right: coords.right }}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-          >
-            {levels.map((n) => (
-              <button
-                key={n}
-                type="button"
-                role="menuitemradio"
-                aria-checked={level === n}
-                className={clsx("openapi-schema-expansion__option", {
-                  "openapi-schema-expansion__option--active": level === n,
-                })}
-                onClick={() => choose(n)}
-              >
-                {n}
-              </button>
-            ))}
-            <button
-              type="button"
-              role="menuitemradio"
-              aria-checked={!Number.isFinite(level)}
-              className={clsx("openapi-schema-expansion__option", {
-                "openapi-schema-expansion__option--active":
-                  !Number.isFinite(level),
-              })}
-              onClick={() => choose(Infinity)}
-            >
-              {allLabel}
-            </button>
-          </div>,
-          document.body
-        )
-      : null;
-
   return (
     <span className="openapi-schema-expansion">
       <button
@@ -182,7 +137,45 @@ const SchemaExpansionControl: React.FC = () => {
       >
         <ExpandIcon />
       </button>
-      {popover}
+      {open && coords && (
+        <div
+          ref={popoverRef}
+          role="menu"
+          className="openapi-schema-expansion__popover"
+          style={{ top: coords.top, right: coords.right }}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+        >
+          {levels.map((n) => (
+            <button
+              key={n}
+              type="button"
+              role="menuitemradio"
+              aria-checked={level === n}
+              className={clsx("openapi-schema-expansion__option", {
+                "openapi-schema-expansion__option--active": level === n,
+              })}
+              onClick={() => choose(n)}
+            >
+              {n}
+            </button>
+          ))}
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={!Number.isFinite(level)}
+            className={clsx("openapi-schema-expansion__option", {
+              "openapi-schema-expansion__option--active":
+                !Number.isFinite(level),
+            })}
+            onClick={() => choose(Infinity)}
+          >
+            {allLabel}
+          </button>
+        </div>
+      )}
     </span>
   );
 };

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -5,10 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { translate } from "@docusaurus/Translate";
 import clsx from "clsx";
+import { createPortal } from "react-dom";
 
 import { useSchemaExpansion } from "./context";
 
@@ -42,16 +49,39 @@ const ExpandIcon: React.FC = () => (
 const SchemaExpansionControl: React.FC = () => {
   const { config, level, setLevel } = useSchemaExpansion();
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [coords, setCoords] = useState<{ top: number; right: number } | null>(
+    null
+  );
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  const updatePosition = useCallback(() => {
+    if (!buttonRef.current) return;
+    const rect = buttonRef.current.getBoundingClientRect();
+    setCoords({
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [open, updatePosition]);
 
   useEffect(() => {
     if (!open) return;
     const handlePointer = (event: MouseEvent) => {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
+      const target = event.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -90,8 +120,52 @@ const SchemaExpansionControl: React.FC = () => {
     description: "Label for the expand-all option",
   });
 
+  const popover =
+    open && coords && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            ref={popoverRef}
+            role="menu"
+            className="openapi-schema-expansion__popover"
+            style={{ top: coords.top, right: coords.right }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+          >
+            {levels.map((n) => (
+              <button
+                key={n}
+                type="button"
+                role="menuitemradio"
+                aria-checked={level === n}
+                className={clsx("openapi-schema-expansion__option", {
+                  "openapi-schema-expansion__option--active": level === n,
+                })}
+                onClick={() => choose(n)}
+              >
+                {n}
+              </button>
+            ))}
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={!Number.isFinite(level)}
+              className={clsx("openapi-schema-expansion__option", {
+                "openapi-schema-expansion__option--active":
+                  !Number.isFinite(level),
+              })}
+              onClick={() => choose(Infinity)}
+            >
+              {allLabel}
+            </button>
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
-    <div className="openapi-schema-expansion" ref={containerRef}>
+    <span className="openapi-schema-expansion">
       <button
         ref={buttonRef}
         type="button"
@@ -108,44 +182,8 @@ const SchemaExpansionControl: React.FC = () => {
       >
         <ExpandIcon />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="openapi-schema-expansion__popover"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-        >
-          {levels.map((n) => (
-            <button
-              key={n}
-              type="button"
-              role="menuitemradio"
-              aria-checked={level === n}
-              className={clsx("openapi-schema-expansion__option", {
-                "openapi-schema-expansion__option--active": level === n,
-              })}
-              onClick={() => choose(n)}
-            >
-              {n}
-            </button>
-          ))}
-          <button
-            type="button"
-            role="menuitemradio"
-            aria-checked={!Number.isFinite(level)}
-            className={clsx("openapi-schema-expansion__option", {
-              "openapi-schema-expansion__option--active":
-                !Number.isFinite(level),
-            })}
-            onClick={() => choose(Infinity)}
-          >
-            {allLabel}
-          </button>
-        </div>
-      )}
-    </div>
+      {popover}
+    </span>
   );
 };
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -66,10 +66,11 @@ const SchemaExpansionControl: React.FC = () => {
   useLayoutEffect(() => {
     if (!open) return;
     updatePosition();
-    window.addEventListener("scroll", updatePosition, true);
+    const handleScroll = () => setOpen(false);
+    window.addEventListener("scroll", handleScroll, true);
     window.addEventListener("resize", updatePosition);
     return () => {
-      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("scroll", handleScroll, true);
       window.removeEventListener("resize", updatePosition);
     };
   }, [open, updatePosition]);
@@ -110,7 +111,7 @@ const SchemaExpansionControl: React.FC = () => {
   const levels = Array.from({ length: config.max + 1 }, (_, i) => i);
   const buttonLabel = translate({
     id: "theme.openapi.schema.expansion.button",
-    message: "Set how deep schemas auto-expand",
+    message: "Schema expansion depth",
     description: "Aria/title tooltip for the schema expansion icon button",
   });
   const allLabel = translate({

--- a/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/styles.scss
@@ -32,6 +32,7 @@
 /* Schema Styling */
 @use "./ParamsItem/ParamsItem";
 @use "./SchemaItem/SchemaItem";
+@use "./SchemaExpansion/SchemaExpansion";
 /* Tabs Styling */
 @use "./ApiTabs/ApiTabs";
 @use "./DiscriminatorTabs/DiscriminatorTabs";

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -78,6 +78,13 @@ export const OPENAPI_SCHEMA = {
   NO_SCHEMA: "theme.openapi.schema.noSchema",
 };
 
+export const OPENAPI_SCHEMA_EXPANSION = {
+  BUTTON_LABEL: "theme.openapi.schema.expansion.button",
+  MENU_LABEL: "theme.openapi.schema.expansion.menu",
+  ALL: "theme.openapi.schema.expansion.all",
+  DEPTH_OPTION: "theme.openapi.schema.expansion.depthOption",
+};
+
 export const OPENAPI_SCHEMA_ITEM = {
   CHARACTERS: "theme.openapi.schemaItem.characters",
   NON_EMPTY: "theme.openapi.schemaItem.nonEmpty",

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -37,15 +37,19 @@ export interface ThemeConfig {
     /**
      * Controls automatic expansion of nested schema trees in request/response
      * documentation. Inspired by Redoc's `schemaExpansionLevel`.
+     *
+     * `default` applies whether or not `enabled` is `true` — set
+     * `{ default: 1 }` alone to auto-expand the first level on every page
+     * without rendering the depth control.
      */
     schemaExpansion?: {
-      /** Show an interactive control on the page so readers can change depth at view time. Defaults to `false`. */
+      /** Render an interactive depth control next to each schema header so readers can change the depth at view time. Defaults to `false`. */
       enabled?: boolean;
-      /** Initial expansion depth. Use `"all"` to expand everything. Defaults to `0` (all collapsed). */
+      /** Initial expansion depth applied on every page load. Use `"all"` to expand everything. Defaults to `0` (all collapsed). */
       default?: number | "all";
-      /** Maximum depth value offered by the UI control's pill buttons. Defaults to `4`. */
+      /** Highest numeric depth offered by the UI control. Ignored when `enabled` is `false`. Defaults to `4`. */
       max?: number;
-      /** Persist the reader's selected depth in `localStorage`. Defaults to `true` when `enabled` is `true`. */
+      /** Persist the reader's selected depth in `localStorage`. Only meaningful when `enabled` is `true`; defaults to `true` in that case. */
       persist?: boolean;
     };
   };

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -34,6 +34,20 @@ export interface ThemeConfig {
      * - `"include"`: Always send cookies, even for cross-origin requests
      */
     requestCredentials?: "omit" | "same-origin" | "include";
+    /**
+     * Controls automatic expansion of nested schema trees in request/response
+     * documentation. Inspired by Redoc's `schemaExpansionLevel`.
+     */
+    schemaExpansion?: {
+      /** Show an interactive control on the page so readers can change depth at view time. Defaults to `false`. */
+      enabled?: boolean;
+      /** Initial expansion depth. Use `"all"` to expand everything. Defaults to `0` (all collapsed). */
+      default?: number | "all";
+      /** Maximum depth value offered by the UI control's pill buttons. Defaults to `4`. */
+      max?: number;
+      /** Persist the reader's selected depth in `localStorage`. Defaults to `true` when `enabled` is `true`. */
+      persist?: boolean;
+    };
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #1222.

Adds an opt-in `themeConfig.api.schemaExpansion` option that controls the default expansion depth of nested request/response schema trees, plus an inline icon control next to each schema header that lets readers change the depth at view time. The selected depth is persisted in `localStorage`.

Inspired by Redoc's [`schemaExpansionLevel`](https://redocly.com/docs/redoc/config#schemaexpansionlevel) — useful primarily for envelope-wrapped APIs (e.g. `{ status, meta, data: {...} }`) where readers otherwise have to manually click into every `data` property.

## How it works

- New `SchemaExpansionProvider` and `SchemaDepthProvider` contexts thread the active expansion level and per-node depth without prop-drilling through the recursive `Schema` renderer.
- `SchemaNodeDetails` opens its `<Details>` when `depth < level`. Keying on `level` forces a remount on level change so the control feels responsive without losing per-row click toggling afterward.
- New `SchemaExpansionControl` renders a small icon trigger inline with the Body / Schema headers; clicking opens a compact popover with depth options including "All". The popover is positioned with `position: fixed` (computed from the trigger's bounding rect) so it isn't clipped when the surrounding `<details>` is collapsed, and closes on scroll to stay visually anchored.
- Behavior is unchanged when `schemaExpansion` is unset — no control rendered, schemas remain collapsed by default.

### Config

```ts
themeConfig: {
  api: {
    schemaExpansion: {
      enabled: true,         // show the depth control (default: false)
      default: 1,            // initial depth — "all" supported (default: 0)
      max: 4,                // max depth offered by the control (default: 4)
      persist: true,         // remember last choice in localStorage (default: true)
    },
  },
}
```

### Accessibility & i18n

- `<button>` trigger with `aria-haspopup="menu"`, `aria-expanded`, `aria-controls`, `aria-label`, and a native `title` tooltip.
- Popover has `role="menu"` and its own `aria-label`; options are `role="menuitemradio"` with `aria-checked` and a translated per-option label (`"Expand to depth N"`).
- Focus moves to the active option on open; ← / → cycle through options; ESC closes and returns focus to the trigger.
- All user-facing strings are routed through `@docusaurus/Translate` and registered in `translationIds.ts` under `OPENAPI_SCHEMA_EXPANSION` (`theme.openapi.schema.expansion.*`).

## Files

- `packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/` — new context module, control component, BEM-style SCSS
- `packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx` — `SchemaNodeDetails` reads context, threads depth
- `packages/docusaurus-theme-openapi-docs/src/theme/{Request,Response}Schema/index.tsx` — render the inline control
- `packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx` — wraps the page in the provider
- `packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts` — registers the new translation keys
- `packages/docusaurus-theme-openapi-docs/src/types.d.ts` — types `schemaExpansion` on `ThemeConfig.api`
- `demo/examples/tests/schemaExpansion.yaml` — envelope-wrapped fixture for manual exercise
- `demo/docusaurus.config.ts` — enables the option in the demo

## Test plan

- [x] Visit `/docs/tests/get-user-envelope-wrapped` — the depth icon appears to the right of the "SCHEMA" header
- [x] With `default: 1`, the top-level `data` property is open on load; deeper children are not
- [x] Clicking the icon opens a popover with `0 1 2 3 4 All`; selecting a value adjusts the open depth across the tree
- [x] Selection persists across reloads (`localStorage` key `docusaurus-openapi-schema-expansion-level`)
- [x] Same control appears next to the "BODY" header on the create-user endpoint
- [x] Tab/arrow-key navigation works inside the popover; ESC closes and returns focus to the trigger
- [x] Removing `schemaExpansion` from the demo config hides the control and restores prior collapsed-by-default behavior
- [x] Mobile / narrow viewport: popover stays anchored to the trigger and doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
