### PR TITLE
fix(plugin): prioritize static paths over parametric in Postman binding

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Deploy to Firebase
         id: deploy_live
-        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.10.0+node24 (pending release)
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ steps.creds.outputs.sa_key }}"
@@ -106,7 +106,6 @@ jobs:
           target: ${{ secrets.FIREBASE_SITE }}
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
   cache_prod_screenshots:
     name: Cache Prod Screenshots

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -199,17 +199,15 @@ jobs:
 
       - name: Deploy to Firebase
         id: deploy_preview
-        uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0.10.0
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.10.0+node24 (pending release)
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ steps.creds.outputs.sa_key }}"
           projectId: ${{ secrets.FIREBASE_PROJECT_ID }}
           expires: 7d
           channelId: "pr${{ github.event.number }}"
-          totalPreviewChannelLimit: 25
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
   visual_diff:
     name: Visual Diff

--- a/__mocks__/@apidevtools/json-schema-ref-parser.js
+++ b/__mocks__/@apidevtools/json-schema-ref-parser.js
@@ -1,0 +1,16 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+// CJS stub for @apidevtools/json-schema-ref-parser (ESM-only in v15+).
+// Returns the input unchanged — sufficient for tests using inline specs
+// without $ref pointers.
+const $RefParser = {
+  dereference: async (input) => input,
+};
+
+module.exports = $RefParser;
+module.exports.default = $RefParser;

--- a/__mocks__/@redocly/openapi-core.js
+++ b/__mocks__/@redocly/openapi-core.js
@@ -1,0 +1,29 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+// CJS stub for @redocly/openapi-core (ESM-only).
+// For inline specs (doc provided), returns them unchanged.
+// For file refs, reads and parses the YAML/JSON from disk.
+const fs = require("fs");
+const yaml = require("yaml");
+
+module.exports = {
+  createConfig: async () => ({}),
+  bundle: async (opts) => {
+    if (opts.doc) {
+      return { bundle: { parsed: opts.doc.parsed } };
+    }
+    if (opts.ref) {
+      const content = fs.readFileSync(opts.ref, "utf8");
+      const parsed = opts.ref.endsWith(".json")
+        ? JSON.parse(content)
+        : yaml.parse(content);
+      return { bundle: { parsed } };
+    }
+    return { bundle: { parsed: {} } };
+  },
+};

--- a/__mocks__/chalk.js
+++ b/__mocks__/chalk.js
@@ -1,0 +1,15 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+// Passthrough stub for chalk (v5 is ESM-only and incompatible with Jest/ts-jest).
+// Supports chained access like chalk.cyan.bold.underline("text").
+const chalk = new Proxy((...args) => args.join(""), {
+  get: (_, prop) => (prop === "default" ? chalk : chalk),
+});
+
+module.exports = chalk;
+module.exports.default = chalk;

--- a/demo/examples/tests/pathOrdering.yaml
+++ b/demo/examples/tests/pathOrdering.yaml
@@ -1,0 +1,94 @@
+openapi: 3.0.1
+info:
+  title: Path Ordering Tests
+  version: 1.0.0
+  description: |
+    Validates that static path segments are correctly resolved when declared
+    after parametric paths at the same nesting level. The `/pet/findByTags`
+    endpoint must show the full URL in code samples, not just the base server.
+
+    Regression coverage for: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1519
+
+servers:
+  - url: https://petstore.swagger.io/v2
+
+tags:
+  - name: path-ordering
+    description: Path ordering regression tests
+
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - path-ordering
+      summary: Finds Pets by status
+      description: |
+        Expected URL in code samples:
+        `https://petstore.swagger.io/v2/pet/findByStatus`
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+            default:
+              - available
+      responses:
+        "200":
+          description: Success
+
+  /pet/{petId}:
+    get:
+      tags:
+        - path-ordering
+      summary: Find pet by ID
+      description: |
+        Expected URL in code samples:
+        `https://petstore.swagger.io/v2/pet/{petId}`
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return.
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Success
+
+  /pet/findByTags:
+    get:
+      tags:
+        - path-ordering
+      summary: Finds Pets by tags
+      description: |
+        This endpoint is declared after `/pet/{petId}` in the spec to verify
+        that path ordering does not affect URL construction.
+
+        Expected URL in code samples:
+        `https://petstore.swagger.io/v2/pet/findByTags`
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Success

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,10 @@ module.exports = {
     "<rootDir>/packages/docusaurus-theme-openapi-docs/src",
   ],
   moduleNameMapper: {
+    "^chalk$": "<rootDir>/__mocks__/chalk.js",
+    "^@apidevtools/json-schema-ref-parser$":
+      "<rootDir>/__mocks__/@apidevtools/json-schema-ref-parser.js",
+    "^@redocly/openapi-core$": "<rootDir>/__mocks__/@redocly/openapi-core.js",
     "^neotraverse/legacy$":
       "<rootDir>/node_modules/neotraverse/dist/legacy/legacy.cjs",
   },

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -272,6 +272,117 @@ describe("openapi", () => {
     });
   });
 
