### PR TITLE
fix(theme): support multiple x-codeSamples per language (#1204)

### DIFF
--- a/demo/docs/vendor-extensions.mdx
+++ b/demo/docs/vendor-extensions.mdx
@@ -22,3 +22,46 @@ The OpenAPI plugin and theme recognize several [vendor extensions](https://swagg
 | `x-enumDescription` / `x-enumDescriptions` | Document individual enum values. |
 
 Other ReDoc extensions such as `x-circular-ref`, `x-code-samples` (deprecated), `x-examples`, `x-ignoredHeaderParameters`, `x-nullable`, `x-servers`, `x-traitTag`, `x-additionalPropertiesName`, and `x-explicitMappingOnly` are detected but ignored when extracting custom extensions.
+
+## `x-codeSamples`
+
+`x-codeSamples` attaches one or more author-written code snippets to an operation. Each entry has a `lang`, an optional `label`, and a `source`. The plugin renders one outer tab per language and one inner tab per sample within that language.
+
+### Multiple samples per language
+
+Authors often want to show several variants of the same language — for example, three Python snippets covering different authentication flows. Provide a distinct `label` on each entry to disambiguate the inner tabs:
+
+```yaml
+x-codeSamples:
+  - lang: Python
+    label: KeyPair Auth
+    source: |
+      # ...
+  - lang: Python
+    label: Basic Auth
+    source: |
+      # ...
+  - lang: Python
+    label: OAuth
+    source: |
+      # ...
+```
+
+If `label` is omitted on entries that share a `lang`, the inner tabs fall back to indexed identifiers (`Python-0`, `Python-1`, …) and will display the bare language name on each tab. Adding a `label` is recommended whenever a language appears more than once.
+
+If two entries share both the same `lang` and the same `label`, the page still renders — a numeric suffix is appended internally to keep tab identifiers unique — but the visible labels will be identical. Use unique labels to avoid reader confusion.
+
+### Hiding generated snippets when custom samples exist
+
+By default, custom `x-codeSamples` and the Postman-generated snippets (HTTP, cURL, language variants, etc.) render side by side inside each language tab. Set `themeConfig.api.hideGeneratedSnippets` to `true` to suppress the generated block on a per-operation, per-language basis whenever `x-codeSamples` are provided for that language:
+
+```ts
+// docusaurus.config.ts
+themeConfig: {
+  api: {
+    hideGeneratedSnippets: true,
+  },
+}
+```
+
+Languages without any custom samples on a given operation continue to show the generated snippets normally. The default is `false`, which preserves existing behavior.

--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -197,7 +197,6 @@ paths:
         - OpenID: []
 
       x-codeSamples:
-        # Single sample, no label (existing case — fallback id is "C#-0")
         - lang: "C#"
           source: |
             PetStore.v1.Pet pet = new PetStore.v1.Pet();
@@ -215,7 +214,6 @@ paths:
               // Something wrong -- check response for errors
               Console.WriteLine(response.getRawResponse());
             }
-        # Single sample, with label (existing case — id is "PHP-Custom")
         - lang: PHP
           label: Custom
           source: |
@@ -228,8 +226,6 @@ paths:
             } catch (UnprocessableEntityException $e) {
                 var_dump($e->getErrors());
             }
-        # Multiple samples for the same language, each with a distinct label
-        # (issue #1204). Inner tabs render as KeyPair Auth / Basic Auth / OAuth.
         - lang: Python
           label: KeyPair Auth
           source: |
@@ -238,7 +234,7 @@ paths:
 
             with open("private_key.pem", "rb") as f:
                 key = load_pem_private_key(f.read(), password=None)
-            token = sign_jwt(key)  # implementation-specific
+            token = sign_jwt(key)
             requests.post(
                 "https://example.com/v1/pet",
                 headers={"Authorization": f"Bearer {token}"},
@@ -266,37 +262,6 @@ paths:
                 "https://example.com/v1/pet",
                 json={"name": "Rex", "photoUrls": []},
             )
