### PR TITLE
fix(theme): make i18n strings extractable by write-translations

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/markdown/schema.ts
@@ -7,7 +7,6 @@
 
 import { translate } from "@docusaurus/Translate";
 
-import { OPENAPI_SCHEMA_ITEM } from "../theme/translationIds";
 import { SchemaObject } from "../types";
 
 /**
@@ -130,7 +129,7 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
   }
 
   let message = `**${translate({
-    id: OPENAPI_SCHEMA_ITEM.POSSIBLE_VALUES,
+    id: "theme.openapi.schemaItem.possibleValues",
     message: "Possible values:",
   })}** `;
 
@@ -149,11 +148,11 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
     let minLength;
     let maxLength;
     const charactersMessage = translate({
-      id: OPENAPI_SCHEMA_ITEM.CHARACTERS,
+      id: "theme.openapi.schemaItem.characters",
       message: "characters",
     });
     const nonEmptyMessage = translate({
-      id: OPENAPI_SCHEMA_ITEM.NON_EMPTY,
+      id: "theme.openapi.schemaItem.nonEmpty",
       message: "non-empty",
     });
     if (schema.minLength && schema.minLength > 1) {
@@ -218,7 +217,7 @@ export function getQualifierMessage(schema?: SchemaObject): string | undefined {
 
   if (schema.pattern) {
     const expressionMessage = translate({
-      id: OPENAPI_SCHEMA_ITEM.EXPRESSION,
+      id: "theme.openapi.schemaItem.expression",
       message: "Value must match regular expression",
     });
     qualifierGroups.push(`${expressionMessage} \`${schema.pattern}\``);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Authorization/index.tsx
@@ -12,7 +12,6 @@ import FormItem from "@theme/ApiExplorer/FormItem";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_AUTH } from "@theme/translationIds";
 
 import { setAuthData, setSelectedAuth } from "./slice";
 
@@ -37,7 +36,7 @@ function Authorization() {
         <FormItem>
           <FormSelect
             label={translate({
-              id: OPENAPI_AUTH.SECURITY_SCHEME,
+              id: "theme.openapi.auth.securityScheme",
               message: "Security Scheme",
             })}
             options={optionKeys}
@@ -54,11 +53,11 @@ function Authorization() {
             <FormItem key={a.key + "-bearer"}>
               <FormTextInput
                 label={translate({
-                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  id: "theme.openapi.auth.bearerToken",
                   message: "Bearer Token",
                 })}
                 placeholder={translate({
-                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  id: "theme.openapi.auth.bearerToken",
                   message: "Bearer Token",
                 })}
                 password
@@ -83,11 +82,11 @@ function Authorization() {
             <FormItem key={a.key + "-oauth2"}>
               <FormTextInput
                 label={translate({
-                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  id: "theme.openapi.auth.bearerToken",
                   message: "Bearer Token",
                 })}
                 placeholder={translate({
-                  id: OPENAPI_AUTH.BEARER_TOKEN,
+                  id: "theme.openapi.auth.bearerToken",
                   message: "Bearer Token",
                 })}
                 password
@@ -113,11 +112,11 @@ function Authorization() {
               <FormItem>
                 <FormTextInput
                   label={translate({
-                    id: OPENAPI_AUTH.USERNAME,
+                    id: "theme.openapi.auth.username",
                     message: "Username",
                   })}
                   placeholder={translate({
-                    id: OPENAPI_AUTH.USERNAME,
+                    id: "theme.openapi.auth.username",
                     message: "Username",
                   })}
                   value={data[a.key].username ?? ""}
@@ -136,11 +135,11 @@ function Authorization() {
               <FormItem>
                 <FormTextInput
                   label={translate({
-                    id: OPENAPI_AUTH.PASSWORD,
+                    id: "theme.openapi.auth.password",
                     message: "Password",
                   })}
                   placeholder={translate({
-                    id: OPENAPI_AUTH.PASSWORD,
+                    id: "theme.openapi.auth.password",
                     message: "Password",
                   })}
                   password

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Body/index.tsx
@@ -16,7 +16,6 @@ import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import Markdown from "@theme/Markdown";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_BODY, OPENAPI_REQUEST } from "@theme/translationIds";
 import { sampleFromSchema } from "docusaurus-plugin-openapi-docs/lib/openapi/createSchemaExample";
 import type { RequestBodyObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import format from "xml-formatter";
@@ -292,7 +291,10 @@ function Body({
         <FormFileUpload
           placeholder={
             schema.description ||
-            translate({ id: OPENAPI_REQUEST.BODY_TITLE, message: "Body" })
+            translate({
+              id: "theme.openapi.request.body.title",
+              message: "Body",
+            })
           }
           onChange={(file: any) => {
             if (file === undefined) {
@@ -322,7 +324,7 @@ function Body({
           {/* @ts-ignore */}
           <TabItem
             label={translate({
-              id: OPENAPI_BODY.EXAMPLE_FROM_SCHEMA,
+              id: "theme.openapi.body.exampleFromSchema",
               message: "Example (from schema)",
             })}
             value="Example (from schema)"
