### PR TITLE
fix(theme): preserve large integer precision in response panel (#1208)

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -22,6 +22,57 @@ import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
 
 import { clearResponse, clearCode, clearHeaders } from "./slice";
 
+// Pretty-print a JSON string by re-indenting structural tokens only.
+// Numbers pass through verbatim, so values beyond Number.MAX_SAFE_INTEGER
+// (e.g. 19-digit IDs) keep their exact digits. Issue #1208.
+function prettyPrintJson(raw: string, indent = 2): string {
+  const pad = " ".repeat(indent);
+  let out = "";
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+
+    if (inString) {
+      out += ch;
+      if (escape) escape = false;
+      else if (ch === "\\") escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") continue;
+
+    if (ch === '"') {
+      out += ch;
+      inString = true;
+    } else if (ch === "{" || ch === "[") {
+      let j = i + 1;
+      while (j < raw.length && /\s/.test(raw[j])) j++;
+      if (raw[j] === "}" || raw[j] === "]") {
+        out += ch + raw[j];
+        i = j;
+      } else {
+        depth++;
+        out += ch + "\n" + pad.repeat(depth);
+      }
+    } else if (ch === "}" || ch === "]") {
+      depth--;
+      out += "\n" + pad.repeat(depth) + ch;
+    } else if (ch === ",") {
+      out += ",\n" + pad.repeat(depth);
+    } else if (ch === ":") {
+      out += ": ";
+    } else {
+      out += ch;
+    }
+  }
+
+  return out;
+}
+
 // TODO: We probably shouldn't attempt to format XML...
 function formatXml(xml: string) {
   const tab = "  ";
@@ -70,7 +121,8 @@ function Response({ item }: { item: ApiItem }) {
 
   if (prettyResponse) {
     try {
-      prettyResponse = JSON.stringify(JSON.parse(response), null, 2);
+      JSON.parse(response);
+      prettyResponse = prettyPrintJson(response);
     } catch {
       if (response.startsWith("<")) {
         prettyResponse = formatXml(response);


### PR DESCRIPTION
## Summary

Fixes #1208. The response pretty-printer round-tripped the body through `JSON.parse` / `JSON.stringify`, which silently truncated integers beyond `Number.MAX_SAFE_INTEGER` (e.g. the reported 19-digit ID `1945044589271781376` became `1945044589271781400`).

This PR replaces the round trip with a small string-level pretty-printer that re-indents structural tokens only — number literals pass through verbatim, so any precision the upstream service emitted is preserved exactly. `JSON.parse` is kept solely as a validity check so malformed bodies still fall through to the XML / raw branch.

- No new dependencies, no bundle-size impact.
- Single file changed (`packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx`).
- Display-only path — no downstream code consumes the parsed object.

## Test plan

- [ ] `yarn watch` + `yarn start`, navigate to the demo's **httpbin → POST /anything** page.
- [ ] Send body `{"id": 1945044589271781376}` and confirm the response panel shows `"id": 1945044589271781376` (not `…1400`).
- [ ] Send body `{"big": 9999999999999999, "neg": -9007199254740993, "sci": 1.10}` and confirm each value is preserved verbatim.
- [ ] Send a small/normal JSON body and confirm formatting is unchanged.
- [ ] Send a non-JSON / XML response and confirm the XML branch still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)