-        # Multiple samples for the same language with NO labels
-        # (defensive indexed-id fallback — ids are PowerShell-7 and PowerShell-8).
-        - lang: PowerShell
-          source: |
-            $pet = @{ name = "Rex"; photoUrls = @() } | ConvertTo-Json
-            Invoke-RestMethod -Uri https://example.com/v1/pet -Method Post -Body $pet -ContentType application/json
-        - lang: PowerShell
-          source: |
-            $headers = @{ Authorization = "Bearer $token" }
-            $pet = @{ name = "Rex"; photoUrls = @() } | ConvertTo-Json
-            Invoke-RestMethod -Uri https://example.com/v1/pet -Method Post -Headers $headers -Body $pet -ContentType application/json
-        # Two samples sharing the same lang AND label (author bug — defensive
-        # collision suffix keeps the page rendering instead of crashing).
-        - lang: Java
-          label: Auth
-          source: |
-            // OkHttp + bearer token
-            Request request = new Request.Builder()
-                .url("https://example.com/v1/pet")
-                .header("Authorization", "Bearer " + token)
-                .post(RequestBody.create(json, JSON))
-                .build();
-        - lang: Java
-          label: Auth
-          source: |
-            // HttpClient (JDK 11+) with basic auth
-            HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://example.com/v1/pet"))
-                .header("Authorization", "Basic " + encoded)
-                .POST(BodyPublishers.ofString(json))
-                .build();
       requestBody:
         $ref: "#/components/requestBodies/Pet"
     put:

--- a/demo/examples/petstore.yaml
+++ b/demo/examples/petstore.yaml
@@ -197,6 +197,7 @@ paths:
         - OpenID: []
 
       x-codeSamples:
+        # Single sample, no label (existing case — fallback id is "C#-0")
         - lang: "C#"
           source: |
             PetStore.v1.Pet pet = new PetStore.v1.Pet();
@@ -214,6 +215,7 @@ paths:
               // Something wrong -- check response for errors
               Console.WriteLine(response.getRawResponse());
             }
+        # Single sample, with label (existing case — id is "PHP-Custom")
         - lang: PHP
           label: Custom
           source: |
@@ -226,6 +228,75 @@ paths:
             } catch (UnprocessableEntityException $e) {
                 var_dump($e->getErrors());
             }
+        # Multiple samples for the same language, each with a distinct label
+        # (issue #1204). Inner tabs render as KeyPair Auth / Basic Auth / OAuth.
+        - lang: Python
+          label: KeyPair Auth
+          source: |
+            import requests
+            from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+            with open("private_key.pem", "rb") as f:
+                key = load_pem_private_key(f.read(), password=None)
+            token = sign_jwt(key)  # implementation-specific
+            requests.post(
+                "https://example.com/v1/pet",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"name": "Rex", "photoUrls": []},
+            )
+        - lang: Python
+          label: Basic Auth
+          source: |
+            import requests
+            from requests.auth import HTTPBasicAuth
+
+            requests.post(
+                "https://example.com/v1/pet",
+                auth=HTTPBasicAuth("user", "password"),
+                json={"name": "Rex", "photoUrls": []},
+            )
+        - lang: Python
+          label: OAuth
+          source: |
+            import requests
+            from requests_oauthlib import OAuth2Session
+
+            oauth = OAuth2Session(client_id, token=token)
+            oauth.post(
+                "https://example.com/v1/pet",
+                json={"name": "Rex", "photoUrls": []},
+            )
+        # Multiple samples for the same language with NO labels
+        # (defensive indexed-id fallback — ids are PowerShell-7 and PowerShell-8).
+        - lang: PowerShell
+          source: |
+            $pet = @{ name = "Rex"; photoUrls = @() } | ConvertTo-Json
+            Invoke-RestMethod -Uri https://example.com/v1/pet -Method Post -Body $pet -ContentType application/json
+        - lang: PowerShell
+          source: |
+            $headers = @{ Authorization = "Bearer $token" }
+            $pet = @{ name = "Rex"; photoUrls = @() } | ConvertTo-Json
+            Invoke-RestMethod -Uri https://example.com/v1/pet -Method Post -Headers $headers -Body $pet -ContentType application/json
+        # Two samples sharing the same lang AND label (author bug — defensive
+        # collision suffix keeps the page rendering instead of crashing).
+        - lang: Java
+          label: Auth
+          source: |
+            // OkHttp + bearer token
+            Request request = new Request.Builder()
+                .url("https://example.com/v1/pet")
+                .header("Authorization", "Bearer " + token)
+                .post(RequestBody.create(json, JSON))
+                .build();
+        - lang: Java
+          label: Auth
+          source: |
+            // HttpClient (JDK 11+) with basic auth
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://example.com/v1/pet"))
+                .header("Authorization", "Basic " + encoded)
+                .POST(BodyPublishers.ofString(json))
+                .build();
       requestBody:
         $ref: "#/components/requestBodies/Pet"
     put:

