### PR TITLE
fix(theme): prefill Send API Request from example fields (#544, #1079)

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiItem/index.tsx
@@ -123,10 +123,22 @@ export default function ApiItem(props: Props): JSX.Element {
       (param: { in: "path" | "query" | "header" | "cookie" }) => {
         const paramType = param.in;
         const paramsArray: ParameterObject[] = params[paramType];
-        const defaultValue = (param as any).schema?.default;
+        const p = param as any;
+        // Prefill order: schema.default, then example sources. `default` is
+        // semantically a server-side fallback, so for required params authors
+        // typically rely on `example` / `examples`. See #544 and #1079.
+        const firstNamedExample =
+          p.examples && typeof p.examples === "object"
+            ? (Object.values(p.examples)[0] as any)?.value
+            : undefined;
+        const prefill =
+          p.schema?.default ??
+          p.example ??
+          p.schema?.example ??
+          firstNamedExample;
         const initialized =
-          defaultValue !== undefined
-            ? ({ ...param, value: defaultValue } as unknown as ParameterObject)
+          prefill !== undefined
+            ? ({ ...param, value: prefill } as unknown as ParameterObject)
             : (param as ParameterObject);
         paramsArray?.push(initialized);
       }


### PR DESCRIPTION
## Summary
- Closes #1079, addresses #544
- `ApiItem` only prefilled parameter inputs from `schema.default`. For required parameters the OpenAPI spec discourages `default` (it is a server-side fallback), so authors typically rely on `example`, `schema.example`, or `examples` — none of which were consulted.

## What changed
- Extend the prefill order to fall through `schema.default → example → schema.example → first of examples`.
- Behavior unchanged when only `schema.default` is set.

## Test plan
- [ ] Reviewer to verify in demo with a query param that defines `example` only (no `default`) — input should be prefilled.
- [ ] Verify existing `schema.default` prefill still works (regression check).
- [ ] Verify a param with `examples: { foo: { value: "bar" } }` prefills `"bar"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)