### PR TITLE
fix(plugin): restore menu__list-item--deprecated class on sidebar items

### DIFF
--- a/demo/templates/api.mustache
+++ b/demo/templates/api.mustache
@@ -19,7 +19,7 @@ hide_table_of_contents: true
 api: {{{json}}}
 {{/json}}
 {{#api.method}}
-sidebar_class_name: "{{{api.method}}} api-method"
+sidebar_class_name: "{{{api.method}}} api-method{{#api.deprecated}} menu__list-item--deprecated{{/api.deprecated}}"
 {{/api.method}}
 {{#infoPath}}
 info_path: {{{infoPath}}}

--- a/packages/docusaurus-plugin-openapi-docs/src/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/index.ts
@@ -223,7 +223,7 @@ hide_table_of_contents: true
 api: {{{json}}}
 {{/json}}
 {{#api.method}}
-sidebar_class_name: "{{{api.method}}} api-method"
+sidebar_class_name: "{{{api.method}}} api-method{{#api.deprecated}} menu__list-item--deprecated{{/api.deprecated}}"
 {{/api.method}}
 {{#infoPath}}
 info_path: {{{infoPath}}}


### PR DESCRIPTION
## Summary

- Adds `menu__list-item--deprecated` to the MDX front matter's `sidebar_class_name` template when an operation is `deprecated: true`
- Restores the strikethrough styling on deprecated sidebar items that broke in v5.0.0

## Why

The sidebar generator (`packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts:55`) already attaches `menu__list-item--deprecated` to deprecated items via `clsx`. That continues to work — but starting with `@docusaurus/plugin-content-docs@3.10` (bundled into v5.0.0), Docusaurus changed sidebar-item resolution from:

```js
className: item.className,
```

to:

```js
className: frontMatter.sidebar_class_name ?? item.className,
```

Our MDX template emitted only `"{{{api.method}}} api-method"` for `sidebar_class_name`, so the front matter value clobbered the sidebar generator's className and the deprecated class never reached the DOM. The same edit is applied to the demo's custom mustache template that drives the petstore config.

## Test plan

- [x] Regenerate `petstore`, `petstore31`, and `tests` API docs and verify front matter:
  - deprecated op → `sidebar_class_name: "get api-method menu__list-item--deprecated"`
  - non-deprecated op → `sidebar_class_name: "get api-method"` (unchanged)
- [x] Confirm rendered `<li>` carries `menu__list-item--deprecated` in the built sidebar JSON
- [ ] Reviewer: load the demo locally and confirm the strikethrough returns on `/petstore31/find-pets-by-tags`

Closes #1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)