--- a/demo/examples/tests/codeSamples.yaml
+++ b/demo/examples/tests/codeSamples.yaml
@@ -1,0 +1,245 @@
+openapi: 3.0.0
+info:
+  title: x-codeSamples Variations API
+  version: 1.0.0
+  description: |
+    Exercises every supported shape of the `x-codeSamples` vendor extension
+    so each path can be inspected in isolation in the demo.
+
+    Tracks:
+      - https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1204
+      - https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1036
+
+servers:
+  - url: https://api.example.com/v1
+    description: Example API server
+
+tags:
+  - name: codeSamples
+    description: x-codeSamples tests
+
+paths:
+  /no-samples:
+    get:
+      tags:
+        - codeSamples
+      summary: Control — no x-codeSamples
+      description: |
+        Sanity check. Only the Postman-generated language tabs should render;
+        no inner sample tabs.
+      responses:
+        "200":
+          description: OK
+
+  /single-sample-no-label:
+    get:
+      tags:
+        - codeSamples
+      summary: Single sample, no label
+      description: |
+        One C# sample with no `label`. Inner tab id falls back to indexed
+        form (`C#-0`) and the visible tab label is the bare language name.
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: "C#"
+          source: |
+            using System.Net.Http;
+            var client = new HttpClient();
+            var response = await client.GetAsync("https://api.example.com/v1/single-sample-no-label");
+
+  /single-sample-with-label:
+    get:
+      tags:
+        - codeSamples
+      summary: Single sample, with label
+      description: |
+        One PHP sample with `label: Custom`. Inner tab id is `PHP-Custom`
+        and the tab displays "Custom".
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: PHP
+          label: Custom
+          source: |
+            <?php
+            $client = new \GuzzleHttp\Client();
+            $response = $client->get('https://api.example.com/v1/single-sample-with-label');
+
+  /multiple-samples-with-labels:
+    post:
+      tags:
+        - codeSamples
+      summary: Multiple samples per language with distinct labels (#1204)
+      description: |
+        Three Python samples covering three auth flows. Before the fix this
+        crashed with `Duplicate values "Python, Python" found in <Tabs>`.
+        After the fix each renders as its own inner tab labeled by `label`.
+      responses:
+        "200":
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      x-codeSamples:
+        - lang: Python
+          label: KeyPair Auth
+          source: |
+            import requests
+            from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+            with open("private_key.pem", "rb") as f:
+                key = load_pem_private_key(f.read(), password=None)
+            token = sign_jwt(key)
+            requests.post(
+                "https://api.example.com/v1/multiple-samples-with-labels",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"name": "rex"},
+            )
+        - lang: Python
+          label: Basic Auth
+          source: |
+            import requests
+            from requests.auth import HTTPBasicAuth
+
+            requests.post(
+                "https://api.example.com/v1/multiple-samples-with-labels",
+                auth=HTTPBasicAuth("user", "password"),
+                json={"name": "rex"},
+            )
+        - lang: Python
+          label: OAuth
+          source: |
+            from requests_oauthlib import OAuth2Session
+
+            oauth = OAuth2Session(client_id, token=token)
+            oauth.post(
+                "https://api.example.com/v1/multiple-samples-with-labels",
+                json={"name": "rex"},
+            )
+
+  /multiple-samples-no-labels:
+    post:
+      tags:
+        - codeSamples
+      summary: Multiple samples per language, no labels
+      description: |
+        Two PowerShell samples without `label`. Inner tab ids fall back to
+        indexed form (`PowerShell-0`, `PowerShell-1`) so the page renders
+        without crashing — but both tabs display the bare language name,
+        which makes them visually identical. Adding `label` is recommended.
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: PowerShell
+          source: |
+            $body = @{ name = "rex" } | ConvertTo-Json
+            Invoke-RestMethod -Uri https://api.example.com/v1/multiple-samples-no-labels -Method Post -Body $body -ContentType application/json
+        - lang: PowerShell
+          source: |
+            $headers = @{ Authorization = "Bearer $token" }
+            $body = @{ name = "rex" } | ConvertTo-Json
+            Invoke-RestMethod -Uri https://api.example.com/v1/multiple-samples-no-labels -Method Post -Headers $headers -Body $body -ContentType application/json
+
+  /duplicate-label-collision:
+    post:
+      tags:
+        - codeSamples
+      summary: Duplicate lang+label (defensive collision suffix)
+      description: |
+        Two Java samples sharing both `lang: Java` and `label: Auth`. This
+        is an author bug, but the page still renders — a numeric suffix is
+        appended internally to keep the inner tab ids unique. The visible
+        labels remain identical and the author should fix the spec.
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: Java
+          label: Auth
+          source: |
+            // OkHttp + bearer token
+            Request request = new Request.Builder()
+                .url("https://api.example.com/v1/duplicate-label-collision")
+                .header("Authorization", "Bearer " + token)
+                .post(RequestBody.create("{}", JSON))
+                .build();
+        - lang: Java
+          label: Auth
+          source: |
+            // HttpClient (JDK 11+) with basic auth
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.example.com/v1/duplicate-label-collision"))
+                .header("Authorization", "Basic " + encoded)
+                .POST(BodyPublishers.ofString("{}"))
+                .build();
+
+  /mixed-languages:
+    post:
+      tags:
+        - codeSamples
+      summary: Mixed languages, some with multiple samples
+      description: |
+        Realistic mix: two Python entries (with labels), one Ruby (no
+        label), one Go (with label). Exercises the case where switching
+        between outer language tabs must not leak `selectedSample` from
+        another language.
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: Python
+          label: requests
+          source: |
+            import requests
+            requests.post("https://api.example.com/v1/mixed-languages")
+        - lang: Python
+          label: httpx
+          source: |
+            import httpx
+            httpx.post("https://api.example.com/v1/mixed-languages")
+        - lang: Ruby
+          source: |
+            require "net/http"
+            Net::HTTP.post(URI("https://api.example.com/v1/mixed-languages"), "")
+        - lang: Go
+          label: net/http
+          source: |
+            package main
+
+            import (
+              "net/http"
+              "strings"
+            )
+
+            func main() {
+              http.Post("https://api.example.com/v1/mixed-languages", "application/json", strings.NewReader(""))
+            }
+
+  /unmatched-language:
+    get:
+      tags:
+        - codeSamples
+      summary: Sample for a language not in languageTabs
+      description: |
+        A Dart sample is provided, but `Dart` is typically not in the
+        default `languageTabs`. The sample is silently dropped (existing
+        behavior — unchanged by this fix). Only the Postman-generated tabs
+        for configured languages should appear.
+      responses:
+        "200":
+          description: OK
+      x-codeSamples:
+        - lang: Dart
+          label: http
+          source: |
+            import 'package:http/http.dart' as http;
+            await http.get(Uri.parse('https://api.example.com/v1/unmatched-language'));

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -296,7 +296,11 @@ function CodeSnippets({
                   }}
                   includeSample={true}
                   currentLanguage={lang}