+  describe("static paths after parametric paths (#1519)", () => {
+    it("binds correct postman requests when static paths follow parametric siblings", async () => {
+      const openapiData = {
+        openapi: "3.0.1",
+        info: {
+          title: "Petstore",
+          version: "0.0.1",
+          description: "This is a sample server Petstore server.",
+        },
+        servers: [{ url: "https://petstore.swagger.io/v2" }],
+        paths: {
+          "/pet/findByStatus": {
+            get: {
+              summary: "Finds Pets by status",
+              operationId: "findPetsByStatus",
+              parameters: [
+                {
+                  name: "status",
+                  in: "query",
+                  required: true,
+                  schema: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                      enum: ["available", "pending", "sold"],
+                    },
+                    default: ["available"],
+                  },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/pet/{petId}": {
+            get: {
+              summary: "Find pet by ID",
+              operationId: "getPetById",
+              parameters: [
+                {
+                  name: "petId",
+                  in: "path",
+                  required: true,
+                  schema: { type: "integer", format: "int64" },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/pet/findByTags": {
+            get: {
+              summary: "Finds Pets by tags",
+              operationId: "findPetsByTags",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  required: true,
+                  style: "form",
+                  explode: true,
+                  schema: {
+                    type: "array",
+                    items: { type: "string" },
+                  },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      };
+
+      const options: APIOptions = {
+        specPath: "dummy",
+        outputDir: "build",
+      };
+      const sidebarOptions = {} as SidebarOptions;
+      const [items] = await processOpenapiFile(
+        openapiData as any,
+        options,
+        sidebarOptions
+      );
+
+      const apiItems = items.filter((item) => item.type === "api");
+      expect(apiItems).toHaveLength(3);
+
+      const findByStatus = apiItems.find(
+        (item) => item.type === "api" && item.id === "find-pets-by-status"
+      ) as any;
+      expect(findByStatus.api.postman).toBeDefined();
+      expect(
+        findByStatus.api.postman.url.getPath({ unresolved: true })
+      ).toContain("/pet/findByStatus");
+
+      const getPetById = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-pet-by-id"
+      ) as any;
+      expect(getPetById.api.postman).toBeDefined();
+      expect(
+        getPetById.api.postman.url.getPath({ unresolved: true })
+      ).toContain("/pet/:petId");
+
+      const findByTags = apiItems.find(
+        (item) => item.type === "api" && item.id === "find-pets-by-tags"
+      ) as any;
+      expect(findByTags.api.postman).toBeDefined();
+      expect(
+        findByTags.api.postman.url.getPath({ unresolved: true })
+      ).toContain("/pet/findByTags");
+    });
+  });
+
   describe("vendor extensions at path level", () => {
     it("does not throw and skips x-* keys and unknown keys on path objects", async () => {
       const openapiData = {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -602,7 +602,9 @@ function bindCollectionToApiItems(
       apiItem: item,
       method: item.api.method.toLowerCase(),
       pathMatcher: pathTemplateToRegex(item.api.path),
-    }));
+      hasParams: /\{[^}]+\}/.test(item.api.path),
+    }))
+    .sort((a, b) => Number(a.hasParams) - Number(b.hasParams));
 
   postmanCollection.forEachItem((item: any) => {
     const method = item.request.method.toLowerCase();


### PR DESCRIPTION
## Summary

Closes #1519

- Sort `apiMatchers` in `bindCollectionToApiItems()` so static paths are tested before parametric ones, preventing greedy regex from stealing matches when static paths (e.g. `/pet/findByTags`) are declared after parametric siblings (e.g. `/pet/{petId}`)
- Add CJS stubs for ESM-only dependencies (chalk v5, `@apidevtools/json-schema-ref-parser`, `@redocly/openapi-core`) to fix pre-existing Jest test suite failures
- Add unit test reproducing the exact #1519 scenario and demo spec for visual regression testing

## Test plan

- [x] All 9 test suites pass (83/83 tests), including new path ordering test
- [x] Visually verified all 3 demo pages (`findByStatus`, `getPetById`, `findByTags`) show correct URLs in endpoint bar and code samples
- [x] Confirmed `findByTags` page no longer shows base URL only (the reported bug)
- [x] Confirmed `getPetById` page no longer shows `findByTags` path (the secondary bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)