### PR TITLE
fix: render nested arrays as Type[][] in Schema tab (#1114)

### DIFF
--- a/demo/examples/tests/nestedArrays.yaml
+++ b/demo/examples/tests/nestedArrays.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.3
+info:
+  title: Nested Arrays
+  description: |
+    Demonstrates nested array types (array of arrays) in the Schema tab.
+
+    Tracks: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1114
+  version: 1.0.0
+tags:
+  - name: nestedArrays
+    description: Nested array tests
+paths:
+  /swap:
+    post:
+      tags:
+        - nestedArrays
+      summary: Swap with nested array of routes
+      description: |
+        The `routes` property is an array of arrays of `Step` objects.
+        The Schema tab should render the type as `Step[][]` (or `object[][]`
+        for inline objects), not `array[]`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SwapData"
+      responses:
+        "200":
+          description: Echoes the request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SwapData"
+  /matrices:
+    get:
+      tags:
+        - nestedArrays
+      summary: Get nested arrays of primitives
+      description: |
+        Exercises nested arrays of primitive types at two and three levels deep.
+      responses:
+        "200":
+          description: Matrix payload.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  matrix:
+                    type: array
+                    description: 2D array of integers (`integer[][]`).
+                    items:
+                      type: array
+                      items:
+                        type: integer
+                  cube:
+                    type: array
+                    description: 3D array of strings (`string[][][]`).
+                    items:
+                      type: array
+                      items:
+                        type: array
+                        items:
+                          type: string
+
+components:
+  schemas:
+    Step:
+      type: object
+      properties:
+        pool_address:
+          type: string
+        token_in:
+          type: string
+        token_out:
+          type: string
+
+    SwapData:
+      type: object
+      properties:
+        slippage_bps:
+          type: integer
+          description: Slippage in basis points for the overall route
+        routes:
+          type: array
+          description: Array of possible routes (each route is a sequence of steps)
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Step"

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.test.ts
@@ -1,0 +1,53 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { getSchemaName } from "./schema";
+import { SchemaObject } from "../openapi/types";
+
+describe("getSchemaName", () => {
+  it("returns the type for a primitive schema", () => {
+    expect(getSchemaName({ type: "string" } as SchemaObject)).toBe("string");
+  });
+
+  it("appends [] for an array of primitives", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: { type: "string" },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("string[]");
+  });
+
+  it("appends [][] for an array of arrays of primitives", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: { type: "array", items: { type: "string" } },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("string[][]");
+  });
+
+  it("appends [][] for an array of arrays of objects (issue #1114)", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: {
+        type: "array",
+        items: { type: "object", properties: { foo: { type: "string" } } },
+      },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("object[][]");
+  });
+
+  it("handles three levels of array nesting", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: {
+        type: "array",
+        items: { type: "array", items: { type: "integer" } },
+      },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("integer[][][]");
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/schema.ts
@@ -61,7 +61,7 @@ export function getSchemaName(
   circular?: boolean
 ): string {
   if (schema.items) {
-    return prettyName(schema.items, circular) + "[]";
+    return getSchemaName(schema.items as SchemaObject, circular) + "[]";
   }
 
   return prettyName(schema, circular) ?? "";

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.test.ts
@@ -1,0 +1,61 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+jest.mock(
+  "@docusaurus/Translate",
+  () => ({
+    translate: ({ message }: { message: string }) => message,
+  }),
+  { virtual: true }
+);
+
+import { getSchemaName } from "./schema";
+import { SchemaObject } from "../types";
+
+describe("getSchemaName", () => {
+  it("returns the type for a primitive schema", () => {
+    expect(getSchemaName({ type: "string" } as SchemaObject)).toBe("string");
+  });
+
+  it("appends [] for an array of primitives", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: { type: "string" },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("string[]");
+  });
+
+  it("appends [][] for an array of arrays of primitives", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: { type: "array", items: { type: "string" } },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("string[][]");
+  });
+
+  it("appends [][] for an array of arrays of objects (issue #1114)", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: {
+        type: "array",
+        items: { type: "object", properties: { foo: { type: "string" } } },
+      },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("object[][]");
+  });
+
+  it("handles three levels of array nesting", () => {
+    const schema: SchemaObject = {
+      type: "array",
+      items: {
+        type: "array",
+        items: { type: "array", items: { type: "integer" } },
+      },
+    } as SchemaObject;
+    expect(getSchemaName(schema)).toBe("integer[][][]");
+  });
+});

--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
@@ -105,7 +105,7 @@ export function getSchemaName(
   circular?: boolean
 ): string {
   if (schema.items) {
-    return prettyName(schema.items, circular) + "[]";
+    return getSchemaName(schema.items as SchemaObject, circular) + "[]";
   }
 
   return prettyName(schema, circular) ?? "";


### PR DESCRIPTION
## Summary
- Fixes #1114: nested arrays (e.g. `array` of `array` of `Step`) rendered as `array[]` in the Schema tab instead of `Step[][]`
- `getSchemaName` now recurses on `schema.items`, so each level of nesting appends another `[]` (applied to both the plugin and theme copies)
- Adds unit tests in both packages and a demo fixture (`demo/examples/tests/nestedArrays.yaml`) covering arrays of objects nested two and three levels deep

## Test plan
- [x] `yarn jest packages/*/src/markdown/schema.test.ts` — 10/10 pass
- [ ] `yarn workspace demo start`, open the **Nested Arrays** group under Tests, and verify the Schema tab shows `Step[][]` for `routes`, `integer[][]` for `matrix`, and `string[][][]` for `cube`

🤖 Generated with [Claude Code](https://claude.com/claude-code)