-                  defaultValue={selectedSample}
+                  defaultValue={
+                    selectedSample && lang.samples.includes(selectedSample)
+                      ? selectedSample
+                      : lang.samples[0]
+                  }
                   languageSet={mergedLangs}
                   lazy
                 >

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx
@@ -17,6 +17,8 @@ import cloneDeep from "lodash/cloneDeep";
 import codegen from "postman-code-generators";
 import * as sdk from "postman-collection";
 
+import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
+
 import { CodeSample, Language } from "./code-snippets-types";
 import {
   getCodeSampleSourceFromLanguage,
@@ -114,6 +116,10 @@ function CodeSnippets({
     encoding,
   });
 
+  const themeConfig = siteConfig.themeConfig as ThemeConfig;
+  const hideGeneratedSnippets =
+    themeConfig?.api?.hideGeneratedSnippets ?? false;
+
   // User-defined languages array
   // Can override languageSet, change order of langs, override options and variants
   const userDefinedLanguageSet =
@@ -152,6 +158,14 @@ function CodeSnippets({
   const [codeSampleCodeText, setCodeSampleCodeText] = useState<string>(() =>
     getCodeSampleSourceFromLanguage(language)
   );
+
+  // Reset selectedSample whenever the active language changes so the inner
+  // tab strip falls back to its first sample instead of trying to match an
+  // id that belongs to a different language's samples.
+  useEffect(() => {
+    setSelectedSample(language?.samples?.[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language?.language]);
 
   useEffect(() => {
     if (language && !!language.sample) {
@@ -295,7 +309,7 @@ function CodeSnippets({
                             ? lang.samplesLabels[index]
                             : sample
                         }
-                        key={`${lang.language}-${lang.sample}`}
+                        key={`${lang.language}-${sample}`}
                         attributes={{
                           className: `openapi-tabs__code-item--sample`,
                         }}
@@ -315,40 +329,42 @@ function CodeSnippets({
               )}
 
               {/* Inner generated code snippets */}
-              <CodeTabs
-                className="openapi-tabs__code-container-inner"
-                action={{
-                  setLanguage: setLanguage,
-                  setSelectedVariant: setSelectedVariant,
-                }}
-                includeVariant={true}
-                currentLanguage={lang}
-                defaultValue={selectedVariant}
-                languageSet={mergedLangs}
-                lazy
-              >
-                {lang.variants.map((variant, index) => {
-                  return (
-                    <CodeTab
-                      value={variant.toLowerCase()}
-                      label={variant.toUpperCase()}
-                      key={`${lang.language}-${lang.variant}`}
-                      attributes={{
-                        className: `openapi-tabs__code-item--variant`,
-                      }}
-                    >
-                      {/* @ts-ignore */}
-                      <ApiCodeBlock
-                        language={lang.highlight}
-                        className="openapi-explorer__code-block"
-                        showLineNumbers={true}
+              {!(hideGeneratedSnippets && lang.samples?.length) && (
+                <CodeTabs
+                  className="openapi-tabs__code-container-inner"
+                  action={{
+                    setLanguage: setLanguage,
+                    setSelectedVariant: setSelectedVariant,
+                  }}
+                  includeVariant={true}
+                  currentLanguage={lang}
+                  defaultValue={selectedVariant}
+                  languageSet={mergedLangs}
+                  lazy
+                >
+                  {lang.variants.map((variant, index) => {
+                    return (
+                      <CodeTab
+                        value={variant.toLowerCase()}
+                        label={variant.toUpperCase()}
+                        key={`${lang.language}-${variant}`}
+                        attributes={{
+                          className: `openapi-tabs__code-item--variant`,
+                        }}
                       >
-                        {codeText}
-                      </ApiCodeBlock>
-                    </CodeTab>
-                  );
-                })}
-              </CodeTabs>
+                        {/* @ts-ignore */}
+                        <ApiCodeBlock
+                          language={lang.highlight}
+                          className="openapi-explorer__code-block"
+                          showLineNumbers={true}
+                        >
+                          {codeText}
+                        </ApiCodeBlock>
+                      </CodeTab>
+                    );
+                  })}
+                </CodeTabs>
+              )}
             </CodeTab>
           );
         })}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.test.ts
@@ -1,0 +1,109 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { CodeSample, Language } from "./code-snippets-types";
+import { mergeCodeSampleLanguage } from "./languages";
+
+const baseLang = (
+  language: string,
+  codeSampleLanguage: Language["codeSampleLanguage"]
+): Language => ({
+  highlight: language,
+  language,
+  codeSampleLanguage,
+  logoClass: language,
+  variant: "http",
+  variants: ["http"],
+});
+
+describe("mergeCodeSampleLanguage", () => {
+  it("returns the language unchanged when no codeSamples target it", () => {
+    const langs = [baseLang("python", "Python")];
+    const result = mergeCodeSampleLanguage(langs, []);
+    expect(result[0]).toEqual(langs[0]);
+    expect(result[0].samples).toBeUndefined();
+  });
+
+  it("attaches a single sample with no label using an indexed id", () => {
+    const samples: CodeSample[] = [{ lang: "Python", source: "print('hi')" }];
+    const [py] = mergeCodeSampleLanguage(
+      [baseLang("python", "Python")],
+      samples
+    );
+    expect(py.samples).toEqual(["Python-0"]);
+    expect(py.samplesLabels).toEqual(["Python"]);
+    expect(py.samplesSources).toEqual(["print('hi')"]);
+    expect(py.sample).toBe("Python-0");
+  });
+
+  it("attaches a single sample with a label using lang-label id", () => {
+    const samples: CodeSample[] = [
+      { lang: "PHP", label: "Custom", source: "<?php" },
+    ];
+    const [php] = mergeCodeSampleLanguage([baseLang("php", "PHP")], samples);
+    expect(php.samples).toEqual(["PHP-Custom"]);
+    expect(php.samplesLabels).toEqual(["Custom"]);
+  });
+
+  it("produces unique ids for multiple samples sharing a lang with distinct labels (#1204)", () => {
+    const samples: CodeSample[] = [
+      { lang: "Python", label: "KeyPair Auth", source: "a" },
+      { lang: "Python", label: "Basic Auth", source: "b" },
+      { lang: "Python", label: "OAuth", source: "c" },
+    ];
+    const [py] = mergeCodeSampleLanguage(
+      [baseLang("python", "Python")],
+      samples
+    );
+    expect(py.samples).toEqual([
+      "Python-KeyPair Auth",
+      "Python-Basic Auth",
+      "Python-OAuth",
+    ]);
+    expect(new Set(py.samples).size).toBe(3);
+    expect(py.samplesLabels).toEqual(["KeyPair Auth", "Basic Auth", "OAuth"]);
+    expect(py.samplesSources).toEqual(["a", "b", "c"]);
+  });
+
+  it("produces unique indexed ids for multiple samples sharing a lang without labels", () => {
+    const samples: CodeSample[] = [
+      { lang: "PowerShell", source: "x" },
+      { lang: "PowerShell", source: "y" },
+    ];
+    const [ps] = mergeCodeSampleLanguage(
+      [baseLang("powershell", "PowerShell")],
+      samples
+    );
+    expect(ps.samples).toEqual(["PowerShell-0", "PowerShell-1"]);
+    expect(new Set(ps.samples).size).toBe(2);
+    expect(ps.samplesLabels).toEqual(["PowerShell", "PowerShell"]);
+  });
+
+  it("defensively suffixes ids when lang+label collides", () => {
+    const samples: CodeSample[] = [
+      { lang: "Java", label: "Auth", source: "a" },
+      { lang: "Java", label: "Auth", source: "b" },
+    ];
+    const [java] = mergeCodeSampleLanguage([baseLang("java", "Java")], samples);
+    expect(java.samples).toEqual(["Java-Auth", "Java-Auth-1"]);
+    expect(new Set(java.samples).size).toBe(2);
+    expect(java.samplesLabels).toEqual(["Auth", "Auth"]);
+  });
+
+  it("filters codeSamples by codeSampleLanguage and leaves other languages alone", () => {
+    const samples: CodeSample[] = [
+      { lang: "Python", label: "A", source: "a" },
+      { lang: "Java", label: "B", source: "b" },
+    ];
+    const result = mergeCodeSampleLanguage(
+      [baseLang("python", "Python"), baseLang("php", "PHP")],
+      samples
+    );
+    expect(result[0].samples).toEqual(["Python-A"]);
+    expect(result[1].samples).toBeUndefined();
+  });
+});

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
@@ -22,11 +22,23 @@ export function mergeCodeSampleLanguage(
     );
 
     if (languageCodeSamples.length) {
-      const samples = languageCodeSamples.map(({ lang }) => lang);
       const samplesLabels = languageCodeSamples.map(
         ({ label, lang }) => label || lang
       );
       const samplesSources = languageCodeSamples.map(({ source }) => source);
+
+      // Build a unique id per sample for use as the inner Tab's `value`.
+      // Prefer `${lang}-${label}`; fall back to `${lang}-${index}` when no
+      // label is provided. Defensively suffix with `-${index}` on collision
+      // so duplicate-label specs render two visually identical tabs instead
+      // of crashing Docusaurus's unique-value check.
+      const seen = new Set<string>();
+      const samples = languageCodeSamples.map((cs, i) => {
+        const base = cs.label ? `${cs.lang}-${cs.label}` : `${cs.lang}-${i}`;
+        const id = seen.has(base) ? `${base}-${i}` : base;
+        seen.add(id);
+        return id;
+      });
 
       return {
         ...language,

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -42,15 +42,6 @@ export interface ThemeConfig {
      * `{ default: 1 }` alone to auto-expand the first level on every page
      * without rendering the depth control.
      */
-    /**
-     * When `true`, suppresses Postman-generated code snippets (HTTP, cURL,
-     * language variants, etc.) on a per-operation, per-language basis whenever
-     * `x-codeSamples` are provided for that language on that operation.
-     * Languages without custom samples render generated snippets normally.
-     * Defaults to `false` (both custom and generated snippets render side by
-     * side, preserving existing behavior).
-     */
-    hideGeneratedSnippets?: boolean;
     schemaExpansion?: {
       /** Render an interactive depth control next to each schema header so readers can change the depth at view time. Defaults to `false`. */
       enabled?: boolean;
@@ -61,6 +52,15 @@ export interface ThemeConfig {
       /** Persist the reader's selected depth in `localStorage`. Only meaningful when `enabled` is `true`; defaults to `true` in that case. */
       persist?: boolean;
     };
+    /**
+     * When `true`, suppresses Postman-generated code snippets (HTTP, cURL,
+     * language variants, etc.) on a per-operation, per-language basis whenever
+     * `x-codeSamples` are provided for that language on that operation.
+     * Languages without custom samples render generated snippets normally.
+     * Defaults to `false` (both custom and generated snippets render side by
+     * side, preserving existing behavior).
+     */
+    hideGeneratedSnippets?: boolean;
   };
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/types.d.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/types.d.ts
@@ -42,6 +42,15 @@ export interface ThemeConfig {
      * `{ default: 1 }` alone to auto-expand the first level on every page
      * without rendering the depth control.
      */
+    /**
+     * When `true`, suppresses Postman-generated code snippets (HTTP, cURL,
+     * language variants, etc.) on a per-operation, per-language basis whenever
+     * `x-codeSamples` are provided for that language on that operation.
+     * Languages without custom samples render generated snippets normally.
+     * Defaults to `false` (both custom and generated snippets render side by
+     * side, preserving existing behavior).
+     */
+    hideGeneratedSnippets?: boolean;
     schemaExpansion?: {
       /** Render an interactive depth control next to each schema header so readers can change the depth at view time. Defaults to `false`. */
       enabled?: boolean;


### PR DESCRIPTION
## Summary

- Allow multiple `x-codeSamples` entries that share a `lang` to render as distinct inner tabs disambiguated by their `label`. Previously this crashed with `Docusaurus error: Duplicate values "Python, Python" found in <Tabs>` (issue #1204).
- Fix two stale React-key bugs in `CodeSnippets/index.tsx` that used the singular `lang.sample` / `lang.variant` defaults inside `.map` iterations, plus seed `selectedSample` on language change so the inner tab strip resolves correctly when switching outer tabs.
- Add opt-in `themeConfig.api.hideGeneratedSnippets` (default `false`) to suppress Postman-generated snippets per-operation, per-language whenever `x-codeSamples` are provided. Closes #1036 for users who opt in.

## Behavior

| Scenario | Before | After |
|---|---|---|
| No `x-codeSamples` | Generated only | Generated only (unchanged) |
| One `x-codeSamples` per lang | Custom + generated tabs both render | Same — unchanged when flag is `false` (default) |
| Multiple `x-codeSamples` per lang | Page crashes with duplicate-value error | Each renders as its own tab, labeled by `label` |
| `hideGeneratedSnippets: true` + custom samples for a lang | n/a | Generated block hidden for that language only |

The `samples` array now stores synthetic ids (`${lang}-${label}` or `${lang}-${index}`) instead of bare `lang` strings. These ids are internal — used as Tab `value`, React `key`, and the lookup key for `samplesSources`. User-visible labels still come from `samplesLabels`. Duplicate `lang`+`label` entries in a spec receive a defensive numeric suffix so the page renders instead of crashing (the visible labels remain identical — author's bug to fix, but no hard failure).

## Files

- `packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts` — unique sample id generation with collision suffix
- `packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/index.tsx` — key bug fixes, `selectedSample` reset, conditional generated block
- `packages/docusaurus-theme-openapi-docs/src/types.d.ts` — new `themeConfig.api.hideGeneratedSnippets` field
- `packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.test.ts` — new unit suite (7 tests)
- `demo/examples/petstore.yaml` — fixture exercising all five paths (single no-label, single with-label, multi with distinct labels, multi without labels, duplicate-label collision)
- `demo/docs/vendor-extensions.mdx` — documentation for multi-sample usage and the new flag

## Test plan

- [x] `yarn jest packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.test.ts` — 7/7 pass
- [x] `tsc --noEmit` on the theme package — clean
- [ ] Run the demo (`yarn workspace demo start`) and verify on the addPet operation:
  - [ ] Outer Python tab shows three inner tabs (KeyPair Auth / Basic Auth / OAuth) and switching between them swaps the source
  - [ ] Outer PowerShell tab shows two inner tabs (no labels) without crashing
  - [ ] Outer Java tab shows two `Auth` tabs (defensive collision case) without crashing
  - [ ] C# and PHP single-sample cases unchanged
  - [ ] With `themeConfig.api.hideGeneratedSnippets: true`, the HTTP/REQUESTS/etc. block disappears for Python/PowerShell/Java/PHP/C# but remains for languages without custom samples (e.g. cURL)

## Related issues

- Closes #1204
- Closes #1036 (opt-in via the new flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)