### PR TITLE
fix: dedupe properties when allOf override redefines nested array items (#1218)

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -742,6 +742,40 @@ paths:
                     type: string
                     example: Resource created successfully
 
+  /allof-array-items-oneof-override:
+    get:
+      tags:
+        - allOf
+      summary: allOf override of nested array items with oneOf
+      description: |
+        Regression coverage for [issue #1218](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1218).
+
+        A schema extends a base via `allOf` and overrides a nested array's `items`
+        with a `oneOf` of subtypes that each include the base's properties. Prior
+        to the fix, the shared base properties (`id`, `type`, `geometry`) rendered
+        twice — once at the array-item level and once inside each oneOf branch.
+
+        Schema:
+        ```yaml
+        type: object
+        allOf:
+          - $ref: '#/components/schemas/FeatureCollectionBase'
+          - type: object
+            properties:
+              features:
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/PointFeature'
+                    - $ref: '#/components/schemas/PolygonFeature'
+        ```
+      responses:
+        "200":
+          description: A custom feature collection
+          content:
+            application/geo+json:
+              schema:
+                $ref: "#/components/schemas/CustomFeatureCollection"
+
 components:
   schemas:
     # Enum schemas for allOf parameter tests
@@ -818,3 +852,65 @@ components:
           type: string
           description: The category of the book
           example: "Fiction"
+
+    # GeoJSON-style schemas for issue #1218: allOf override of nested array items with oneOf
+    FeatureBase:
+      type: object
+      required: [type, geometry]
+      properties:
+        id:
+          type: string
+          description: Feature identifier
+        type:
+          type: string
+          enum: [Feature]
+        geometry:
+          type: object
+          description: GeoJSON geometry
+
+    PointFeature:
+      allOf:
+        - $ref: "#/components/schemas/FeatureBase"
+        - type: object
+          properties:
+            properties:
+              type: object
+              properties:
+                label:
+                  type: string
+                  description: Point label
+
+    PolygonFeature:
+      allOf:
+        - $ref: "#/components/schemas/FeatureBase"
+        - type: object
+          properties:
+            properties:
+              type: object
+              properties:
+                area:
+                  type: number
+                  description: Polygon area
+
+    FeatureCollectionBase:
+      type: object
+      required: [type, features]
+      properties:
+        type:
+          type: string
+          enum: [FeatureCollection]
+        features:
+          type: array
+          items:
+            $ref: "#/components/schemas/FeatureBase"
+
+    CustomFeatureCollection:
+      allOf:
+        - $ref: "#/components/schemas/FeatureCollectionBase"
+        - type: object
+          properties:
+            features:
+              items:
+                oneOf:
+                  - $ref: "#/components/schemas/PointFeature"
+                  - $ref: "#/components/schemas/PolygonFeature"

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -19,6 +19,16 @@ Array [
           <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
             <SchemaItem
               collapsible={false}
+              name={\\"description\\"}
+              required={true}
+              schemaName={\\"string\\"}
+              schema={{
+                type: \\"string\\",
+                description: \\"Description of the body part.\\",
+              }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
               name={\\"type\\"}
               required={true}
               schemaName={\\"string\\"}
@@ -28,6 +38,16 @@ Array [
           <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
             <SchemaItem
               collapsible={false}
+              name={\\"description\\"}
+              required={true}
+              schemaName={\\"string\\"}
+              schema={{
+                type: \\"string\\",
+                description: \\"Description of the body part.\\",
+              }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
               name={\\"type\\"}
               required={true}
               schemaName={\\"string\\"}
@@ -35,6 +55,16 @@ Array [
             ></SchemaItem>
           </TabItem>
           <TabItem label={\\"MOD3\\"} value={\\"2-item-properties\\"}>
+            <SchemaItem
+              collapsible={false}
+              name={\\"description\\"}
+              required={true}
+              schemaName={\\"string\\"}
+              schema={{
+                type: \\"string\\",
+                description: \\"Description of the body part.\\",
+              }}
+            ></SchemaItem>
             <SchemaItem
               collapsible={false}
               name={\\"type\\"}
@@ -52,16 +82,6 @@ Array [
           </TabItem>
         </SchemaTabs>
       </div>
-      <SchemaItem
-        collapsible={false}
-        name={\\"description\\"}
-        required={true}
-        schemaName={\\"string\\"}
-        schema={{
-          type: \\"string\\",
-          description: \\"Description of the body part.\\",
-        }}
-      ></SchemaItem>
     </div>
   </details>
 </SchemaItem>;
@@ -308,6 +328,77 @@ Array [
 ]
 `;
 
+exports[`createNodes allOf should not duplicate shared item properties when items.allOf combines base + oneOf (#1218) 1`] = `
+Array [
+  "<SchemaItem collapsible={true} className={\\"schemaItem\\"}>
+  <details style={{}} className={\\"openapi-markdown__details\\"}>
+    <summary style={{}}>
+      <span className={\\"openapi-schema__container\\"}>
+        <strong className={\\"openapi-schema__property\\"}>features</strong>
+        <span className={\\"openapi-schema__name\\"}>object</span>
+      </span>
+    </summary>
+    <div style={{ marginLeft: \\"1rem\\" }}>
+      <div>
+        <span className={\\"badge badge--info\\"} style={{ marginBottom: \\"1rem\\" }}>
+          oneOf
+        </span>
+        <SchemaTabs>
+          <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+            <SchemaItem
+              collapsible={false}
+              name={\\"id\\"}
+              required={false}
+              schemaName={\\"string\\"}
+              schema={{ type: \\"string\\" }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"type\\"}
+              required={true}
+              schemaName={\\"string\\"}
+              schema={{ type: \\"string\\", enum: [\\"Feature\\"] }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"customA\\"}
+              required={false}
+              schemaName={\\"string\\"}
+              schema={{ type: \\"string\\" }}
+            ></SchemaItem>
+          </TabItem>
+          <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+            <SchemaItem
+              collapsible={false}
+              name={\\"id\\"}
+              required={false}
+              schemaName={\\"string\\"}
+              schema={{ type: \\"string\\" }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"type\\"}
+              required={true}
+              schemaName={\\"string\\"}
+              schema={{ type: \\"string\\", enum: [\\"Feature\\"] }}
+            ></SchemaItem>
+            <SchemaItem
+              collapsible={false}
+              name={\\"customB\\"}
+              required={false}
+              schemaName={\\"number\\"}
+              schema={{ type: \\"number\\" }}
+            ></SchemaItem>
+          </TabItem>
+        </SchemaTabs>
+      </div>
+    </div>
+  </details>
+</SchemaItem>;
+",
+]
+`;
+
 exports[`createNodes allOf should render same-level properties with allOf 1`] = `
 Array [
   "<SchemaItem
@@ -456,13 +547,35 @@ Array [
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
-      <SchemaItem
-        collapsible={false}
-        name={\\"type\\"}
-        required={true}
-        schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
-      ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propA\\"}
@@ -472,13 +585,35 @@ Array [
       ></SchemaItem>
     </TabItem>
     <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
-      <SchemaItem
-        collapsible={false}
-        name={\\"type\\"}
-        required={true}
-        schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
-      ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propB\\"}
@@ -488,31 +623,6 @@ Array [
       ></SchemaItem>
     </TabItem>
   </SchemaTabs>
-</div>;
-",
-  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
-  <div>
-    <span className={\\"openapi-schema__container\\"}>
-      <strong
-        className={\\"openapi-discriminator__name openapi-schema__property\\"}
-      >
-        type
-      </strong>
-      <span className={\\"openapi-schema__name\\"}>string</span>
-    </span>
-    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
-      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeA
-        </div>
-      </TabItem>
-      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeB
-        </div>
-      </TabItem>
-    </DiscriminatorTabs>
-  </div>
 </div>;
 ",
 ]
@@ -560,14 +670,6 @@ Array [
   </SchemaTabs>
 </div>;
 ",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
 ]
 `;
 
@@ -613,14 +715,6 @@ Array [
   </SchemaTabs>
 </div>;
 ",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
 ]
 `;
 
@@ -642,6 +736,13 @@ Array [
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
       <SchemaItem
         collapsible={false}
+        name={\\"sharedProp\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
         name={\\"type\\"}
         required={true}
         schemaName={\\"string\\"}
@@ -656,6 +757,13 @@ Array [
       ></SchemaItem>
     </TabItem>
     <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <SchemaItem
+        collapsible={false}
+        name={\\"sharedProp\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
       <SchemaItem
         collapsible={false}
         name={\\"type\\"}
@@ -673,22 +781,6 @@ Array [
     </TabItem>
   </SchemaTabs>
 </div>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"sharedProp\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
 ",
 ]
 `;
@@ -728,11 +820,40 @@ Array [
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
       <SchemaItem
         collapsible={false}
-        name={\\"type\\"}
-        required={true}
+        name={\\"sharedProp\\"}
+        required={false}
         schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+        schema={{ type: \\"string\\" }}
       ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propA\\"}
@@ -744,11 +865,40 @@ Array [
     <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
       <SchemaItem
         collapsible={false}
-        name={\\"type\\"}
-        required={true}
+        name={\\"sharedProp\\"}
+        required={false}
         schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+        schema={{ type: \\"string\\" }}
       ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propB\\"}
@@ -758,39 +908,6 @@ Array [
       ></SchemaItem>
     </TabItem>
   </SchemaTabs>
-</div>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"sharedProp\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
-  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
-  <div>
-    <span className={\\"openapi-schema__container\\"}>
-      <strong
-        className={\\"openapi-discriminator__name openapi-schema__property\\"}
-      >
-        type
-      </strong>
-      <span className={\\"openapi-schema__name\\"}>string</span>
-    </span>
-    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
-      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeA
-        </div>
-      </TabItem>
-      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeB
-        </div>
-      </TabItem>
-    </DiscriminatorTabs>
-  </div>
 </div>;
 ",
 ]
@@ -876,14 +993,6 @@ Array [
   </SchemaTabs>
 </div>;
 ",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
 ]
 `;
 
@@ -929,14 +1038,6 @@ Array [
   </SchemaTabs>
 </div>;
 ",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
 ]
 `;
 
@@ -948,13 +1049,35 @@ Array [
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
-      <SchemaItem
-        collapsible={false}
-        name={\\"type\\"}
-        required={true}
-        schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
-      ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propA\\"}
@@ -964,13 +1087,35 @@ Array [
       ></SchemaItem>
     </TabItem>
     <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
-      <SchemaItem
-        collapsible={false}
-        name={\\"type\\"}
-        required={true}
-        schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
-      ></SchemaItem>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
         name={\\"propB\\"}
@@ -980,31 +1125,6 @@ Array [
       ></SchemaItem>
     </TabItem>
   </SchemaTabs>
-</div>;
-",
-  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
-  <div>
-    <span className={\\"openapi-schema__container\\"}>
-      <strong
-        className={\\"openapi-discriminator__name openapi-schema__property\\"}
-      >
-        type
-      </strong>
-      <span className={\\"openapi-schema__name\\"}>string</span>
-    </span>
-    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
-      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeA
-        </div>
-      </TabItem>
-      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeB
-        </div>
-      </TabItem>
-    </DiscriminatorTabs>
-  </div>
 </div>;
 ",
 ]
@@ -1027,6 +1147,13 @@ Array [
       ></SchemaItem>
       <SchemaItem
         collapsible={false}
+        name={\\"sharedProp\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
         name={\\"propA\\"}
         required={false}
         schemaName={\\"string\\"}
@@ -1043,6 +1170,13 @@ Array [
       ></SchemaItem>
       <SchemaItem
         collapsible={false}
+        name={\\"sharedProp\\"}
+        required={false}
+        schemaName={\\"string\\"}
+        schema={{ type: \\"string\\" }}
+      ></SchemaItem>
+      <SchemaItem
+        collapsible={false}
         name={\\"propB\\"}
         required={false}
         schemaName={\\"number\\"}
@@ -1051,22 +1185,6 @@ Array [
     </TabItem>
   </SchemaTabs>
 </div>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"type\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"sharedProp\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
 ",
 ]
 `;
@@ -1079,12 +1197,41 @@ Array [
   </span>
   <SchemaTabs>
     <TabItem label={\\"MOD1\\"} value={\\"0-item-properties\\"}>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
-        name={\\"type\\"}
-        required={true}
+        name={\\"sharedProp\\"}
+        required={false}
         schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeA\\"] }}
+        schema={{ type: \\"string\\" }}
       ></SchemaItem>
       <SchemaItem
         collapsible={false}
@@ -1095,12 +1242,41 @@ Array [
       ></SchemaItem>
     </TabItem>
     <TabItem label={\\"MOD2\\"} value={\\"1-item-properties\\"}>
+      <div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
+        <div>
+          <span className={\\"openapi-schema__container\\"}>
+            <strong
+              className={\\"openapi-discriminator__name openapi-schema__property\\"}
+            >
+              type
+            </strong>
+            <span className={\\"openapi-schema__name\\"}>string</span>
+            <span className={\\"openapi-schema__required\\"}>
+              <Translate id=\\"theme.openapi.schemaItem.required\\">
+                required
+              </Translate>
+            </span>
+          </span>
+          <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
+            <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeA
+              </div>
+            </TabItem>
+            <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
+              <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
+                #/definitions/TypeB
+              </div>
+            </TabItem>
+          </DiscriminatorTabs>
+        </div>
+      </div>
       <SchemaItem
         collapsible={false}
-        name={\\"type\\"}
-        required={true}
+        name={\\"sharedProp\\"}
+        required={false}
         schemaName={\\"string\\"}
-        schema={{ type: \\"string\\", enum: [\\"typeB\\"] }}
+        schema={{ type: \\"string\\" }}
       ></SchemaItem>
       <SchemaItem
         collapsible={false}
@@ -1112,39 +1288,6 @@ Array [
     </TabItem>
   </SchemaTabs>
 </div>;
-",
-  "<div className={\\"openapi-discriminator__item openapi-schema__list-item\\"}>
-  <div>
-    <span className={\\"openapi-schema__container\\"}>
-      <strong
-        className={\\"openapi-discriminator__name openapi-schema__property\\"}
-      >
-        type
-      </strong>
-      <span className={\\"openapi-schema__name\\"}>string</span>
-    </span>
-    <DiscriminatorTabs className={\\"openapi-tabs__discriminator\\"}>
-      <TabItem label={\\"typeA\\"} value={\\"0-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeA
-        </div>
-      </TabItem>
-      <TabItem label={\\"typeB\\"} value={\\"1-item-discriminator\\"}>
-        <div style={{ marginTop: \\".5rem\\", marginBottom: \\".5rem\\" }}>
-          #/definitions/TypeB
-        </div>
-      </TabItem>
-    </DiscriminatorTabs>
-  </div>
-</div>;
-",
-  "<SchemaItem
-  collapsible={false}
-  name={\\"sharedProp\\"}
-  required={false}
-  schemaName={\\"string\\"}
-  schema={{ type: \\"string\\" }}
-></SchemaItem>;
 ",
 ]
 `;

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -487,6 +487,54 @@ describe("createNodes", () => {
     //   ).toMatchSnapshot();
     // });
 
+    // Regression test for https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1218
+    // When an array's `items.allOf` combines a base object with a `oneOf` of
+    // subtypes, the merged items schema has both `properties` (from the base)
+    // and `oneOf` (from the override). Prior to the fix, both were rendered,
+    // duplicating the shared base properties.
+    it("should not duplicate shared item properties when items.allOf combines base + oneOf (#1218)", async () => {
+      const schema: SchemaObject = {
+        type: "object",
+        properties: {
+          features: {
+            type: "array",
+            items: {
+              allOf: [
+                {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    type: { type: "string", enum: ["Feature"] },
+                  },
+                  required: ["type"],
+                },
+                {
+                  oneOf: [
+                    {
+                      type: "object",
+                      properties: { customA: { type: "string" } },
+                    },
+                    {
+                      type: "object",
+                      properties: { customB: { type: "number" } },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
     it("should correctly deep merge properties in allOf schemas", async () => {
       const schema: SchemaObject = {
         allOf: [

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -36,6 +36,33 @@ export function mergeAllOf(allOf: SchemaObject) {
 }
 
 /**
+ * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge, so each
+ * branch is self-contained. Mirrors Redoc's `SchemaModel.initOneOf` behavior.
+ * Without this, when an `allOf` override redefines a nested property with
+ * `oneOf`, the merged schema ends up with both `properties` and `oneOf` as
+ * siblings — and the renderer prints the shared properties twice.
+ *
+ * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1218
+ */
+function foldSiblingsIntoBranches(schema: SchemaObject): SchemaObject {
+  const branchKey = schema.oneOf ? "oneOf" : schema.anyOf ? "anyOf" : undefined;
+  if (!branchKey) return schema;
+
+  const branches = (schema as any)[branchKey];
+  if (!Array.isArray(branches) || branches.length === 0) return schema;
+
+  const siblings: SchemaObject = { ...schema };
+  delete (siblings as any)[branchKey];
+  if (Object.keys(siblings).length === 0) return schema;
+
+  const folded = branches.map((branch: SchemaObject) =>
+    mergeAllOf({ allOf: [siblings, branch] } as SchemaObject)
+  );
+
+  return { [branchKey]: folded } as SchemaObject;
+}
+
+/**
  * For handling nested anyOf/oneOf.
  */
 function createAnyOneOf(schema: SchemaObject): any {
@@ -249,7 +276,8 @@ function createItems(schema: SchemaObject) {
     // TODO: figure out if and how we should pass merged required array
     const mergedSchemas = mergeAllOf(schema.items) as SchemaObject;
 
-    // Handles combo anyOf/oneOf + properties
+    // Handles combo anyOf/oneOf + properties — fold siblings into branches
+    // to avoid duplicate property rendering. See issue #1218.
     if (
       (mergedSchemas.oneOf !== undefined ||
         mergedSchemas.anyOf !== undefined) &&
@@ -257,8 +285,7 @@ function createItems(schema: SchemaObject) {
     ) {
       return [
         createOpeningArrayBracket(),
-        createAnyOneOf(mergedSchemas),
-        createProperties(mergedSchemas),
+        createAnyOneOf(foldSiblingsIntoBranches(mergedSchemas)),
         createClosingArrayBracket(),
       ].flat();
     }
@@ -748,12 +775,20 @@ export function createNodes(
   //   return createDiscriminator(schema);
   // }
 
-  if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
-    nodes.push(createAnyOneOf(schema));
-  }
+  if (
+    (schema.oneOf !== undefined || schema.anyOf !== undefined) &&
+    schema.properties !== undefined
+  ) {
+    // Fold siblings into branches to avoid duplicate properties — see issue #1218
+    nodes.push(createAnyOneOf(foldSiblingsIntoBranches(schema)));
+  } else {
+    if (schema.oneOf !== undefined || schema.anyOf !== undefined) {
+      nodes.push(createAnyOneOf(schema));
+    }
 
-  if (schema.properties !== undefined) {
-    nodes.push(createProperties(schema));
+    if (schema.properties !== undefined) {
+      nodes.push(createProperties(schema));
+    }
   }
 
   if (schema.additionalProperties !== undefined) {
@@ -769,14 +804,23 @@ export function createNodes(
     const mergedSchemas = mergeAllOf(schema) as SchemaObject;
 
     if (
-      mergedSchemas.oneOf !== undefined ||
-      mergedSchemas.anyOf !== undefined
+      (mergedSchemas.oneOf !== undefined ||
+        mergedSchemas.anyOf !== undefined) &&
+      mergedSchemas.properties !== undefined
     ) {
-      nodes.push(createAnyOneOf(mergedSchemas));
-    }
+      // Fold siblings into branches to avoid duplicate properties — see issue #1218
+      nodes.push(createAnyOneOf(foldSiblingsIntoBranches(mergedSchemas)));
+    } else {
+      if (
+        mergedSchemas.oneOf !== undefined ||
+        mergedSchemas.anyOf !== undefined
+      ) {
+        nodes.push(createAnyOneOf(mergedSchemas));
+      }
 
-    if (mergedSchemas.properties !== undefined) {
-      nodes.push(createProperties(mergedSchemas));
+      if (mergedSchemas.properties !== undefined) {
+        nodes.push(createProperties(mergedSchemas));
+      }
     }
   }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -45,6 +45,37 @@ const mergeAllOf = (allOf: any) => {
 };
 
 /**
+ * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge, so each
+ * branch is self-contained. Mirrors Redoc's `SchemaModel.initOneOf` behavior.
+ * Without this, when an `allOf` override redefines a nested property with
+ * `oneOf`, the merged schema ends up with both `properties` and `oneOf` as
+ * siblings — and the renderer prints the shared properties twice.
+ *
+ * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1218
+ */
+const foldSiblingsIntoBranches = (schema: any): any => {
+  const branchKey = schema?.oneOf
+    ? "oneOf"
+    : schema?.anyOf
+      ? "anyOf"
+      : undefined;
+  if (!branchKey) return schema;
+
+  const branches = schema[branchKey];
+  if (!Array.isArray(branches) || branches.length === 0) return schema;
+
+  const siblings = { ...schema };
+  delete siblings[branchKey];
+  if (Object.keys(siblings).length === 0) return schema;
+
+  const folded = branches.map((branch: any) =>
+    mergeAllOf({ allOf: [siblings, branch] })
+  );
+
+  return { [branchKey]: folded };
+};
+
+/**
  * Recursively searches for a property in a schema, including nested
  * oneOf, anyOf, and allOf structures. This is needed for discriminators
  * where the property definition may be in a nested schema.
@@ -737,17 +768,25 @@ const Items: React.FC<{
   const itemsSchemaPath = schemaPath ? `${schemaPath}.items` : undefined;
 
   if (hasOneOfAnyOf || hasProperties || hasAdditionalProperties) {
+    // Fold sibling properties into each oneOf/anyOf branch to avoid duplicate
+    // property rendering. See issue #1218.
+    const renderSchema =
+      hasOneOfAnyOf && hasProperties
+        ? foldSiblingsIntoBranches(itemsSchema)
+        : itemsSchema;
+    const renderHasProperties =
+      hasOneOfAnyOf && hasProperties ? false : hasProperties;
     return (
       <>
         <OpeningArrayBracket />
         {hasOneOfAnyOf && (
           <AnyOneOf
-            schema={itemsSchema}
+            schema={renderSchema}
             schemaType={schemaType}
             schemaPath={itemsSchemaPath}
           />
         )}
-        {hasProperties && (
+        {renderHasProperties && (
           <Properties
             schema={itemsSchema}
             schemaType={schemaType}
@@ -1032,23 +1071,31 @@ function renderChildren(
   schemaType: "request" | "response",
   schemaPath?: string
 ) {
+  // Fold sibling properties into each oneOf/anyOf branch to avoid duplicate
+  // property rendering. See issue #1218.
+  const hasOneOfAnyOf = !!(schema.oneOf || schema.anyOf);
+  const hasProperties = !!schema.properties;
+  const folded =
+    hasOneOfAnyOf && hasProperties ? foldSiblingsIntoBranches(schema) : schema;
+  const renderProperties =
+    hasOneOfAnyOf && hasProperties ? false : hasProperties;
   return (
     <>
-      {schema.oneOf && (
+      {folded.oneOf && (
         <AnyOneOf
-          schema={schema}
+          schema={folded}
           schemaType={schemaType}
           schemaPath={schemaPath}
         />
       )}
-      {schema.anyOf && (
+      {folded.anyOf && (
         <AnyOneOf
-          schema={schema}
+          schema={folded}
           schemaType={schemaType}
           schemaPath={schemaPath}
         />
       )}
-      {schema.properties && (
+      {renderProperties && (
         <Properties
           schema={schema}
           schemaType={schemaType}
@@ -1172,23 +1219,34 @@ const SchemaNode: React.FC<SchemaProps> = ({
       return null;
     }
 
+    // Fold sibling properties into each oneOf/anyOf branch to avoid duplicate
+    // property rendering. See issue #1218.
+    const hasOneOfAnyOf = !!(mergedSchemas.oneOf || mergedSchemas.anyOf);
+    const hasProperties = !!mergedSchemas.properties;
+    const folded =
+      hasOneOfAnyOf && hasProperties
+        ? foldSiblingsIntoBranches(mergedSchemas)
+        : mergedSchemas;
+    const renderProperties =
+      hasOneOfAnyOf && hasProperties ? false : hasProperties;
+
     return (
       <div>
-        {mergedSchemas.oneOf && (
+        {folded.oneOf && (
           <AnyOneOf
-            schema={mergedSchemas}
+            schema={folded}
             schemaType={schemaType}
             schemaPath={schemaPath}
           />
         )}
-        {mergedSchemas.anyOf && (
+        {folded.anyOf && (
           <AnyOneOf
-            schema={mergedSchemas}
+            schema={folded}
             schemaType={schemaType}
             schemaPath={schemaPath}
           />
         )}
-        {mergedSchemas.properties && (
+        {renderProperties && (
           <Properties
             schema={mergedSchemas}
             schemaType={schemaType}


### PR DESCRIPTION
## Summary
- Fixes #1218 — when an `allOf` branch overrides a nested array's `items` with `oneOf`, shared base properties were rendered twice (once at the array-item level, once inside each oneOf branch).
- Adds `foldSiblingsIntoBranches()` in `createSchema.ts` that mirrors Redoc's `SchemaModel.initOneOf`: when sibling fields appear alongside `oneOf`/`anyOf`, fold them into each branch via allOf-merge so each branch is self-contained, then render only the branches.
- Applied at three combo-render sites: `items.allOf` merge path, top-level `oneOf`+`properties` path, and top-level `allOf` merge path.

## Behavior change
Existing schemas that combine `oneOf`/`anyOf` with sibling properties (via `allOf` or directly) will now render the sibling properties inside each branch tab instead of separately below the tabs. This is the semantically correct interpretation (the constraints apply to every variant) and matches Redoc's output. 9 existing snapshots updated to reflect this — see the `__snapshots__` diff.

## Test plan
- [x] New unit regression test: `should not duplicate shared item properties when items.allOf combines base + oneOf (#1218)`
- [x] All 32 `createSchema.test.ts` cases pass
- [x] New demo fixture at `demo/examples/tests/allOf.yaml` → `/allof-array-items-oneof-override` (GeoJSON-style `FeatureCollectionBase`/`PointFeature`/`PolygonFeature`/`CustomFeatureCollection`) generates cleanly via `yarn workspace demo gen-api-docs tests`
- [ ] Visually verify the new fixture page in the demo via `yarn start`
- [ ] Spot-check existing pages that exercise `allOf` + `oneOf` + shared properties (e.g., discriminator examples, allof-multiple-oneof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)