@@ -412,7 +414,7 @@ function Body({
           {/* @ts-ignore */}
           <TabItem
             label={translate({
-              id: OPENAPI_BODY.EXAMPLE_FROM_SCHEMA,
+              id: "theme.openapi.body.exampleFromSchema",
               message: "Example (from schema)",
             })}
             value="Example (from schema)"
@@ -453,7 +455,7 @@ function Body({
           {/* @ts-ignore */}
           <TabItem
             label={translate({
-              id: OPENAPI_BODY.EXAMPLE_FROM_SCHEMA,
+              id: "theme.openapi.body.exampleFromSchema",
               message: "Example (from schema)",
             })}
             value="Example (from schema)"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Export/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Export/index.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 
+import { translate } from "@docusaurus/Translate";
 import fileSaver from "file-saver";
 
 const saveFile = (url: string) => {
@@ -24,7 +25,7 @@ function Export({ url, proxy }: any) {
       className="dropdown dropdown--hoverable dropdown--right"
     >
       <button className="export-button button button--sm button--secondary">
-        Export
+        {translate({ id: "theme.openapi.export.button", message: "Export" })}
       </button>
       <ul className="export-dropdown dropdown__menu">
         <li>
@@ -36,7 +37,10 @@ function Export({ url, proxy }: any) {
             className="dropdown__link"
             href={`${url}`}
           >
-            OpenAPI Spec
+            {translate({
+              id: "theme.openapi.export.openapiSpec",
+              message: "OpenAPI Spec",
+            })}
           </a>
         </li>
       </ul>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormFileUpload/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormFileUpload/index.tsx
@@ -9,7 +9,6 @@ import React, { useState } from "react";
 
 import { translate } from "@docusaurus/Translate";
 import FloatingButton from "@theme/ApiExplorer/FloatingButton";
-import { OPENAPI_FORM_FILE_UPLOAD } from "@theme/translationIds";
 import MagicDropzone from "react-magic-dropzone";
 
 type PreviewFile = { preview: string } & File;
@@ -105,7 +104,7 @@ function FormFileUpload({ placeholder, onChange }: Props) {
               }}
             >
               {translate({
-                id: OPENAPI_FORM_FILE_UPLOAD.CLEAR_BUTTON,
+                id: "theme.openapi.formFileUpload.clearButton",
                 message: "Clear",
               })}
             </button>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormLabel/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormLabel/index.tsx
@@ -8,7 +8,6 @@
 import React from "react";
 
 import { translate } from "@docusaurus/Translate";
-import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 
 export interface Props {
   htmlFor?: string;
@@ -31,7 +30,7 @@ function FormLabel({ htmlFor, label, type, required }: Props) {
       {required && (
         <span className="openapi-schema__required">
           {translate({
-            id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+            id: "theme.openapi.schemaItem.required",
             message: "required",
           })}
         </span>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormTextInput/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/FormTextInput/index.tsx
@@ -11,7 +11,6 @@ import React, { useId } from "react";
 import { translate } from "@docusaurus/Translate";
 import { ErrorMessage } from "@hookform/error-message";
 import FormLabel from "@theme/ApiExplorer/FormLabel";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import clsx from "clsx";
 import { useFormContext } from "react-hook-form";
 
@@ -59,7 +58,7 @@ function FormTextInput({
           {...register(paramName, {
             required: isRequired
               ? translate({
-                  id: OPENAPI_FORM.FIELD_REQUIRED,
+                  id: "theme.openapi.form.fieldRequired",
                   message: "This field is required",
                 })
               : false,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/LiveEditor/index.tsx
@@ -11,7 +11,6 @@ import { usePrismTheme } from "@docusaurus/theme-common";
 import { translate } from "@docusaurus/Translate";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import { ErrorMessage } from "@hookform/error-message";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import clsx from "clsx";
 import { Controller, useFormContext } from "react-hook-form";
 import { LiveProvider, LiveEditor, withLive } from "react-live";
@@ -89,7 +88,7 @@ function App({
             required:
               isRequired && !code
                 ? translate({
-                    id: OPENAPI_FORM.FIELD_REQUIRED,
+                    id: "theme.openapi.form.fieldRequired",
                     message: "This field is required",
                   })
                 : false,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem.tsx
@@ -15,7 +15,6 @@ import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -138,7 +137,7 @@ export default function ParamArrayFormItem({
         rules={{
           required: param.required
             ? translate({
-                id: OPENAPI_FORM.FIELD_REQUIRED,
+                id: "theme.openapi.form.fieldRequired",
                 message: "This field is required",
               })
             : false,
@@ -177,7 +176,10 @@ export default function ParamArrayFormItem({
               className="openapi-explorer__thin-btn"
               onClick={handleAddItem}
             >
-              Add item
+              {translate({
+                id: "theme.openapi.paramArray.addItem",
+                message: "Add item",
+              })}
             </button>
           </>
         )}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem.tsx
@@ -12,7 +12,6 @@ import { ErrorMessage } from "@hookform/error-message";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -60,7 +59,7 @@ export default function ParamBooleanFormItem({
         rules={{
           required: param.required
             ? translate({
-                id: OPENAPI_FORM.FIELD_REQUIRED,
+                id: "theme.openapi.form.fieldRequired",
                 message: "This field is required",
               })
             : false,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem.tsx
@@ -13,7 +13,6 @@ import FormMultiSelect from "@theme/ApiExplorer/FormMultiSelect";
 import { getSchemaEnum } from "@theme/ApiExplorer/ParamOptions";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -75,7 +74,7 @@ export default function ParamMultiSelectFormItem({
         rules={{
           required: param.required
             ? translate({
-                id: OPENAPI_FORM.FIELD_REQUIRED,
+                id: "theme.openapi.form.fieldRequired",
                 message: "This field is required",
               })
             : false,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem.tsx
@@ -13,7 +13,6 @@ import FormSelect from "@theme/ApiExplorer/FormSelect";
 import { getSchemaEnum } from "@theme/ApiExplorer/ParamOptions";
 import { Param, setParam } from "@theme/ApiExplorer/ParamOptions/slice";
 import { useTypedDispatch } from "@theme/ApiItem/hooks";
-import { OPENAPI_FORM } from "@theme/translationIds";
 import { Controller, useFormContext } from "react-hook-form";
 
 export interface ParamProps {
@@ -58,7 +57,7 @@ export default function ParamSelectFormItem({
         rules={{
           required: param.required
             ? translate({
-                id: OPENAPI_FORM.FIELD_REQUIRED,
+                id: "theme.openapi.form.fieldRequired",
                 message: "This field is required",
               })
             : false,

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/ParamOptions/index.tsx
@@ -15,7 +15,6 @@ import ParamMultiSelectFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormI
 import ParamSelectFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem";
 import ParamTextFormItem from "@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_PARAM_OPTIONS } from "@theme/translationIds";
 
 import { Param } from "./slice";
 
@@ -207,11 +206,11 @@ function ParamOptions() {
             </span>
             {showOptional
               ? translate({
-                  id: OPENAPI_PARAM_OPTIONS.HIDE_OPTIONAL,
+                  id: "theme.openapi.paramOptions.hideOptional",
                   message: "Hide optional parameters",
                 })
               : translate({
-                  id: OPENAPI_PARAM_OPTIONS.SHOW_OPTIONAL,
+                  id: "theme.openapi.paramOptions.showOptional",
                   message: "Show optional parameters",
                 })}
           </button>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Request/index.tsx
@@ -16,6 +16,7 @@ import Authorization from "@theme/ApiExplorer/Authorization";
 import Body from "@theme/ApiExplorer/Body";
 import buildPostmanRequest from "@theme/ApiExplorer/buildPostmanRequest";
 import ContentType from "@theme/ApiExplorer/ContentType";
+import { useResolvedEncoding } from "@theme/ApiExplorer/EncodingSelection/useResolvedEncoding";
 import ParamOptions from "@theme/ApiExplorer/ParamOptions";
 import {
   setResponse,
@@ -25,9 +26,7 @@ import {
   clearHeaders,
 } from "@theme/ApiExplorer/Response/slice";
 import Server from "@theme/ApiExplorer/Server";
-import { useResolvedEncoding } from "@theme/ApiExplorer/EncodingSelection/useResolvedEncoding";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_REQUEST } from "@theme/translationIds";
 import type { ParameterObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
@@ -137,26 +136,26 @@ function Request({ item }: { item: ApiItem }) {
     switch (errorType) {
       case "timeout":
         return translate({
-          id: OPENAPI_REQUEST.ERROR_TIMEOUT,
+          id: "theme.openapi.request.error.timeout",
           message:
             "The request timed out waiting for the server to respond. Please try again. If the issue persists, try using a different client (e.g., curl) with a longer timeout.",
         });
       case "network":
         return translate({
-          id: OPENAPI_REQUEST.ERROR_NETWORK,
+          id: "theme.openapi.request.error.network",
           message:
             "Unable to reach the server. Please check your network connection and verify the server URL is correct. If the server is running, this may be a CORS issue.",
         });
       case "cors":
         return translate({
-          id: OPENAPI_REQUEST.ERROR_CORS,
+          id: "theme.openapi.request.error.cors",
           message:
             "The request was blocked, possibly due to CORS restrictions. Ensure the server allows requests from this origin, or try using a proxy.",
         });
       case "unknown":
       default:
         return translate({
-          id: OPENAPI_REQUEST.ERROR_UNKNOWN,
+          id: "theme.openapi.request.error.unknown",
           message:
             "An unexpected error occurred while making the request. Please try again.",
         });
@@ -167,7 +166,7 @@ function Request({ item }: { item: ApiItem }) {
     dispatch(
       setResponse(
         translate({
-          id: OPENAPI_REQUEST.FETCHING_MESSAGE,
+          id: "theme.openapi.request.fetchingMessage",
           message: "Fetching...",
         })
       )
@@ -195,7 +194,7 @@ function Request({ item }: { item: ApiItem }) {
         errorMessage = getErrorMessage(e.type);
       } else {
         errorMessage = translate({
-          id: OPENAPI_REQUEST.CONNECTION_FAILED,
+          id: "theme.openapi.request.connectionFailed",
           message: "Connection failed",
         });
       }
@@ -253,7 +252,7 @@ function Request({ item }: { item: ApiItem }) {
         <div className="openapi-explorer__request-header-container">
           <span className="openapi-explorer__request-title">
             {translate({
-              id: OPENAPI_REQUEST.REQUEST_TITLE,
+              id: "theme.openapi.request.title",
               message: "Request",
             })}
           </span>
@@ -264,7 +263,7 @@ function Request({ item }: { item: ApiItem }) {
               onClick={collapseAllDetails}
             >
               {translate({
-                id: OPENAPI_REQUEST.COLLAPSE_ALL,
+                id: "theme.openapi.request.collapseAll",
                 message: "Collapse all",
               })}
             </button>
@@ -275,7 +274,7 @@ function Request({ item }: { item: ApiItem }) {
               onClick={expandAllDetails}
             >
               {translate({
-                id: OPENAPI_REQUEST.EXPAND_ALL,
+                id: "theme.openapi.request.expandAll",
                 message: "Expand all",
               })}
             </button>
@@ -296,7 +295,7 @@ function Request({ item }: { item: ApiItem }) {
                 }}
               >
                 {translate({
-                  id: OPENAPI_REQUEST.BASE_URL_TITLE,
+                  id: "theme.openapi.request.baseUrl.title",
                   message: "Base URL",
                 })}
               </summary>
@@ -315,7 +314,10 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandAuth(!expandAuth);
                 }}
               >
-                {translate({ id: OPENAPI_REQUEST.AUTH_TITLE, message: "Auth" })}
+                {translate({
+                  id: "theme.openapi.request.auth.title",
+                  message: "Auth",
+                })}
               </summary>
               <Authorization />
             </details>
@@ -335,7 +337,7 @@ function Request({ item }: { item: ApiItem }) {
                 }}
               >
                 {translate({
-                  id: OPENAPI_REQUEST.PARAMETERS_TITLE,
+                  id: "theme.openapi.request.parameters.title",
                   message: "Parameters",
                 })}
               </summary>
@@ -354,12 +356,15 @@ function Request({ item }: { item: ApiItem }) {
                   setExpandBody(!expandBody);
                 }}
               >
-                {translate({ id: OPENAPI_REQUEST.BODY_TITLE, message: "Body" })}
+                {translate({
+                  id: "theme.openapi.request.body.title",
+                  message: "Body",
+                })}
                 {requestBodyRequired && (
                   <span className="openapi-schema__required">
                     &nbsp;
                     {translate({
-                      id: OPENAPI_REQUEST.REQUIRED_LABEL,
+                      id: "theme.openapi.request.requiredLabel",
                       message: "required",
                     })}
                   </span>
@@ -388,7 +393,7 @@ function Request({ item }: { item: ApiItem }) {
                 }}
               >
                 {translate({
-                  id: OPENAPI_REQUEST.ACCEPT_TITLE,
+                  id: "theme.openapi.request.accept.title",
                   message: "Accept",
                 })}
               </summary>
@@ -398,7 +403,7 @@ function Request({ item }: { item: ApiItem }) {
           {showRequestButton && item.method !== "event" && (
             <button className="openapi-explorer__request-btn" type="submit">
               {translate({
-                id: OPENAPI_REQUEST.SEND_BUTTON,
+                id: "theme.openapi.request.sendButton",
                 message: "Send API Request",
               })}
             </button>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Response/index.tsx
@@ -15,7 +15,6 @@ import ApiCodeBlock from "@theme/ApiExplorer/ApiCodeBlock";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_REQUEST, OPENAPI_RESPONSE } from "@theme/translationIds";
 import clsx from "clsx";
 import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 import type { ThemeConfig } from "docusaurus-theme-openapi-docs/src/types";
@@ -134,7 +133,10 @@ function Response({ item }: { item: ApiItem }) {
     <div className="openapi-explorer__response-container">
       <div className="openapi-explorer__response-title-container">
         <span className="openapi-explorer__response-title">
-          {translate({ id: OPENAPI_RESPONSE.TITLE, message: "Response" })}
+          {translate({
+            id: "theme.openapi.response.title",
+            message: "Response",
+          })}
         </span>
         <button
           type="button"
@@ -145,7 +147,7 @@ function Response({ item }: { item: ApiItem }) {
             dispatch(clearHeaders());
           }}
         >
-          {translate({ id: OPENAPI_RESPONSE.CLEAR, message: "Clear" })}
+          {translate({ id: "theme.openapi.response.clear", message: "Clear" })}
         </button>
       </div>
       <div
@@ -180,11 +182,11 @@ function Response({ item }: { item: ApiItem }) {
                 {prettyResponse || (
                   <p className="openapi-explorer__response-placeholder-message">
                     <Translate
-                      id={OPENAPI_RESPONSE.PLACEHOLDER}
+                      id={"theme.openapi.response.placeholder"}
                       values={{
                         code: (
                           <code>
-                            <Translate id={OPENAPI_REQUEST.SEND_BUTTON}>
+                            <Translate id={"theme.openapi.request.sendButton"}>
                               Send API Request
                             </Translate>
                           </code>
@@ -202,7 +204,7 @@ function Response({ item }: { item: ApiItem }) {
             {/* @ts-ignore */}
             <TabItem
               label={translate({
-                id: OPENAPI_RESPONSE.HEADERS_TAB,
+                id: "theme.openapi.response.headersTab",
                 message: "Headers",
               })}
               value="headers"
@@ -228,11 +230,11 @@ function Response({ item }: { item: ApiItem }) {
         ) : (
           <p className="openapi-explorer__response-placeholder-message">
             <Translate
-              id={OPENAPI_RESPONSE.PLACEHOLDER}
+              id={"theme.openapi.response.placeholder"}
               values={{
                 code: (
                   <code>
-                    <Translate id={OPENAPI_REQUEST.SEND_BUTTON}>
+                    <Translate id={"theme.openapi.request.sendButton"}>
                       Send API Request
                     </Translate>
                   </code>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/SecuritySchemes/index.tsx
@@ -10,7 +10,6 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import { translate } from "@docusaurus/Translate";
 import { useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_SECURITY_SCHEMES } from "@theme/translationIds";
 
 function SecuritySchemes(props: any) {
   const options = useTypedSelector((state: any) => state.auth.options);
@@ -25,45 +24,54 @@ function SecuritySchemes(props: any) {
 
   const selectedAuth = options[selected];
 
-  const keyTranslations: Record<string, { id: string; message: string }> = {
-    description: {
-      id: OPENAPI_SECURITY_SCHEMES.DESCRIPTION,
-      message: "description:",
-    },
-    scheme: {
-      id: OPENAPI_SECURITY_SCHEMES.SCHEME,
-      message: "scheme:",
-    },
-    bearerFormat: {
-      id: OPENAPI_SECURITY_SCHEMES.BEARER_FORMAT,
-      message: "bearerFormat:",
-    },
-    openIdConnectUrl: {
-      id: OPENAPI_SECURITY_SCHEMES.OPEN_ID_CONNECT_URL,
-      message: "openIdConnectUrl:",
-    },
+  // Each label uses a static `translate()` call (literal id + message) so that
+  // `docusaurus write-translations` can statically extract it. A dynamic
+  // `translate({ id: someVar })` would be skipped by the extractor.
+  const renderRestLabel = (k: string): string => {
+    switch (k) {
+      case "description":
+        return translate({
+          id: "theme.openapi.securitySchemes.description",
+          message: "description:",
+        });
+      case "scheme":
+        return translate({
+          id: "theme.openapi.securitySchemes.scheme",
+          message: "scheme:",
+        });
+      case "bearerFormat":
+        return translate({
+          id: "theme.openapi.securitySchemes.bearerFormat",
+          message: "bearerFormat:",
+        });
+      case "openIdConnectUrl":
+        return translate({
+          id: "theme.openapi.securitySchemes.openIdConnectUrl",
+          message: "openIdConnectUrl:",
+        });
+      default:
+        return `${k}:`;
+    }
   };
 
   const renderRest = (rest: Record<string, any>) =>
-    Object.keys(rest).map((k) => {
-      const translation = keyTranslations[k];
-      const label = translation
-        ? translate({ id: translation.id, message: translation.message })
-        : `${k}:`;
-      return (
-        <span key={k}>
-          <strong>{label} </strong>
-          {typeof rest[k] === "object"
-            ? JSON.stringify(rest[k], null, 2)
-            : String(rest[k])}
-        </span>
-      );
-    });
+    Object.keys(rest).map((k) => (
+      <span key={k}>
+        <strong>{renderRestLabel(k)} </strong>
+        {typeof rest[k] === "object"
+          ? JSON.stringify(rest[k], null, 2)
+          : String(rest[k])}
+      </span>
+    ));
   return (
     <details className="openapi-security__details" open={false}>
       <summary className="openapi-security__summary-container">
         <h4 className="openapi-security__summary-header">
-          Authorization: {selectedAuth[0].name ?? selectedAuth[0].type}
+          {translate({
+            id: "theme.openapi.securitySchemes.authorization",
+            message: "Authorization:",
+          })}{" "}
+          {selectedAuth[0].name ?? selectedAuth[0].type}
         </h4>
       </summary>
       {selectedAuth.map((auth: any) => {
@@ -87,7 +95,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.NAME,
+                        id: "theme.openapi.securitySchemes.name",
                         message: "name:",
                       })}
                     </strong>{" "}
@@ -96,7 +104,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                        id: "theme.openapi.securitySchemes.type",
                         message: "type:",
                       })}
                     </strong>{" "}
@@ -106,7 +114,7 @@ function SecuritySchemes(props: any) {
                     <span>
                       <strong>
                         {translate({
-                          id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                          id: "theme.openapi.securitySchemes.scopes",
                           message: "scopes:",
                         })}
                       </strong>{" "}
@@ -134,7 +142,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.NAME,
+                        id: "theme.openapi.securitySchemes.name",
                         message: "name:",
                       })}
                     </strong>{" "}
@@ -143,7 +151,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                        id: "theme.openapi.securitySchemes.type",
                         message: "type:",
                       })}
                     </strong>{" "}
@@ -153,7 +161,7 @@ function SecuritySchemes(props: any) {
                     <span>
                       <strong>
                         {translate({
-                          id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                          id: "theme.openapi.securitySchemes.scopes",
                           message: "scopes:",
                         })}
                       </strong>{" "}
@@ -179,7 +187,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      id: "theme.openapi.securitySchemes.name",
                       message: "name:",
                     })}
                   </strong>{" "}
@@ -188,7 +196,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      id: "theme.openapi.securitySchemes.type",
                       message: "type:",
                     })}
                   </strong>{" "}
@@ -197,7 +205,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.IN,
+                      id: "theme.openapi.securitySchemes.in",
                       message: "in:",
                     })}
                   </strong>{" "}
@@ -222,7 +230,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      id: "theme.openapi.securitySchemes.name",
                       message: "name:",
                     })}
                   </strong>{" "}
@@ -231,7 +239,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      id: "theme.openapi.securitySchemes.type",
                       message: "type:",
                     })}
                   </strong>{" "}
@@ -241,7 +249,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        id: "theme.openapi.securitySchemes.scopes",
                         message: "scopes:",
                       })}
                     </strong>{" "}
@@ -270,7 +278,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      id: "theme.openapi.securitySchemes.name",
                       message: "name:",
                     })}
                   </strong>{" "}
@@ -279,7 +287,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      id: "theme.openapi.securitySchemes.type",
                       message: "type:",
                     })}
                   </strong>{" "}
@@ -289,7 +297,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        id: "theme.openapi.securitySchemes.scopes",
                         message: "scopes:",
                       })}
                     </strong>{" "}
@@ -304,7 +312,7 @@ function SecuritySchemes(props: any) {
                     <code>
                       <strong>
                         {translate({
-                          id: OPENAPI_SECURITY_SCHEMES.FLOWS,
+                          id: "theme.openapi.securitySchemes.flows",
                           message: "flows:",
                         })}
                       </strong>{" "}
@@ -331,7 +339,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.NAME,
+                      id: "theme.openapi.securitySchemes.name",
                       message: "name:",
                     })}
                   </strong>{" "}
@@ -340,7 +348,7 @@ function SecuritySchemes(props: any) {
                 <span>
                   <strong>
                     {translate({
-                      id: OPENAPI_SECURITY_SCHEMES.TYPE,
+                      id: "theme.openapi.securitySchemes.type",
                       message: "type:",
                     })}
                   </strong>{" "}
@@ -350,7 +358,7 @@ function SecuritySchemes(props: any) {
                   <span>
                     <strong>
                       {translate({
-                        id: OPENAPI_SECURITY_SCHEMES.SCOPES,
+                        id: "theme.openapi.securitySchemes.scopes",
                         message: "scopes:",
                       })}
                     </strong>{" "}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/Server/index.tsx
@@ -13,7 +13,6 @@ import FormItem from "@theme/ApiExplorer/FormItem";
 import FormSelect from "@theme/ApiExplorer/FormSelect";
 import FormTextInput from "@theme/ApiExplorer/FormTextInput";
 import { useTypedDispatch, useTypedSelector } from "@theme/ApiItem/hooks";
-import { OPENAPI_SERVER } from "@theme/translationIds";
 
 import { setServer, setServerVariable } from "./slice";
 
@@ -65,7 +64,10 @@ function Server({ labelId }: ServerProps) {
     return (
       <FloatingButton
         onClick={() => setIsEditing(true)}
-        label={translate({ id: OPENAPI_SERVER.EDIT_BUTTON, message: "Edit" })}
+        label={translate({
+          id: "theme.openapi.server.editButton",
+          message: "Edit",
+        })}
       >
         <FormItem>
           <span className="openapi-explorer__server-url" title={url}>
@@ -79,7 +81,10 @@ function Server({ labelId }: ServerProps) {
     <div className="openapi-explorer__server-container">
       <FloatingButton
         onClick={() => setIsEditing(false)}
-        label={translate({ id: OPENAPI_SERVER.HIDE_BUTTON, message: "Hide" })}
+        label={translate({
+          id: "theme.openapi.server.hideButton",
+          message: "Hide",
+        })}
       >
         <FormItem>
           <FormSelect

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiTabs/index.tsx
@@ -24,7 +24,6 @@ import {
 import { translate } from "@docusaurus/Translate";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import Heading from "@theme/Heading";
-import { OPENAPI_TABS } from "@theme/translationIds";
 import clsx from "clsx";
 
 export interface TabListProps extends TabProps {
@@ -39,7 +38,7 @@ function TabList({
   selectValue,
   tabValues,
   label = translate({
-    id: OPENAPI_TABS.RESPONSES_LABEL,
+    id: "theme.openapi.tabs.responses.label",
     message: "Responses",
   }),
   id = "responses",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Example/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Example/index.tsx
@@ -11,7 +11,6 @@ import { translate } from "@docusaurus/Translate";
 import { ExampleObject } from "@theme/ParamsItem";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 
 const EXAMPLE_CLASS_NAME = "openapi-example";
 const EXAMPLES_CLASS_NAME = "openapi-examples";
@@ -58,7 +57,7 @@ const renderExample = (example: ExampleType) => {
     <div className={EXAMPLE_CLASS_NAME}>
       <strong>
         {translate({
-          id: OPENAPI_SCHEMA_ITEM.EXAMPLE,
+          id: "theme.openapi.schemaItem.example",
           message: "Example:",
         })}{" "}
       </strong>
@@ -121,7 +120,7 @@ export const renderExamplesRecord = (
     <div className={EXAMPLES_CLASS_NAME}>
       <strong>
         {translate({
-          id: OPENAPI_SCHEMA_ITEM.EXAMPLES,
+          id: "theme.openapi.schemaItem.examples",
           message: "Examples:",
         })}
       </strong>
@@ -153,7 +152,7 @@ const renderExampleObject = (
         <p>
           <strong>
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.DESCRIPTION,
+              id: "theme.openapi.schemaItem.description",
               message: "Description:",
             })}{" "}
           </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsDetails/index.tsx
@@ -12,7 +12,6 @@ import { translate } from "@docusaurus/Translate";
 import Details from "@theme/Details";
 import ParamsItem from "@theme/ParamsItem";
 import SkeletonLoader from "@theme/SkeletonLoader";
-import { OPENAPI_PARAMS_DETAILS } from "@theme/translationIds";
 
 interface Props {
   parameters: any[];
@@ -35,7 +34,7 @@ const ParamsDetailsComponent: React.FC<Props> = ({ parameters }) => {
             <h3 className="openapi-markdown__details-summary-header-params">
               {translate(
                 {
-                  id: OPENAPI_PARAMS_DETAILS.PARAMETERS_TITLE,
+                  id: "theme.openapi.paramsDetails.parametersTitle",
                   message: "{type} Parameters",
                 },
                 { type: type.charAt(0).toUpperCase() + type.slice(1) }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ParamsItem/index.tsx
@@ -11,7 +11,6 @@ import { translate } from "@docusaurus/Translate";
 import { Example } from "@theme/Example";
 import Markdown from "@theme/Markdown";
 /* eslint-disable import/no-extraneous-dependencies*/
-import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 import clsx from "clsx";
 
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
@@ -41,11 +40,11 @@ export interface Props {
 const getEnumDescriptionMarkdown = (enumDescriptions?: [string, string][]) => {
   if (enumDescriptions?.length) {
     const enumValue = translate({
-      id: OPENAPI_SCHEMA_ITEM.ENUM_VALUE,
+      id: "theme.openapi.schemaItem.enumValue",
       message: "Enum Value",
     });
     const description = translate({
-      id: OPENAPI_SCHEMA_ITEM.ENUM_DESCRIPTION,
+      id: "theme.openapi.schemaItem.enumDescription",
       message: "Description",
     });
     return `| ${enumValue} | ${description} |
@@ -92,13 +91,19 @@ function ParamsItem({ param, ...rest }: Props) {
 
   const renderSchemaRequired = guard(required, () => (
     <span className="openapi-schema__required">
-      {translate({ id: OPENAPI_SCHEMA_ITEM.REQUIRED, message: "required" })}
+      {translate({
+        id: "theme.openapi.schemaItem.required",
+        message: "required",
+      })}
     </span>
   ));
 
   const renderDeprecated = guard(deprecated, () => (
     <span className="openapi-schema__deprecated">
-      {translate({ id: OPENAPI_SCHEMA_ITEM.DEPRECATED, message: "deprecated" })}
+      {translate({
+        id: "theme.openapi.schemaItem.deprecated",
+        message: "deprecated",
+      })}
     </span>
   ));
 
@@ -113,7 +118,7 @@ function ParamsItem({ param, ...rest }: Props) {
       return undefined;
     }
     const label = translate({
-      id: OPENAPI_SCHEMA_ITEM.CONSTANT_VALUE,
+      id: "theme.openapi.schemaItem.constantValue",
       message: "Constant value:",
     });
     return (
@@ -152,7 +157,7 @@ function ParamsItem({ param, ...rest }: Props) {
           <div>
             <strong>
               {translate({
-                id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+                id: "theme.openapi.schemaItem.defaultValue",
                 message: "Default value:",
               })}{" "}
             </strong>
@@ -166,7 +171,7 @@ function ParamsItem({ param, ...rest }: Props) {
         <div>
           <strong>
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+              id: "theme.openapi.schemaItem.defaultValue",
               message: "Default value:",
             })}{" "}
           </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/RequestSchema/index.tsx
@@ -22,7 +22,6 @@ import SchemaExpansionControl from "@theme/SchemaExpansion";
 import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 import type { MediaTypeObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 interface Props {
@@ -81,13 +80,13 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                         <summary className="openapi-markdown__details-summary--with-control">
                           <h3 className="openapi-markdown__details-summary-header-body">
                             {translate({
-                              id: OPENAPI_REQUEST.BODY_TITLE,
+                              id: "theme.openapi.request.body.title",
                               message: title,
                             })}
                             {body.required === true && (
                               <span className="openapi-schema__required">
                                 {translate({
-                                  id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                  id: "theme.openapi.schemaItem.required",
                                   message: "required",
                                 })}
                               </span>
@@ -167,7 +166,7 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                 <summary className="openapi-markdown__details-summary--with-control">
                   <h3 className="openapi-markdown__details-summary-header-body">
                     {translate({
-                      id: OPENAPI_REQUEST.BODY_TITLE,
+                      id: "theme.openapi.request.body.title",
                       message: title,
                     })}
                     {firstBody.type === "array" && (
@@ -176,7 +175,7 @@ const RequestSchemaComponent: React.FC<Props> = ({ title, body, style }) => {
                     {body.required && (
                       <strong className="openapi-schema__required">
                         {translate({
-                          id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                          id: "theme.openapi.schemaItem.required",
                           message: "required",
                         })}
                       </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseExamples/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseExamples/index.tsx
@@ -11,7 +11,6 @@ import { translate } from "@docusaurus/Translate";
 import CodeSamples from "@theme/CodeSamples";
 import Markdown from "@theme/Markdown";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_RESPONSE_EXAMPLES } from "@theme/translationIds";
 import { sampleResponseFromSchema } from "docusaurus-plugin-openapi-docs/lib/openapi/createResponseExample";
 import format from "xml-formatter";
 
@@ -115,7 +114,7 @@ export const ResponseExample: React.FC<ResponseExampleProps> = ({
     // @ts-ignore
     <TabItem
       label={translate({
-        id: OPENAPI_RESPONSE_EXAMPLES.EXAMPLE,
+        id: "theme.openapi.responseExamples.example",
         message: "Example",
       })}
       value="Example"
@@ -173,7 +172,7 @@ export const ExampleFromSchema: React.FC<ExampleFromSchemaProps> = ({
         // @ts-ignore
         <TabItem
           label={translate({
-            id: OPENAPI_RESPONSE_EXAMPLES.AUTO_EXAMPLE,
+            id: "theme.openapi.responseExamples.autoExample",
             message: "Example (auto)",
           })}
           value="Example (auto)"
@@ -192,7 +191,7 @@ export const ExampleFromSchema: React.FC<ExampleFromSchemaProps> = ({
       // @ts-ignore
       <TabItem
         label={translate({
-          id: OPENAPI_RESPONSE_EXAMPLES.AUTO_EXAMPLE,
+          id: "theme.openapi.responseExamples.autoExample",
           message: "Example (auto)",
         })}
         value="Example (auto)"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ResponseSchema/index.tsx
@@ -22,7 +22,6 @@ import SchemaExpansionControl from "@theme/SchemaExpansion";
 import SchemaTabs from "@theme/SchemaTabs";
 import SkeletonLoader from "@theme/SkeletonLoader";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_SCHEMA, OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 import type { MediaTypeObject } from "docusaurus-plugin-openapi-docs/src/openapi/types";
 
 interface Props {
@@ -72,7 +71,7 @@ const ResponseSchemaComponent: React.FC<Props> = ({
               <TabItem key={mimeType} label={mimeType} value={mimeType}>
                 <div>
                   {translate({
-                    id: OPENAPI_SCHEMA.NO_SCHEMA,
+                    id: "theme.openapi.schema.noSchema",
                     message: "No schema",
                   })}
                 </div>
@@ -98,7 +97,7 @@ const ResponseSchemaComponent: React.FC<Props> = ({
                           {body.required === true && (
                             <span className="openapi-schema__required">
                               {translate({
-                                id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                                id: "theme.openapi.schemaItem.required",
                                 message: "required",
                               })}
                             </span>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -22,7 +22,6 @@ import {
 import SchemaItem from "@theme/SchemaItem";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { merge } from "allof-merge";
 import clsx from "clsx";
@@ -261,7 +260,7 @@ const Summary: React.FC<SummaryProps> = ({
         {nullable && (
           <span className="openapi-schema__nullable">
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.NULLABLE,
+              id: "theme.openapi.schemaItem.nullable",
               message: "nullable",
             })}
           </span>
@@ -269,7 +268,7 @@ const Summary: React.FC<SummaryProps> = ({
         {isRequired && (
           <span className="openapi-schema__required">
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+              id: "theme.openapi.schemaItem.required",
               message: "required",
             })}
           </span>
@@ -277,7 +276,7 @@ const Summary: React.FC<SummaryProps> = ({
         {deprecated && (
           <span className="openapi-schema__deprecated">
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.DEPRECATED,
+              id: "theme.openapi.schemaItem.deprecated",
               message: "deprecated",
             })}
           </span>
@@ -314,8 +313,8 @@ const AnyOneOf: React.FC<SchemaProps> = ({
   }
 
   const type = schema.oneOf
-    ? translate({ id: OPENAPI_SCHEMA_ITEM.ONE_OF, message: "oneOf" })
-    : translate({ id: OPENAPI_SCHEMA_ITEM.ANY_OF, message: "anyOf" });
+    ? translate({ id: "theme.openapi.schemaItem.oneOf", message: "oneOf" })
+    : translate({ id: "theme.openapi.schemaItem.anyOf", message: "anyOf" });
 
   // Generate a unique ID for this anyOf/oneOf to prevent tab value collisions
   const uniqueId = React.useMemo(
@@ -364,12 +363,12 @@ const AnyOneOf: React.FC<SchemaProps> = ({
           if (!label) {
             if (anyOneSchema.oneOf) {
               label = translate({
-                id: OPENAPI_SCHEMA_ITEM.ONE_OF,
+                id: "theme.openapi.schemaItem.oneOf",
                 message: "oneOf",
               });
             } else if (anyOneSchema.anyOf) {
               label = translate({
-                id: OPENAPI_SCHEMA_ITEM.ANY_OF,
+                id: "theme.openapi.schemaItem.anyOf",
                 message: "anyOf",
               });
             } else {
@@ -550,7 +549,7 @@ const PropertyDiscriminator: React.FC<SchemaEdgeProps> = ({
             {required && (
               <span className="openapi-schema__required">
                 {translate({
-                  id: OPENAPI_SCHEMA_ITEM.REQUIRED,
+                  id: "theme.openapi.schemaItem.required",
                   message: "required",
                 })}
               </span>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaExpansion/index.tsx
@@ -16,7 +16,6 @@ import React, {
 } from "react";
 
 import { translate } from "@docusaurus/Translate";
-import { OPENAPI_SCHEMA_EXPANSION } from "@theme/translationIds";
 import clsx from "clsx";
 
 import { useSchemaExpansion } from "./context";
@@ -146,17 +145,17 @@ const SchemaExpansionControl: React.FC = () => {
   if (!config.enabled) return null;
 
   const buttonLabel = translate({
-    id: OPENAPI_SCHEMA_EXPANSION.BUTTON_LABEL,
+    id: "theme.openapi.schema.expansion.button",
     message: "Schema expansion depth",
     description: "Aria/title tooltip for the schema expansion icon button",
   });
   const menuLabel = translate({
-    id: OPENAPI_SCHEMA_EXPANSION.MENU_LABEL,
+    id: "theme.openapi.schema.expansion.menu",
     message: "Schema expansion depth options",
     description: "Accessible label for the expansion options menu",
   });
   const allLabel = translate({
-    id: OPENAPI_SCHEMA_EXPANSION.ALL,
+    id: "theme.openapi.schema.expansion.all",
     message: "All",
     description: "Label for the expand-all option",
   });
@@ -201,7 +200,7 @@ const SchemaExpansionControl: React.FC = () => {
               ? allLabel
               : translate(
                   {
-                    id: OPENAPI_SCHEMA_EXPANSION.DEPTH_OPTION,
+                    id: "theme.openapi.schema.expansion.depthOption",
                     message: "Expand to depth {depth}",
                     description: "Accessible label for a depth option",
                   },

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaItem/index.tsx
@@ -10,7 +10,6 @@ import React, { ReactNode } from "react";
 import { translate } from "@docusaurus/Translate";
 import { Example } from "@theme/Example";
 import Markdown from "@theme/Markdown";
-import { OPENAPI_SCHEMA_ITEM } from "@theme/translationIds";
 import clsx from "clsx";
 
 import { getQualifierMessage } from "../../markdown/schema";
@@ -41,11 +40,11 @@ const transformEnumDescriptions = (
 const getEnumDescriptionMarkdown = (enumDescriptions?: [string, string][]) => {
   if (enumDescriptions?.length) {
     const enumValue = translate({
-      id: OPENAPI_SCHEMA_ITEM.ENUM_VALUE,
+      id: "theme.openapi.schemaItem.enumValue",
       message: "Enum Value",
     });
     const description = translate({
-      id: OPENAPI_SCHEMA_ITEM.ENUM_DESCRIPTION,
+      id: "theme.openapi.schemaItem.enumDescription",
       message: "Description",
     });
     return `| ${enumValue} | ${description} |
@@ -97,20 +96,29 @@ export default function SchemaItem(props: Props) {
     Array.isArray(required) ? required.includes(name) : required,
     () => (
       <span className="openapi-schema__required">
-        {translate({ id: OPENAPI_SCHEMA_ITEM.REQUIRED, message: "required" })}
+        {translate({
+          id: "theme.openapi.schemaItem.required",
+          message: "required",
+        })}
       </span>
     )
   );
 
   const renderDeprecated = guard(deprecated, () => (
     <span className="openapi-schema__deprecated">
-      {translate({ id: OPENAPI_SCHEMA_ITEM.DEPRECATED, message: "deprecated" })}
+      {translate({
+        id: "theme.openapi.schemaItem.deprecated",
+        message: "deprecated",
+      })}
     </span>
   ));
 
   const renderNullable = guard(nullable, () => (
     <span className="openapi-schema__nullable">
-      {translate({ id: OPENAPI_SCHEMA_ITEM.NULLABLE, message: "nullable" })}
+      {translate({
+        id: "theme.openapi.schemaItem.nullable",
+        message: "nullable",
+      })}
     </span>
   ));
 
@@ -148,7 +156,7 @@ export default function SchemaItem(props: Props) {
           <div>
             <strong>
               {translate({
-                id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+                id: "theme.openapi.schemaItem.defaultValue",
                 message: "Default value:",
               })}{" "}
             </strong>
@@ -162,7 +170,7 @@ export default function SchemaItem(props: Props) {
         <div>
           <strong>
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.DEFAULT_VALUE,
+              id: "theme.openapi.schemaItem.defaultValue",
               message: "Default value:",
             })}{" "}
           </strong>
@@ -182,7 +190,7 @@ export default function SchemaItem(props: Props) {
           <div>
             <strong>
               {translate({
-                id: OPENAPI_SCHEMA_ITEM.CONSTANT_VALUE,
+                id: "theme.openapi.schemaItem.constantValue",
                 message: "Constant value:",
               })}{" "}
             </strong>
@@ -196,7 +204,7 @@ export default function SchemaItem(props: Props) {
         <div>
           <strong>
             {translate({
-              id: OPENAPI_SCHEMA_ITEM.CONSTANT_VALUE,
+              id: "theme.openapi.schemaItem.constantValue",
               message: "Constant value:",
             })}{" "}
           </strong>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/StatusCodes/index.tsx
@@ -14,7 +14,6 @@ import Markdown from "@theme/Markdown";
 import ResponseHeaders from "@theme/ResponseHeaders";
 import ResponseSchema from "@theme/ResponseSchema";
 import TabItem from "@theme/TabItem";
-import { OPENAPI_STATUS_CODES } from "@theme/translationIds";
 import type { ApiItem } from "docusaurus-plugin-openapi-docs/src/types";
 
 interface Props {
@@ -55,7 +54,7 @@ const StatusCodes: React.FC<Props> = ({ label, id, responses }: any) => {
                   <summary>
                     <strong>
                       {translate({
-                        id: OPENAPI_STATUS_CODES.RESPONSE_HEADERS,
+                        id: "theme.openapi.statusCodes.responseHeaders",
                         message: "Response Headers",
                       })}
                     </strong>
@@ -67,7 +66,7 @@ const StatusCodes: React.FC<Props> = ({ label, id, responses }: any) => {
             )}
             <ResponseSchema
               title={translate({
-                id: OPENAPI_STATUS_CODES.SCHEMA_TITLE,
+                id: "theme.openapi.statusCodes.schemaTitle",
                 message: "Schema",
               })}
               body={{ content: response.content }}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/translationIds.ts
@@ -5,117 +5,41 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-export const OPENAPI_RESPONSE = {
-  TITLE: "theme.openapi.response.title",
-  CLEAR: "theme.openapi.response.clear",
-  PLACEHOLDER: "theme.openapi.response.placeholder",
-  HEADERS_TAB: "theme.openapi.response.headersTab",
-};
+/*
+ * The central dictionary of translation-id constants that used to live here
+ * (OPENAPI_REQUEST, OPENAPI_SCHEMA_ITEM, ...) has been removed. Each
+ * `translate({ id, message })` / `<Translate id="...">` call site now passes
+ * its id as an inline string literal instead.
+ *
+ * WHY THE DICTIONARY WAS REMOVED
+ * ------------------------------
+ * `docusaurus write-translations` only performs STATIC analysis of the source
+ * code (via @docusaurus/babel) — it never runs the site. To collect a string
+ * it evaluates the argument of every `translate()` / `<Translate>` call with
+ * Babel's `path.evaluate()` and keeps it only when the result is `confident`.
+ *
+ * An id referenced through an imported constant, e.g.
+ *
+ *     import { OPENAPI_REQUEST } from "@theme/translationIds";
+ *     translate({ id: OPENAPI_REQUEST.COLLAPSE_ALL, message: "Collapse all" });
+ *
+ * is a member expression on a binding imported from another module. Babel
+ * cannot statically resolve a cross-module binding, so `evaluate()` returns
+ * `confident === false`, the extractor skips the call (emitting a warning), and
+ * NOTHING is written to the locale `code.json`. As a result `write-translations`
+ * produced an empty template and downstream projects had no ids to translate,
+ * even though the strings rendered fine at runtime (the inlined constant value
+ * matched the runtime lookup key).
+ *
+ * The id and message must therefore be static string literals AT THE CALL SITE.
+ * This is the approach Docusaurus' own theme-classic uses and what its i18n
+ * guide mandates ("Text labels must be static"):
+ *
+ *   - https://docusaurus.io/docs/i18n/tutorial#translate-your-react-code
+ *   - https://docusaurus.io/docs/docusaurus-core#translate
+ *
+ * Keep this note here so the removal of the constants is discoverable; do not
+ * reintroduce a shared id dictionary for `translate()` arguments.
+ */
 
-export const OPENAPI_TABS = {
-  RESPONSES_LABEL: "theme.openapi.tabs.responses.label",
-};
-
-export const OPENAPI_REQUEST = {
-  BODY_TITLE: "theme.openapi.request.body.title",
-  ACCEPT_TITLE: "theme.openapi.request.accept.title",
-  SEND_BUTTON: "theme.openapi.request.sendButton",
-  REQUIRED_LABEL: "theme.openapi.request.requiredLabel",
-  REQUEST_TITLE: "theme.openapi.request.title",
-  COLLAPSE_ALL: "theme.openapi.request.collapseAll",
-  EXPAND_ALL: "theme.openapi.request.expandAll",
-  BASE_URL_TITLE: "theme.openapi.request.baseUrl.title",
-  AUTH_TITLE: "theme.openapi.request.auth.title",
-  PARAMETERS_TITLE: "theme.openapi.request.parameters.title",
-  FETCHING_MESSAGE: "theme.openapi.request.fetchingMessage",
-  CONNECTION_FAILED: "theme.openapi.request.connectionFailed",
-  ERROR_TIMEOUT: "theme.openapi.request.error.timeout",
-  ERROR_NETWORK: "theme.openapi.request.error.network",
-  ERROR_CORS: "theme.openapi.request.error.cors",
-  ERROR_UNKNOWN: "theme.openapi.request.error.unknown",
-};
-
-export const OPENAPI_SERVER = {
-  EDIT_BUTTON: "theme.openapi.server.editButton",
-  HIDE_BUTTON: "theme.openapi.server.hideButton",
-};
-
-export const OPENAPI_PARAM_OPTIONS = {
-  SHOW_OPTIONAL: "theme.openapi.paramOptions.showOptional",
-  HIDE_OPTIONAL: "theme.openapi.paramOptions.hideOptional",
-};
-
-export const OPENAPI_FORM_FILE_UPLOAD = {
-  CLEAR_BUTTON: "theme.openapi.formFileUpload.clearButton",
-};
-
-export const OPENAPI_FORM = {
-  FIELD_REQUIRED: "theme.openapi.form.fieldRequired",
-};
-
-export const OPENAPI_AUTH = {
-  BEARER_TOKEN: "theme.openapi.auth.bearerToken",
-  USERNAME: "theme.openapi.auth.username",
-  PASSWORD: "theme.openapi.auth.password",
-  SECURITY_SCHEME: "theme.openapi.auth.securityScheme",
-};
-
-export const OPENAPI_RESPONSE_EXAMPLES = {
-  EXAMPLE: "theme.openapi.responseExamples.example",
-  AUTO_EXAMPLE: "theme.openapi.responseExamples.autoExample",
-};
-
-export const OPENAPI_BODY = {
-  EXAMPLE_FROM_SCHEMA: "theme.openapi.body.exampleFromSchema",
-};
-
-export const OPENAPI_STATUS_CODES = {
-  RESPONSE_HEADERS: "theme.openapi.statusCodes.responseHeaders",
-  SCHEMA_TITLE: "theme.openapi.statusCodes.schemaTitle",
-};
-
-export const OPENAPI_SCHEMA = {
-  NO_SCHEMA: "theme.openapi.schema.noSchema",
-};
-
-export const OPENAPI_SCHEMA_EXPANSION = {
-  BUTTON_LABEL: "theme.openapi.schema.expansion.button",
-  MENU_LABEL: "theme.openapi.schema.expansion.menu",
-  ALL: "theme.openapi.schema.expansion.all",
-  DEPTH_OPTION: "theme.openapi.schema.expansion.depthOption",
-};
-
-export const OPENAPI_SCHEMA_ITEM = {
-  CHARACTERS: "theme.openapi.schemaItem.characters",
-  NON_EMPTY: "theme.openapi.schemaItem.nonEmpty",
-  REQUIRED: "theme.openapi.schemaItem.required",
-  DEPRECATED: "theme.openapi.schemaItem.deprecated",
-  NULLABLE: "theme.openapi.schemaItem.nullable",
-  DEFAULT_VALUE: "theme.openapi.schemaItem.defaultValue",
-  EXAMPLE: "theme.openapi.schemaItem.example",
-  EXAMPLES: "theme.openapi.schemaItem.examples",
-  DESCRIPTION: "theme.openapi.schemaItem.description",
-  CONSTANT_VALUE: "theme.openapi.schemaItem.constantValue",
-  ENUM_VALUE: "theme.openapi.schemaItem.enumValue",
-  ENUM_DESCRIPTION: "theme.openapi.schemaItem.enumDescription",
-  POSSIBLE_VALUES: "theme.openapi.schemaItem.possibleValues",
-  EXPRESSION: "theme.openapi.schemaItem.expression",
-  ONE_OF: "theme.openapi.schemaItem.oneOf",
-  ANY_OF: "theme.openapi.schemaItem.anyOf",
-};
-
-export const OPENAPI_PARAMS_DETAILS = {
-  PARAMETERS_TITLE: "theme.openapi.paramsDetails.parametersTitle",
-};
-
-export const OPENAPI_SECURITY_SCHEMES = {
-  NAME: "theme.openapi.securitySchemes.name",
-  TYPE: "theme.openapi.securitySchemes.type",
-  SCOPES: "theme.openapi.securitySchemes.scopes",
-  IN: "theme.openapi.securitySchemes.in",
-  FLOWS: "theme.openapi.securitySchemes.flows",
-  DESCRIPTION: "theme.openapi.securitySchemes.description",
-  SCHEME: "theme.openapi.securitySchemes.scheme",
-  BEARER_FORMAT: "theme.openapi.securitySchemes.bearerFormat",
-  OPEN_ID_CONNECT_URL: "theme.openapi.securitySchemes.openIdConnectUrl",
-};
+export {};


### PR DESCRIPTION
## Description

Every UI string in the theme was wrapped with `translate()` / `<Translate>`, but the `id` was referenced through constants imported from `translationIds.ts`. Docusaurus' `write-translations` only performs static analysis (@docusaurus/babel): it evaluates each call's argument with Babel's `path.evaluate()` and keeps it only when the result is `confident`. An id read from an imported constant is a cross-module member expression that Babel cannot statically resolve, so every call was skipped (with a warning) and nothing was written to the locale `code.json`. Consuming projects therefore got an empty translation template even though the English defaults rendered fine at runtime.

## Changes:
- Inline all translation ids as string literals at the call site — the approach Docusaurus theme-classic uses and its i18n guide mandates ("Text labels must be static"): https://docusaurus.io/docs/i18n/tutorial#translate-your-react-code
- Remove the `translationIds.ts` dictionary; keep an explanatory note in its place so the removal is discoverable and the pattern isn't reintroduced.
- Wrap strings that were not localized at all: Authorization (SecuritySchemes), Export / OpenAPI Spec (Export), Add item (ParamArrayFormItem).
- Replace the dynamic `translate({ id: someVar })` in SecuritySchemes.renderRest with static per-key calls so description/scheme/bearerFormat/openIdConnectUrl are extracted too.

`write-translations` now statically extracts all `theme.openapi.*` ids.

Part of #319 
Improve of #1210 