### PR TITLE
fix: render allOf schemas with additionalProperties:false on every member (#1119)

### DIFF
--- a/demo/examples/tests/allOf.yaml
+++ b/demo/examples/tests/allOf.yaml
@@ -776,6 +776,97 @@ paths:
               schema:
                 $ref: "#/components/schemas/CustomFeatureCollection"
 
+  /allof-strict-additional-properties:
+    get:
+      tags:
+        - allOf
+      summary: allOf with additionalProperties false on every member
+      description: |
+        NSwag and Swashbuckle emit `additionalProperties: false` on every
+        object schema by default. Combined with `allOf` composition this
+        defines a JSON-Schema-unsatisfiable shape (each member rejects the
+        other's properties as "additional"), and strict allof-merge
+        implementations collapse the result to no properties — leaving the
+        rendered schema blank.
+
+        Regression coverage for
+        https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119:
+        the docs renderer should union the properties across siblings the
+        same way Redoc and Swagger UI do.
+
+        Schema:
+        ```yaml
+        allOf:
+          - type: object
+            additionalProperties: false
+            properties:
+              ContinuationToken: { type: string, nullable: true }
+            title: ResponseBase
+          - type: object
+            additionalProperties: false
+            properties:
+              Items:
+                type: array
+                items:
+                  allOf:
+                    - type: object
+                      additionalProperties: false
+                      properties:
+                        Guid: { type: string, format: uuid }
+                        Revision: { type: integer, format: int64 }
+                    - type: object
+                      additionalProperties: false
+                      required: [Name]
+                      properties:
+                        Name: { type: string, nullable: true }
+                        Code: { type: string, nullable: true }
+            title: ItemsWrap
+        ```
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    additionalProperties: false
+                    properties:
+                      ContinuationToken:
+                        type: string
+                        nullable: true
+                    title: ResponseBase
+                  - type: object
+                    additionalProperties: false
+                    properties:
+                      Items:
+                        type: array
+                        nullable: true
+                        items:
+                          allOf:
+                            - type: object
+                              additionalProperties: false
+                              properties:
+                                Guid:
+                                  type: string
+                                  format: uuid
+                                Revision:
+                                  type: integer
+                                  format: int64
+                            - type: object
+                              additionalProperties: false
+                              required: [Name]
+                              properties:
+                                Name:
+                                  type: string
+                                  nullable: true
+                                Code:
+                                  type: string
+                                  nullable: true
+                          title: ResponseItem
+                    title: ItemsWrap
+                title: ActivitiesResponse
+
 components:
   schemas:
     # Enum schemas for allOf parameter tests

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap
@@ -399,6 +399,19 @@ Array [
 ]
 `;
 
+exports[`createNodes allOf should preserve additionalProperties:false on single-member allOf 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"onlyProp\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
 exports[`createNodes allOf should render same-level properties with allOf 1`] = `
 Array [
   "<SchemaItem
@@ -447,6 +460,64 @@ Array [
   required={false}
   schemaName={\\"string\\"}
   schema={{ type: \\"string\\" }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes allOf should union properties across allOf members that all set additionalProperties:false 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"ContinuationToken\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  schema={{ type: \\"string\\", nullable: true }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"Items\\"}
+  required={false}
+  schemaName={\\"string[]\\"}
+  schema={{ type: \\"array\\", items: { type: \\"string\\" }, nullable: true }}
+></SchemaItem>;
+",
+]
+`;
+
+exports[`createNodes allOf should union properties when only some allOf members set additionalProperties:false 1`] = `
+Array [
+  "<SchemaItem
+  collapsible={false}
+  name={\\"Guid\\"}
+  required={false}
+  schemaName={\\"string<guid>\\"}
+  schema={{ type: \\"string\\", format: \\"guid\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"Revision\\"}
+  required={false}
+  schemaName={\\"integer<int64>\\"}
+  schema={{ type: \\"integer\\", format: \\"int64\\" }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"Name\\"}
+  required={true}
+  schemaName={\\"string\\"}
+  schema={{ type: \\"string\\", nullable: true }}
+></SchemaItem>;
+",
+  "<SchemaItem
+  collapsible={false}
+  name={\\"Code\\"}
+  required={false}
+  schemaName={\\"string\\"}
+  schema={{ type: \\"string\\", nullable: true }}
 ></SchemaItem>;
 ",
 ]

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts
@@ -610,6 +610,109 @@ describe("createNodes", () => {
     //     )
     //   ).toMatchSnapshot();
     // });
+
+    // Regression coverage for issue #1119: NSwag/Swashbuckle emit allOf members
+    // with `additionalProperties: false` on every model. Strict allof-merge
+    // semantics treat that as an unsatisfiable constraint and drop the unioned
+    // properties, leaving the rendered schema blank. We strip the flag from
+    // multi-member allOf siblings to match Redoc/Swagger UI behavior.
+    // https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
+    it("should union properties across allOf members that all set additionalProperties:false", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              ContinuationToken: { type: "string", nullable: true },
+            },
+            title: "ResponseBase",
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              Items: {
+                type: "array",
+                items: { type: "string" },
+                nullable: true,
+              },
+            },
+            title: "ItemsWrap",
+          },
+        ],
+        title: "ActivitiesResponse",
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    // Asymmetric variant: only one sibling is strict, but its property set is
+    // disjoint from the other — also collapses without the strip. Mirrors the
+    // inner `Items.items` allOf in the issue 1119 spec.
+    it("should union properties when only some allOf members set additionalProperties:false", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              Guid: { type: "string", format: "guid" },
+              Revision: { type: "integer", format: "int64" },
+            },
+            title: "SystemFields",
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              Name: { type: "string", nullable: true },
+              Code: { type: "string", nullable: true },
+            },
+            required: ["Name"],
+            title: "ConcreteFields",
+          },
+        ],
+        title: "ActivitiesResponseItem",
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
+
+    // Negative case: a single-member allOf with additionalProperties:false is
+    // valid (nothing to conflict with) and must be left untouched.
+    it("should preserve additionalProperties:false on single-member allOf", async () => {
+      const schema: SchemaObject = {
+        allOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              onlyProp: { type: "string" },
+            },
+          },
+        ],
+      };
+
+      expect(
+        await Promise.all(
+          createNodes(schema, "response").map(
+            async (md: any) => await prettier.format(md, { parser: "babel" })
+          )
+        )
+      ).toMatchSnapshot();
+    });
   });
 
   describe("discriminator", () => {

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -24,6 +24,63 @@ import { SchemaObject } from "../openapi/types";
 let SCHEMA_TYPE: "request" | "response";
 
 /**
+ * Strip `additionalProperties: false` from sibling allOf members so the
+ * strict-AND semantics of `allof-merge` don't collapse the result to an
+ * unsatisfiable empty schema.
+ *
+ * Per JSON Schema, two allOf members that each set `additionalProperties: false`
+ * with disjoint `properties` sets define an unsatisfiable schema (no value can
+ * satisfy both — each member rejects the other's properties). `allof-merge` is
+ * technically correct to drop all properties in that case, but it leaves the
+ * rendered schema blank.
+ *
+ * NSwag and Swashbuckle emit this pattern by default whenever a model uses
+ * inheritance/composition, so it's the dominant style for .NET-generated specs.
+ * Redoc, Swagger UI, and Stoplight all union the properties and ignore the
+ * conflicting flag — the approach this helper emulates by stripping the flag
+ * before delegating to `allof-merge`. The flag is render-irrelevant anyway:
+ * `additionalProperties: false` is treated identically to `undefined` by the
+ * renderer (see AdditionalProperties in theme/Schema/index.tsx).
+ *
+ * Strips from every allOf member whenever the parent has ≥2 members. The
+ * collapse triggers symmetrically (both siblings strict) or asymmetrically
+ * (one strict member rejects another's properties as "additional"), so the
+ * presence of multiple members is the right gate. Single-member allOf is left
+ * alone — it can't conflict with anything.
+ *
+ * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
+ */
+function stripConflictingAdditionalProps(node: any): any {
+  if (Array.isArray(node)) return node.map(stripConflictingAdditionalProps);
+  if (!node || typeof node !== "object") return node;
+
+  let working: any = node;
+  if (Array.isArray(node.allOf) && node.allOf.length > 1) {
+    const hasStrictMember = node.allOf.some(
+      (m: any) => m && m.additionalProperties === false
+    );
+    if (hasStrictMember) {
+      working = {
+        ...node,
+        allOf: node.allOf.map((m: any) => {
+          if (m && m.additionalProperties === false) {
+            const { additionalProperties: _drop, ...rest } = m;
+            return rest;
+          }
+          return m;
+        }),
+      };
+    }
+  }
+
+  const result: any = {};
+  for (const [k, v] of Object.entries(working)) {
+    result[k] = stripConflictingAdditionalProps(v);
+  }
+  return result;
+}
+
+/**
  * Returns a merged representation of allOf array of schemas.
  */
 export function mergeAllOf(allOf: SchemaObject) {
@@ -31,7 +88,9 @@ export function mergeAllOf(allOf: SchemaObject) {
     console.warn(msg);
   };
 
-  const mergedSchemas = merge(allOf, { onMergeError }) as SchemaObject;
+  const mergedSchemas = merge(stripConflictingAdditionalProps(allOf), {
+    onMergeError,
+  }) as SchemaObject;
   return mergedSchemas ?? ({} as SchemaObject);
 }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -34,12 +34,72 @@ import type { SchemaObject } from "../../types.d";
 // eslint-disable-next-line import/no-extraneous-dependencies
 // const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
 
+/**
+ * Strip `additionalProperties: false` from sibling allOf members so the
+ * strict-AND semantics of `allof-merge` don't collapse the result to an
+ * unsatisfiable empty schema.
+ *
+ * Per JSON Schema, two allOf members that each set `additionalProperties: false`
+ * with disjoint `properties` sets define an unsatisfiable schema (no value can
+ * satisfy both — each member rejects the other's properties). `allof-merge` is
+ * technically correct to drop all properties in that case, but it leaves the
+ * rendered schema blank.
+ *
+ * NSwag and Swashbuckle emit this pattern by default whenever a model uses
+ * inheritance/composition, so it's the dominant style for .NET-generated specs.
+ * Redoc, Swagger UI, and Stoplight all union the properties and ignore the
+ * conflicting flag — the approach this helper emulates by stripping the flag
+ * before delegating to `allof-merge`. The flag is render-irrelevant anyway:
+ * `additionalProperties: false` is treated identically to `undefined` by the
+ * AdditionalProperties component below (line ~641).
+ *
+ * Strips from every allOf member whenever the parent has ≥2 members. The
+ * collapse triggers symmetrically (both siblings strict) or asymmetrically
+ * (one strict member rejects another's properties as "additional"), so the
+ * presence of multiple members is the right gate. Single-member allOf is left
+ * alone — it can't conflict with anything.
+ *
+ * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
+ * Mirrored in plugin: docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+ */
+const stripConflictingAdditionalProps = (node: any): any => {
+  if (Array.isArray(node)) return node.map(stripConflictingAdditionalProps);
+  if (!node || typeof node !== "object") return node;
+
+  let working: any = node;
+  if (Array.isArray(node.allOf) && node.allOf.length > 1) {
+    const hasStrictMember = node.allOf.some(
+      (m: any) => m && m.additionalProperties === false
+    );
+    if (hasStrictMember) {
+      working = {
+        ...node,
+        allOf: node.allOf.map((m: any) => {
+          if (m && m.additionalProperties === false) {
+            const { additionalProperties: _drop, ...rest } = m;
+            return rest;
+          }
+          return m;
+        }),
+      };
+    }
+  }
+
+  const result: any = {};
+  for (const [k, v] of Object.entries(working)) {
+    result[k] = stripConflictingAdditionalProps(v);
+  }
+  return result;
+};
+
 const mergeAllOf = (allOf: any) => {
   const onMergeError = (msg: string) => {
     console.warn(msg);
   };
 
-  const mergedSchemas = merge(allOf, { onMergeError });
+  const mergedSchemas = merge(stripConflictingAdditionalProps(allOf), {
+    onMergeError,
+  });
 
   return mergedSchemas ?? {};
 };


### PR DESCRIPTION
## Summary
- Fixes #1119: response/request schemas rendered blank when allOf members each set `additionalProperties: false` (the default emit pattern of NSwag, Swashbuckle, and similar .NET tooling).
- Pre-process allOf nodes before delegating to `allof-merge`: when there are ≥2 members and any of them sets `additionalProperties: false`, strip the flag from those members so the union of properties survives. Mirrors how Redoc, Swagger UI, and Stoplight handle the same pattern.
- Applied at both the build-time MDX path (`createSchema.ts`) and the runtime theme path (`Schema/index.tsx`); the helper is duplicated locally in each file with cross-references and a JSDoc explaining the JSON-Schema subtlety.

## Why this is the right scope
Per JSON Schema, two allOf members each declaring `additionalProperties: false` with disjoint `properties` define an unsatisfiable schema — no value can validate against both. `allof-merge` is technically correct to collapse the result. But the convention across docs tools (Redoc, Swagger UI, Stoplight, ReadMe) is to treat `additionalProperties: false` as an authoring hint that doesn't propagate through composition. The renderer's `AdditionalProperties` component (Schema/index.tsx:641) already treats `false` identically to `undefined`, so stripping it before merge has no visible effect beyond restoring the union.

Single-member allOf is left untouched (no possible conflict). Specs without this pattern are unaffected.

## Test plan
- [x] 3 new snapshot tests in `createSchema.test.ts`:
  - symmetric: two strict siblings with disjoint properties — union both
  - asymmetric: one strict + one non-strict sibling (the inner case from #1119) — union both
  - negative: single-member allOf with `additionalProperties: false` — flag preserved
- [x] Visible regression demo at `demo/examples/tests/allOf.yaml` → `/allof-strict-additional-properties`
- [x] Reproduced original blank render against the spec attached to #1119; verified all 15 properties (incl. nested allOf, `oneOf` with single-enum arms, examples) now render
- [x] Manual regression check on `petstore/find-pet-by-id` and `tests/*` — no visible change
- [x] `yarn test -- createSchema.test`: 35/35 pass

## Files changed
- `packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx` — runtime helper + wiring
- `packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts` — build-time helper + wiring
- `packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.test.ts` — 3 new tests
- `packages/docusaurus-plugin-openapi-docs/src/markdown/__snapshots__/createSchema.test.ts.snap` — generated
- `demo/examples/tests/allOf.yaml` — visible fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)