### PR TITLE
refactor: reduce lodash footprint (follow-up to #1509)

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -48,7 +48,7 @@
     "fs-extra": "^11.3.0",
     "json-pointer": "^0.6.2",
     "json5": "^2.2.3",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "mustache": "^4.2.0",
     "openapi-to-postmanv2": "^6.0.0",
     "postman-collection": "^5.0.2",

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -8,7 +8,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { merge } from "allof-merge";
 import clsx from "clsx";
-import isEmpty from "lodash/isEmpty";
 
 import {
   createClosingArrayBracket,
@@ -249,7 +248,10 @@ function createAdditionalProperties(schema: SchemaObject) {
   if (!additionalProperties) return [];
 
   // Handle free-form objects
-  if (additionalProperties === true || isEmpty(additionalProperties)) {
+  if (
+    additionalProperties === true ||
+    Object.keys(additionalProperties).length === 0
+  ) {
     return create("SchemaItem", {
       name: "property name*",
       required: false,

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -13,7 +13,6 @@ import fs from "fs-extra";
 import cloneDeep from "lodash/cloneDeep";
 import kebabCase from "lodash/kebabCase";
 import unionBy from "lodash/unionBy";
-import uniq from "lodash/uniq";
 import Converter from "openapi-to-postmanv2";
 import { Collection } from "postman-collection";
 import * as sdk from "postman-collection";
@@ -516,11 +515,13 @@ function createItems(
     const apiItems = items.filter((item) => {
       return item.type === "api";
     }) as ApiPageMetadata[];
-    const operationTags = uniq(
-      apiItems
-        .flatMap((item) => item.api.tags)
-        .filter((item): item is string => !!item)
-    );
+    const operationTags = [
+      ...new Set(
+        apiItems
+          .flatMap((item) => item.api.tags)
+          .filter((item): item is string => !!item)
+      ),
+    ];
 
     // eslint-disable-next-line array-callback-return
     tags

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -15,7 +15,7 @@ import {
 } from "@docusaurus/plugin-content-docs/src/sidebars/types";
 import { posixPath } from "@docusaurus/utils";
 import clsx from "clsx";
-import { kebabCase } from "lodash";
+import kebabCase from "lodash/kebabCase";
 
 import { TagGroupObject, TagObject } from "../openapi/types";
 import type {

--- a/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/sidebars/index.ts
@@ -16,7 +16,6 @@ import {
 import { posixPath } from "@docusaurus/utils";
 import clsx from "clsx";
 import { kebabCase } from "lodash";
-import uniq from "lodash/uniq";
 
 import { TagGroupObject, TagObject } from "../openapi/types";
 import type {
@@ -101,16 +100,20 @@ function groupByTags(
   });
 
   // TODO: make sure we only take the first tag
-  const operationTags = uniq(
-    apiItems
-      .flatMap((item) => item.api.tags)
-      .filter((item): item is string => !!item)
-  );
-  const schemaTags = uniq(
-    schemaItems
-      .flatMap((item) => item.schema["x-tags"])
-      .filter((item): item is string => !!item)
-  );
+  const operationTags = [
+    ...new Set(
+      apiItems
+        .flatMap((item) => item.api.tags)
+        .filter((item): item is string => !!item)
+    ),
+  ];
+  const schemaTags = [
+    ...new Set(
+      schemaItems
+        .flatMap((item) => item.schema["x-tags"])
+        .filter((item): item is string => !!item)
+    ),
+  ];
 
   // Combine globally defined tags with operation and schema tags
   // Only include global tag if referenced in operation/schema tags
@@ -123,7 +126,7 @@ function groupByTags(
   });
 
   if (sidebarOptions.groupPathsBy !== "tagGroup") {
-    apiTags = uniq(apiTags.concat(operationTags, schemaTags));
+    apiTags = [...new Set(apiTags.concat(operationTags, schemaTags))];
   }
 
   // Extract base path from outputDir, handling cases where docPath may not be in outputDir

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -51,7 +51,7 @@
     "copy-text-to-clipboard": "^3.2.0",
     "crypto-js": "^4.2.0",
     "file-saver": "^2.0.5",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "pako": "^2.1.0",
     "path-browserify": "^1.0.1",
     "postman-code-generators": "^2.0.0",

--- a/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/ApiExplorer/CodeSnippets/languages.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import find from "lodash/find";
 import mergeWith from "lodash/mergeWith";
 import unionBy from "lodash/unionBy";
 import codegen from "postman-code-generators";
@@ -58,8 +57,8 @@ export const mergeArraysbyLanguage = (arr1: any, arr2: any) => {
 
   return mergedArray.map((item: any) => {
     const matchingItems = [
-      find(arr1, ["language", item["language"]]),
-      find(arr2, ["language", item["language"]]),
+      arr1?.find((el: any) => el["language"] === item["language"]),
+      arr2?.find((el: any) => el["language"] === item["language"]),
     ];
     return mergeWith({}, ...matchingItems, (objValue: any) => {
       return objValue;

--- a/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/DiscriminatorTabs/index.tsx
@@ -15,7 +15,6 @@ import React, {
 
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import clsx from "clsx";
-import flatten from "lodash/flatten";
 
 import { useScrollPositionBlocker } from "@theme/utils/scrollUtils";
 import {
@@ -179,7 +178,7 @@ function TabContent({
   const childTabs = (Array.isArray(children) ? children : [children]).filter(
     Boolean
   ) as ReactElement<TabItemProps>[];
-  const flattenedChildTabs = flatten(childTabs);
+  const flattenedChildTabs = childTabs.flat();
   if (lazy) {
     const selectedTabItem = flattenedChildTabs.find(
       (tabItem) => tabItem.props.value === selectedValue

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -25,7 +25,6 @@ import TabItem from "@theme/TabItem";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { merge } from "allof-merge";
 import clsx from "clsx";
-import isEmpty from "lodash/isEmpty";
 
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
 import type { SchemaObject } from "../../types.d";
@@ -700,7 +699,10 @@ const AdditionalProperties: React.FC<SchemaProps> = ({
   if (!additionalProperties) return null;
 
   // Handle free-form objects
-  if (additionalProperties === true || isEmpty(additionalProperties)) {
+  if (
+    additionalProperties === true ||
+    Object.keys(additionalProperties).length === 0
+  ) {
     return (
       <SchemaItem
         name="property name*"

--- a/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/SchemaTabs/index.tsx
@@ -16,7 +16,6 @@ import React, {
 
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import clsx from "clsx";
-import flatten from "lodash/flatten";
 
 import { useScrollPositionBlocker } from "@theme/utils/scrollUtils";
 import {
@@ -194,7 +193,7 @@ function TabContent({
   const childTabs = (Array.isArray(children) ? children : [children]).filter(
     Boolean
   ) as ReactElement<TabItemProps>[];
-  const flattenedChildTabs = flatten(childTabs);
+  const flattenedChildTabs = childTabs.flat();
   if (lazy) {
     const selectedTabItem = flattenedChildTabs.find(
       (tabItem) => tabItem.props.value === selectedValue


### PR DESCRIPTION
## Summary

Follow-up to the discussion in #1509. That issue proposed swapping `lodash` for `es-toolkit`; @sserrata closed it in favor of three lower-risk steps and noted PRs for items 1–3 would be welcome. This PR implements all three.

Each item is a separate commit so they can be reviewed (or dropped) independently:

1. **`build(deps): bump lodash to ^4.18.1`** — picks up the security patches released in the lodash 4.18.x line.
2. **`refactor: replace lodash find/flatten/uniq/isEmpty with native JS`** — removes the four utilities that have direct native equivalents:
   - `uniq` → `[...new Set(...)]` (`openapi.ts`, `sidebars/index.ts`)
   - `flatten` → `Array.prototype.flat()` (`DiscriminatorTabs`, `SchemaTabs`)
   - `find` → `Array.prototype.find()` (`languages.ts`)
   - `isEmpty` → `Object.keys(x).length === 0` (`createSchema.ts`, `Schema`)
3. **`refactor: use lodash subpath import for kebabCase in sidebars`** — switches the one remaining barrel import (`import { kebabCase } from "lodash"`) to the subpath form so the rest of lodash can be tree-shaken. Every other lodash usage already imports from a subpath.

The remaining lodash utilities (`merge`, `mergeWith`, `cloneDeep`, `kebabCase`, `unionBy`) are kept and could be vendored later (item 4) if the project wants to drop the dependency entirely.

## Notes on correctness

- The two `isEmpty` call sites are both guarded by a preceding truthiness check (`if (!additionalProperties) return ...`), so the value is always a non-null object at the call — `Object.keys(x).length === 0` is equivalent there.
- The `find` replacement keeps optional chaining (`arr1?.find(...)`) to preserve lodash's tolerance of a nullish collection.
- `lodash.flatten` flattens a single level, which matches `Array.prototype.flat()`'s default depth of 1.

## Testing

- `yarn build` (tsc) passes for both `docusaurus-plugin-openapi-docs` and `docusaurus-theme-openapi-docs`.
- All test suites covering the changed files pass (`sidebars`, `languages`, `openapi`, `webhooks`).
- One unrelated suite (`createSchema.test.ts`) fails, but it fails identically on a clean `main` checkout (an `allof-merge` issue) — it is not affected by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
