### PR TITLE
fix(theme): hoist schema normalization out of render path

### DIFF
--- a/demo/examples/tests/circularRef.yaml
+++ b/demo/examples/tests/circularRef.yaml
@@ -1,0 +1,247 @@
+openapi: 3.0.3
+info:
+  title: Circular Reference API
+  description: |
+    Tests various circular `$ref` patterns that produce `circular(Title)` markers
+    after dereferencing. Validates that the schema renderer handles self-references,
+    mutual recursion, and nested circular structures without hanging or losing the
+    circular badge.
+  version: 1.0.0
+tags:
+  - name: circular-ref
+    description: Circular reference tests
+paths:
+  /tree-node:
+    get:
+      tags:
+        - circular-ref
+      summary: Self-referencing tree node
+      description: |
+        A tree node whose `children` array references itself. The simplest
+        circular reference pattern.
+      responses:
+        "200":
+          description: A tree node
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TreeNode"
+
+  /category:
+    get:
+      tags:
+        - circular-ref
+      summary: Self-referencing category with parent
+      description: |
+        A category that references itself through both `parent` (single ref)
+        and `subcategories` (array of refs). Tests circular refs in both
+        property and items positions.
+      responses:
+        "200":
+          description: A category
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Category"
+
+  /person:
+    get:
+      tags:
+        - circular-ref
+      summary: Mutual recursion between Person and Address
+      description: |
+        `Person` has an `address` referencing `Address`, and `Address` has an
+        `occupants` array referencing `Person`. Tests circular refs across two
+        mutually recursive schemas.
+      responses:
+        "200":
+          description: A person
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+
+  /org-chart:
+    get:
+      tags:
+        - circular-ref
+      summary: Circular ref via additionalProperties
+      description: |
+        An org chart where the value type of `additionalProperties` references
+        the parent schema. Tests circular refs in the additionalProperties position.
+      responses:
+        "200":
+          description: An org chart node
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrgChart"
+
+  /comment-thread:
+    post:
+      tags:
+        - circular-ref
+      summary: Circular ref inside allOf composition
+      description: |
+        A comment that uses `allOf` to compose shared metadata with a `replies`
+        array that references the composed schema. Tests that circular markers
+        inside allOf are preserved during normalization.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Comment"
+      responses:
+        "201":
+          description: Created comment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comment"
+
+  /linked-list:
+    get:
+      tags:
+        - circular-ref
+      summary: Deeply nested circular ref
+      description: |
+        A linked list node with `next` referencing itself through a wrapper
+        object. Tests circular refs that are not direct self-references but
+        go through an intermediate schema.
+      responses:
+        "200":
+          description: A linked list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LinkedListNode"
+
+components:
+  schemas:
+    TreeNode:
+      title: TreeNode
+      type: object
+      properties:
+        id:
+          type: integer
+        label:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/TreeNode"
+      required:
+        - id
+        - label
+
+    Category:
+      title: Category
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        parent:
+          $ref: "#/components/schemas/Category"
+        subcategories:
+          type: array
+          items:
+            $ref: "#/components/schemas/Category"
+      required:
+        - id
+        - name
+
+    Person:
+      title: Person
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        address:
+          $ref: "#/components/schemas/Address"
+      required:
+        - name
+
+    Address:
+      title: Address
+      type: object
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        occupants:
+          type: array
+          items:
+            $ref: "#/components/schemas/Person"
+      required:
+        - street
+        - city
+
+    OrgChart:
+      title: OrgChart
+      type: object
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+      additionalProperties:
+        $ref: "#/components/schemas/OrgChart"
+
+    TimestampMixin:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    Comment:
+      title: Comment
+      allOf:
+        - $ref: "#/components/schemas/TimestampMixin"
+        - type: object
+          properties:
+            id:
+              type: integer
+            author:
+              type: string
+            body:
+              type: string
+            replies:
+              type: array
+              items:
+                $ref: "#/components/schemas/Comment"
+          required:
+            - id
+            - author
+            - body
+
+    LinkedListNode:
+      title: LinkedListNode
+      type: object
+      properties:
+        value:
+          type: string
+        next:
+          $ref: "#/components/schemas/ListNodeWrapper"
+
+    ListNodeWrapper:
+      title: ListNodeWrapper
+      type: object
+      properties:
+        node:
+          $ref: "#/components/schemas/LinkedListNode"
+        metadata:
+          type: object
+          properties:
+            position:
+              type: integer

--- a/demo/examples/tests/circularRef.yaml
+++ b/demo/examples/tests/circularRef.yaml
@@ -19,6 +19,21 @@ paths:
       description: |
         A tree node whose `children` array references itself. The simplest
         circular reference pattern.
+
+        Schema:
+        ```yaml
+        TreeNode:
+          type: object
+          properties:
+            id:
+              type: integer
+            label:
+              type: string
+            children:
+              type: array
+              items:
+                $ref: "#/components/schemas/TreeNode"
+        ```
       responses:
         "200":
           description: A tree node
@@ -36,6 +51,23 @@ paths:
         A category that references itself through both `parent` (single ref)
         and `subcategories` (array of refs). Tests circular refs in both
         property and items positions.
+
+        Schema:
+        ```yaml
+        Category:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+            parent:
+              $ref: "#/components/schemas/Category"
+            subcategories:
+              type: array
+              items:
+                $ref: "#/components/schemas/Category"
+        ```
       responses:
         "200":
           description: A category
@@ -53,6 +85,32 @@ paths:
         `Person` has an `address` referencing `Address`, and `Address` has an
         `occupants` array referencing `Person`. Tests circular refs across two
         mutually recursive schemas.
+
+        Schema:
+        ```yaml
+        Person:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
+              format: email
+            address:
+              $ref: "#/components/schemas/Address"
+
+        Address:
+          type: object
+          properties:
+            street:
+              type: string
+            city:
+              type: string
+            occupants:
+              type: array
+              items:
+                $ref: "#/components/schemas/Person"
+        ```
       responses:
         "200":
           description: A person
@@ -69,6 +127,19 @@ paths:
       description: |
         An org chart where the value type of `additionalProperties` references
         the parent schema. Tests circular refs in the additionalProperties position.
+
+        Schema:
+        ```yaml
+        OrgChart:
+          type: object
+          properties:
+            name:
+              type: string
+            title:
+              type: string
+          additionalProperties:
+            $ref: "#/components/schemas/OrgChart"
+        ```
       responses:
         "200":
           description: An org chart node
@@ -86,6 +157,25 @@ paths:
         A comment that uses `allOf` to compose shared metadata with a `replies`
         array that references the composed schema. Tests that circular markers
         inside allOf are preserved during normalization.
+
+        Schema:
+        ```yaml
+        Comment:
+          allOf:
+            - $ref: "#/components/schemas/TimestampMixin"
+            - type: object
+              properties:
+                id:
+                  type: integer
+                author:
+                  type: string
+                body:
+                  type: string
+                replies:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/Comment"
+        ```
       requestBody:
         required: true
         content:
@@ -109,6 +199,28 @@ paths:
         A linked list node with `next` referencing itself through a wrapper
         object. Tests circular refs that are not direct self-references but
         go through an intermediate schema.
+
+        Schema:
+        ```yaml
+        LinkedListNode:
+          type: object
+          properties:
+            value:
+              type: string
+            next:
+              $ref: "#/components/schemas/ListNodeWrapper"
+
+        ListNodeWrapper:
+          type: object
+          properties:
+            node:
+              $ref: "#/components/schemas/LinkedListNode"
+            metadata:
+              type: object
+              properties:
+                position:
+                  type: integer
+        ```
       responses:
         "200":
           description: A linked list
@@ -195,6 +307,7 @@ components:
         $ref: "#/components/schemas/OrgChart"
 
     TimestampMixin:
+      title: TimestampMixin
       type: object
       properties:
         createdAt:

--- a/demo/examples/tests/recursiveFilter.yaml
+++ b/demo/examples/tests/recursiveFilter.yaml
@@ -1,0 +1,171 @@
+openapi: 3.0.3
+info:
+  title: Recursive Filter API
+  description: |
+    Reproduces the recursive search-filter schema shape from Komga (issue #1525).
+    The `SearchCondition` schema references itself via oneOf branches, creating a
+    deeply recursive tree after `$ref` dereferencing. Without the normalizeSchema
+    optimisation this causes O(N²) render cost and hangs the browser.
+  version: 1.0.0
+tags:
+  - name: recursive-filter
+    description: Recursive filter tests (issue 1525)
+paths:
+  /search:
+    post:
+      tags:
+        - recursive-filter
+      operationId: search
+      summary: Search with recursive filter
+      description: |
+        Accepts a recursive search condition that mirrors Komga's filter schema.
+        The condition uses a discriminator on `operator` with `allOf`, `anyOf`,
+        and `not` branches that recurse back into `SearchCondition`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchCondition"
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totalCount:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SearchResult"
+
+components:
+  schemas:
+    SearchCondition:
+      title: SearchCondition
+      type: object
+      discriminator:
+        propertyName: operator
+        mapping:
+          AND: "#/components/schemas/AllOfCondition"
+          OR: "#/components/schemas/AnyOfCondition"
+          NOT: "#/components/schemas/NotCondition"
+          EQUALS: "#/components/schemas/EqualsCondition"
+          CONTAINS: "#/components/schemas/ContainsCondition"
+          GREATER_THAN: "#/components/schemas/GreaterThanCondition"
+      oneOf:
+        - $ref: "#/components/schemas/AllOfCondition"
+        - $ref: "#/components/schemas/AnyOfCondition"
+        - $ref: "#/components/schemas/NotCondition"
+        - $ref: "#/components/schemas/EqualsCondition"
+        - $ref: "#/components/schemas/ContainsCondition"
+        - $ref: "#/components/schemas/GreaterThanCondition"
+
+    AllOfCondition:
+      title: AllOfCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["AND"]
+        conditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchCondition"
+      required:
+        - operator
+        - conditions
+
+    AnyOfCondition:
+      title: AnyOfCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["OR"]
+        conditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SearchCondition"
+      required:
+        - operator
+        - conditions
+
+    NotCondition:
+      title: NotCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["NOT"]
+        condition:
+          $ref: "#/components/schemas/SearchCondition"
+      required:
+        - operator
+        - condition
+
+    EqualsCondition:
+      title: EqualsCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["EQUALS"]
+        field:
+          type: string
+        value:
+          type: string
+      required:
+        - operator
+        - field
+        - value
+
+    ContainsCondition:
+      title: ContainsCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["CONTAINS"]
+        field:
+          type: string
+        value:
+          type: string
+        caseSensitive:
+          type: boolean
+          default: false
+      required:
+        - operator
+        - field
+        - value
+
+    GreaterThanCondition:
+      title: GreaterThanCondition
+      type: object
+      properties:
+        operator:
+          type: string
+          enum: ["GREATER_THAN"]
+        field:
+          type: string
+        value:
+          type: number
+      required:
+        - operator
+        - field
+        - value
+
+    SearchResult:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        score:
+          type: number
+          format: double

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -50,9 +50,26 @@ let SCHEMA_TYPE: "request" | "response";
  *
  * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
  */
+// Memoize by input identity so deeply-shared subtrees in dereferenced specs
+// (e.g. recursive search-filter schemas like Komga's, which fan out to ~17K
+// nodes) are walked at most once across every mergeAllOf call during MDX
+// generation. Mirrors the theme-side cache in Schema/index.tsx — kept in
+// lockstep until both copies are consolidated into the shared
+// schemaNormalization module planned for phase 1.
+// See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
+const stripCache = new WeakMap<object, any>();
+
 function stripConflictingAdditionalProps(node: any): any {
-  if (Array.isArray(node)) return node.map(stripConflictingAdditionalProps);
+  if (Array.isArray(node)) {
+    const cached = stripCache.get(node);
+    if (cached) return cached;
+    const result = node.map(stripConflictingAdditionalProps);
+    stripCache.set(node, result);
+    return result;
+  }
   if (!node || typeof node !== "object") return node;
+  const cached = stripCache.get(node);
+  if (cached) return cached;
 
   let working: any = node;
   if (Array.isArray(node.allOf) && node.allOf.length > 1) {
@@ -74,6 +91,9 @@ function stripConflictingAdditionalProps(node: any): any {
   }
 
   const result: any = {};
+  // Cache before recursing so reference cycles in shared-identity subtrees
+  // resolve to the in-progress object instead of recursing forever.
+  stripCache.set(node, result);
   for (const [k, v] of Object.entries(working)) {
     result[k] = stripConflictingAdditionalProps(v);
   }

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
@@ -50,13 +50,6 @@ let SCHEMA_TYPE: "request" | "response";
  *
  * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
  */
-// Memoize by input identity so deeply-shared subtrees in dereferenced specs
-// (e.g. recursive search-filter schemas like Komga's, which fan out to ~17K
-// nodes) are walked at most once across every mergeAllOf call during MDX
-// generation. Mirrors the theme-side cache in Schema/index.tsx — kept in
-// lockstep until both copies are consolidated into the shared
-// schemaNormalization module planned for phase 1.
-// See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
 const stripCache = new WeakMap<object, any>();
 
 function stripConflictingAdditionalProps(node: any): any {
@@ -91,8 +84,6 @@ function stripConflictingAdditionalProps(node: any): any {
   }
 
   const result: any = {};
-  // Cache before recursing so reference cycles in shared-identity subtrees
-  // resolve to the in-progress object instead of recursing forever.
   stripCache.set(node, result);
   for (const [k, v] of Object.entries(working)) {
     result[k] = stripConflictingAdditionalProps(v);

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -17,6 +17,7 @@ import Markdown from "@theme/Markdown";
 import {
   foldSiblingsIntoBranches,
   getDiscriminator,
+  isCircularMarker,
   mergeAllOf,
   normalizeSchema,
 } from "@theme/Schema/normalize";
@@ -524,7 +525,7 @@ const AdditionalProperties: React.FC<SchemaProps> = ({
 
   if (!additionalProperties) return null;
 
-  if (typeof additionalProperties === "string") {
+  if (isCircularMarker(additionalProperties)) {
     return (
       <SchemaItem
         name="property name*"
@@ -651,7 +652,7 @@ const Items: React.FC<{
   schemaType: "request" | "response";
   schemaPath?: string;
 }> = ({ schema, schemaType, schemaPath }) => {
-  if (typeof schema.items === "string") {
+  if (isCircularMarker(schema.items)) {
     return (
       <div style={{ marginLeft: ".5rem" }}>
         <OpeningArrayBracket />
@@ -788,7 +789,7 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     return null;
   }
 
-  if (typeof schema === "string") {
+  if (isCircularMarker(schema)) {
     return (
       <SchemaItem
         collapsible={false}
@@ -888,7 +889,7 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     );
   }
 
-  if (typeof schema.items === "string") {
+  if (isCircularMarker(schema.items)) {
     return (
       <SchemaNodeDetails
         name={name}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -440,17 +440,29 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   schema: rawSchema,
   schemaType,
 }) => {
-  // Eagerly merge top-level allOf so shared properties contributed by allOf
-  // members (e.g. CommonProps in nested-discriminator-in-all-of) are accessible
-  // to PropertyDiscriminator's top-level rendering.
-  const schema = rawSchema.allOf
-    ? (mergeAllOf(rawSchema) as SchemaObject)
-    : rawSchema;
+  // Merge top-level allOf only when the discriminator is nested inside allOf
+  // (rawSchema.discriminator is undefined). This matches prod behavior where
+  // SchemaNode merged allOf via `workingSchema = mergeAllOf(schema)` to
+  // promote nested discriminators. When the discriminator is at the raw
+  // top level (rawSchema.discriminator exists), skip the merge to avoid
+  // pulling in unrelated allOf-derived properties.
+  const schema =
+    rawSchema.allOf && !rawSchema.discriminator
+      ? (mergeAllOf(rawSchema) as SchemaObject)
+      : rawSchema;
 
   let discriminatedSchemas: any = {};
   let inferredMapping: any = {};
 
-  if (schema.oneOf || schema.anyOf) {
+  if (schema.allOf) {
+    // Discriminator is at top level and schema still has allOf. Merge just to
+    // extract the discriminated oneOf/anyOf branches, without replacing
+    // `schema` — matches prod's DiscriminatorNode behavior.
+    const mergedSchemas = mergeAllOf(schema) as SchemaObject;
+    if (mergedSchemas.oneOf || mergedSchemas.anyOf) {
+      discriminatedSchemas = mergedSchemas.oneOf || mergedSchemas.anyOf;
+    }
+  } else if (schema.oneOf || schema.anyOf) {
     discriminatedSchemas = schema.oneOf || schema.anyOf;
   }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 
 import { translate } from "@docusaurus/Translate";
 import { setSchemaSelection } from "@theme/ApiExplorer/SchemaSelection/slice";
@@ -14,6 +14,7 @@ import { ClosingArrayBracket, OpeningArrayBracket } from "@theme/ArrayBrackets";
 import Details from "@theme/Details";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import Markdown from "@theme/Markdown";
+import { normalizeSchema } from "@theme/Schema/normalize";
 import {
   SchemaDepthProvider,
   useSchemaDepth,
@@ -61,9 +62,26 @@ import type { SchemaObject } from "../../types.d";
  * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
  * Mirrored in plugin: docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
  */
+// Memoize by input identity so deeply-shared subtrees (typical of
+// dereferenced specs with recursive $refs) are walked at most once across
+// every render and every mergeAllOf call on the page. Without this, specs
+// like Komga's that fan a recursive search-filter schema into ~17K nodes
+// hang the browser: the strip is invoked per-render per-Schema-component,
+// each call deep-walks the full subtree, and the work compounds with depth.
+// See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
+const stripCache = new WeakMap<object, any>();
+
 const stripConflictingAdditionalProps = (node: any): any => {
-  if (Array.isArray(node)) return node.map(stripConflictingAdditionalProps);
+  if (Array.isArray(node)) {
+    const cached = stripCache.get(node);
+    if (cached) return cached;
+    const result = node.map(stripConflictingAdditionalProps);
+    stripCache.set(node, result);
+    return result;
+  }
   if (!node || typeof node !== "object") return node;
+  const cached = stripCache.get(node);
+  if (cached) return cached;
 
   let working: any = node;
   if (Array.isArray(node.allOf) && node.allOf.length > 1) {
@@ -85,6 +103,9 @@ const stripConflictingAdditionalProps = (node: any): any => {
   }
 
   const result: any = {};
+  // Cache before recursing so cycles in shared-reference subtrees resolve
+  // to the in-progress object instead of recursing forever.
+  stripCache.set(node, result);
   for (const [k, v] of Object.entries(working)) {
     result[k] = stripConflictingAdditionalProps(v);
   }
@@ -616,9 +637,11 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   let discriminatedSchemas: any = {};
   let inferredMapping: any = {};
 
-  // Search for the discriminator property in the schema, including nested structures
+  // Direct O(1) lookup — after normalizeSchema merges allOf, properties are at
+  // the top level. The recursive findProperty walk from #1303 is no longer
+  // needed and was contributing to O(N²) cost (issue #1525).
   const discriminatorProperty =
-    findProperty(schema, discriminator.propertyName) ?? {};
+    schema.properties?.[discriminator.propertyName] ?? {};
 
   if (schema.allOf) {
     const mergedSchemas = mergeAllOf(schema) as SchemaObject;
@@ -1176,10 +1199,19 @@ function renderChildren(
 }
 
 const SchemaNode: React.FC<SchemaProps> = ({
-  schema,
+  schema: rawSchema,
   schemaType,
   schemaPath,
 }) => {
+  // Hoist normalization (allOf merge, additionalProperties strip, sibling
+  // fold into oneOf/anyOf branches) out of the recursive render path so the
+  // existing inline calls below become dead-by-precondition. A WeakSet inside
+  // `normalizeSchema` short-circuits already-normalized subtrees, so the
+  // top-level SchemaNode pays the O(N) walk once and every nested SchemaNode
+  // returns the same object identity from useMemo in O(1).
+  // See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
+  const schema = useMemo(() => normalizeSchema(rawSchema), [rawSchema]);
+
   if (
     (schemaType === "request" && schema.readOnly) ||
     (schemaType === "response" && schema.writeOnly)
@@ -1187,24 +1219,17 @@ const SchemaNode: React.FC<SchemaProps> = ({
     return null;
   }
 
-  // Resolve discriminator recursively so nested oneOf/anyOf/allOf compositions
-  // can still render discriminator tabs.
-  let workingSchema = schema;
-  const resolvedDiscriminator =
-    schema.discriminator ?? findDiscriminator(schema);
-  if (schema.allOf && !schema.discriminator && resolvedDiscriminator) {
-    workingSchema = mergeAllOf(schema) as SchemaObject;
-  }
-  if (!workingSchema.discriminator && resolvedDiscriminator) {
-    workingSchema.discriminator = resolvedDiscriminator;
-  }
-
-  if (workingSchema.discriminator) {
-    const { discriminator } = workingSchema;
+  // Use direct O(1) check — after normalizeSchema merges allOf, any
+  // discriminator that was inside an allOf member is promoted to the top level.
+  // Discriminators inside oneOf/anyOf branches are handled when those branches
+  // render as their own SchemaNode. The recursive findDiscriminator walk from
+  // #1303 is no longer needed and was causing O(N²) compound cost (issue #1525).
+  if (schema.discriminator) {
+    const { discriminator } = schema;
     return (
       <DiscriminatorNode
         discriminator={discriminator}
-        schema={workingSchema}
+        schema={schema}
         schemaType={schemaType}
       />
     );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -437,21 +437,20 @@ interface DiscriminatorNodeProps {
 
 const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   discriminator,
-  schema,
+  schema: rawSchema,
   schemaType,
 }) => {
+  // Eagerly merge top-level allOf so shared properties contributed by allOf
+  // members (e.g. CommonProps in nested-discriminator-in-all-of) are accessible
+  // to PropertyDiscriminator's top-level rendering.
+  const schema = rawSchema.allOf
+    ? (mergeAllOf(rawSchema) as SchemaObject)
+    : rawSchema;
+
   let discriminatedSchemas: any = {};
   let inferredMapping: any = {};
 
-  const discriminatorProperty =
-    schema.properties?.[discriminator.propertyName] ?? {};
-
-  if (schema.allOf) {
-    const mergedSchemas = mergeAllOf(schema) as SchemaObject;
-    if (mergedSchemas.oneOf || mergedSchemas.anyOf) {
-      discriminatedSchemas = mergedSchemas.oneOf || mergedSchemas.anyOf;
-    }
-  } else if (schema.oneOf || schema.anyOf) {
+  if (schema.oneOf || schema.anyOf) {
     discriminatedSchemas = schema.oneOf || schema.anyOf;
   }
 
@@ -499,8 +498,12 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   });
 
   const name = discriminator.propertyName;
+  // Compute discriminatorProperty AFTER the merge loop so it picks up the
+  // definition populated from branches (handles cases where the discriminator
+  // property is defined only inside oneOf/anyOf branches, not at top level).
+  const discriminatorProperty =
+    schema.properties?.[discriminator.propertyName] ?? {};
   const schemaName = getSchemaName(discriminatorProperty);
-  // Default case for discriminator without oneOf/anyOf/allOf
   return (
     <PropertyDiscriminator
       name={name}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -722,6 +722,21 @@ const AdditionalProperties: React.FC<SchemaProps> = ({
 
   if (!additionalProperties) return null;
 
+  // Handle circular-reference string markers
+  if (typeof additionalProperties === "string") {
+    return (
+      <SchemaItem
+        name="property name*"
+        required={false}
+        schemaName={additionalProperties}
+        schema={additionalProperties}
+        collapsible={false}
+        discriminator={false}
+        children={null}
+      />
+    );
+  }
+
   // Handle free-form objects
   if (additionalProperties === true || isEmpty(additionalProperties)) {
     return (
@@ -835,6 +850,25 @@ const Items: React.FC<{
   schemaType: "request" | "response";
   schemaPath?: string;
 }> = ({ schema, schemaType, schemaPath }) => {
+  // Handle circular-reference string markers in items position
+  // (e.g. `"items": "circular(TreeNode)"`)
+  if (typeof schema.items === "string") {
+    return (
+      <div style={{ marginLeft: ".5rem" }}>
+        <OpeningArrayBracket />
+        <SchemaItem
+          collapsible={false}
+          name=""
+          schemaName={schema.items}
+          schema={schema.items}
+          discriminator={false}
+          children={null}
+        />
+        <ClosingArrayBracket />
+      </div>
+    );
+  }
+
   // Process schema.items to handle allOf merging
   let itemsSchema = schema.items;
   if (schema.items?.allOf) {
@@ -955,6 +989,22 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     return null;
   }
 
+  // Handle circular-reference string markers in property position
+  // (e.g. `"parent": "circular(Category)"`)
+  if (typeof schema === "string") {
+    return (
+      <SchemaItem
+        collapsible={false}
+        name={name}
+        required={Array.isArray(required) ? required.includes(name) : required}
+        schemaName={schema}
+        schema={schema}
+        discriminator={false}
+        children={null}
+      />
+    );
+  }
+
   const schemaName = getSchemaName(schema);
 
   if (discriminator && discriminator.propertyName === name) {
@@ -1028,6 +1078,21 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
   }
 
   if (schema.items?.anyOf || schema.items?.oneOf || schema.items?.allOf) {
+    return (
+      <SchemaNodeDetails
+        name={name}
+        schemaName={schemaName}
+        required={required}
+        nullable={schema.nullable}
+        schema={schema}
+        schemaType={schemaType}
+        schemaPath={schemaPath}
+      />
+    );
+  }
+
+  // Handle arrays whose items is a circular-reference string marker
+  if (typeof schema.items === "string") {
     return (
       <SchemaNodeDetails
         name={name}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -16,6 +16,7 @@ import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import Markdown from "@theme/Markdown";
 import {
   foldSiblingsIntoBranches,
+  getDiscriminator,
   mergeAllOf,
   normalizeSchema,
 } from "@theme/Schema/normalize";
@@ -32,80 +33,6 @@ import isEmpty from "lodash/isEmpty";
 
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
 import type { SchemaObject } from "../../types.d";
-
-/**
- * Recursively searches for a property in a schema, including nested
- * oneOf, anyOf, and allOf structures. This is needed for discriminators
- * where the property definition may be in a nested schema.
- */
-const findProperty = (
-  schema: SchemaObject,
-  propertyName: string
-): SchemaObject | undefined => {
-  // Check direct properties first
-  if (schema.properties?.[propertyName]) {
-    return schema.properties[propertyName];
-  }
-
-  // Search in oneOf schemas
-  if (schema.oneOf) {
-    for (const subschema of schema.oneOf) {
-      const found = findProperty(subschema as SchemaObject, propertyName);
-      if (found) return found;
-    }
-  }
-
-  // Search in anyOf schemas
-  if (schema.anyOf) {
-    for (const subschema of schema.anyOf) {
-      const found = findProperty(subschema as SchemaObject, propertyName);
-      if (found) return found;
-    }
-  }
-
-  // Search in allOf schemas
-  if (schema.allOf) {
-    for (const subschema of schema.allOf) {
-      const found = findProperty(subschema as SchemaObject, propertyName);
-      if (found) return found;
-    }
-  }
-
-  return undefined;
-};
-
-/**
- * Recursively searches for a discriminator in a schema, including nested
- * oneOf, anyOf, and allOf structures.
- */
-const findDiscriminator = (schema: SchemaObject): any | undefined => {
-  if (schema.discriminator) {
-    return schema.discriminator;
-  }
-
-  if (schema.oneOf) {
-    for (const subschema of schema.oneOf) {
-      const found = findDiscriminator(subschema as SchemaObject);
-      if (found) return found;
-    }
-  }
-
-  if (schema.anyOf) {
-    for (const subschema of schema.anyOf) {
-      const found = findDiscriminator(subschema as SchemaObject);
-      if (found) return found;
-    }
-  }
-
-  if (schema.allOf) {
-    for (const subschema of schema.allOf) {
-      const found = findDiscriminator(subschema as SchemaObject);
-      if (found) return found;
-    }
-  }
-
-  return undefined;
-};
 
 interface MarkdownProps {
   text: string | undefined;
@@ -515,9 +442,6 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   let discriminatedSchemas: any = {};
   let inferredMapping: any = {};
 
-  // Direct O(1) lookup — after normalizeSchema merges allOf, properties are at
-  // the top level. The recursive findProperty walk from #1303 is no longer
-  // needed and was contributing to O(N²) cost (issue #1525).
   const discriminatorProperty =
     schema.properties?.[discriminator.propertyName] ?? {};
 
@@ -600,7 +524,6 @@ const AdditionalProperties: React.FC<SchemaProps> = ({
 
   if (!additionalProperties) return null;
 
-  // Handle circular-reference string markers
   if (typeof additionalProperties === "string") {
     return (
       <SchemaItem
@@ -728,8 +651,6 @@ const Items: React.FC<{
   schemaType: "request" | "response";
   schemaPath?: string;
 }> = ({ schema, schemaType, schemaPath }) => {
-  // Handle circular-reference string markers in items position
-  // (e.g. `"items": "circular(TreeNode)"`)
   if (typeof schema.items === "string") {
     return (
       <div style={{ marginLeft: ".5rem" }}>
@@ -867,8 +788,6 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     return null;
   }
 
-  // Handle circular-reference string markers in property position
-  // (e.g. `"parent": "circular(Category)"`)
   if (typeof schema === "string") {
     return (
       <SchemaItem
@@ -969,7 +888,6 @@ const SchemaEdge: React.FC<SchemaEdgeProps> = ({
     );
   }
 
-  // Handle arrays whose items is a circular-reference string marker
   if (typeof schema.items === "string") {
     return (
       <SchemaNodeDetails
@@ -1146,13 +1064,6 @@ const SchemaNode: React.FC<SchemaProps> = ({
   schemaType,
   schemaPath,
 }) => {
-  // Hoist normalization (allOf merge, additionalProperties strip, sibling
-  // fold into oneOf/anyOf branches) out of the recursive render path so the
-  // existing inline calls below become dead-by-precondition. A WeakSet inside
-  // `normalizeSchema` short-circuits already-normalized subtrees, so the
-  // top-level SchemaNode pays the O(N) walk once and every nested SchemaNode
-  // returns the same object identity from useMemo in O(1).
-  // See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
   const schema = useMemo(() => normalizeSchema(rawSchema), [rawSchema]);
 
   if (
@@ -1162,13 +1073,10 @@ const SchemaNode: React.FC<SchemaProps> = ({
     return null;
   }
 
-  // Use direct O(1) check — after normalizeSchema merges allOf, any
-  // discriminator that was inside an allOf member is promoted to the top level.
-  // Discriminators inside oneOf/anyOf branches are handled when those branches
-  // render as their own SchemaNode. The recursive findDiscriminator walk from
-  // #1303 is no longer needed and was causing O(N²) compound cost (issue #1525).
-  if (schema.discriminator) {
-    const { discriminator } = schema;
+  // Check top-level first (O(1)), then fall back to cached recursive lookup
+  // for discriminators that allof-merge doesn't promote (e.g. inside oneOf).
+  const discriminator = schema.discriminator ?? getDiscriminator(schema);
+  if (discriminator) {
     return (
       <DiscriminatorNode
         discriminator={discriminator}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -152,7 +152,8 @@ const foldSiblingsIntoBranches = (schema: any): any => {
     mergeAllOf({ allOf: [siblings, branch] })
   );
 
-  return { [branchKey]: folded };
+  const { properties: _, required: _r, type: _t, ...metadata } = schema;
+  return { ...metadata, [branchKey]: folded };
 };
 
 /**

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -14,7 +14,11 @@ import { ClosingArrayBracket, OpeningArrayBracket } from "@theme/ArrayBrackets";
 import Details from "@theme/Details";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import Markdown from "@theme/Markdown";
-import { normalizeSchema } from "@theme/Schema/normalize";
+import {
+  foldSiblingsIntoBranches,
+  mergeAllOf,
+  normalizeSchema,
+} from "@theme/Schema/normalize";
 import {
   SchemaDepthProvider,
   useSchemaDepth,
@@ -23,138 +27,11 @@ import {
 import SchemaItem from "@theme/SchemaItem";
 import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { merge } from "allof-merge";
 import clsx from "clsx";
 import isEmpty from "lodash/isEmpty";
 
 import { getQualifierMessage, getSchemaName } from "../../markdown/schema";
 import type { SchemaObject } from "../../types.d";
-
-// eslint-disable-next-line import/no-extraneous-dependencies
-// const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
-
-/**
- * Strip `additionalProperties: false` from sibling allOf members so the
- * strict-AND semantics of `allof-merge` don't collapse the result to an
- * unsatisfiable empty schema.
- *
- * Per JSON Schema, two allOf members that each set `additionalProperties: false`
- * with disjoint `properties` sets define an unsatisfiable schema (no value can
- * satisfy both — each member rejects the other's properties). `allof-merge` is
- * technically correct to drop all properties in that case, but it leaves the
- * rendered schema blank.
- *
- * NSwag and Swashbuckle emit this pattern by default whenever a model uses
- * inheritance/composition, so it's the dominant style for .NET-generated specs.
- * Redoc, Swagger UI, and Stoplight all union the properties and ignore the
- * conflicting flag — the approach this helper emulates by stripping the flag
- * before delegating to `allof-merge`. The flag is render-irrelevant anyway:
- * `additionalProperties: false` is treated identically to `undefined` by the
- * AdditionalProperties component below (line ~641).
- *
- * Strips from every allOf member whenever the parent has ≥2 members. The
- * collapse triggers symmetrically (both siblings strict) or asymmetrically
- * (one strict member rejects another's properties as "additional"), so the
- * presence of multiple members is the right gate. Single-member allOf is left
- * alone — it can't conflict with anything.
- *
- * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1119
- * Mirrored in plugin: docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts
- */
-// Memoize by input identity so deeply-shared subtrees (typical of
-// dereferenced specs with recursive $refs) are walked at most once across
-// every render and every mergeAllOf call on the page. Without this, specs
-// like Komga's that fan a recursive search-filter schema into ~17K nodes
-// hang the browser: the strip is invoked per-render per-Schema-component,
-// each call deep-walks the full subtree, and the work compounds with depth.
-// See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
-const stripCache = new WeakMap<object, any>();
-
-const stripConflictingAdditionalProps = (node: any): any => {
-  if (Array.isArray(node)) {
-    const cached = stripCache.get(node);
-    if (cached) return cached;
-    const result = node.map(stripConflictingAdditionalProps);
-    stripCache.set(node, result);
-    return result;
-  }
-  if (!node || typeof node !== "object") return node;
-  const cached = stripCache.get(node);
-  if (cached) return cached;
-
-  let working: any = node;
-  if (Array.isArray(node.allOf) && node.allOf.length > 1) {
-    const hasStrictMember = node.allOf.some(
-      (m: any) => m && m.additionalProperties === false
-    );
-    if (hasStrictMember) {
-      working = {
-        ...node,
-        allOf: node.allOf.map((m: any) => {
-          if (m && m.additionalProperties === false) {
-            const { additionalProperties: _drop, ...rest } = m;
-            return rest;
-          }
-          return m;
-        }),
-      };
-    }
-  }
-
-  const result: any = {};
-  // Cache before recursing so cycles in shared-reference subtrees resolve
-  // to the in-progress object instead of recursing forever.
-  stripCache.set(node, result);
-  for (const [k, v] of Object.entries(working)) {
-    result[k] = stripConflictingAdditionalProps(v);
-  }
-  return result;
-};
-
-const mergeAllOf = (allOf: any) => {
-  const onMergeError = (msg: string) => {
-    console.warn(msg);
-  };
-
-  const mergedSchemas = merge(stripConflictingAdditionalProps(allOf), {
-    onMergeError,
-  });
-
-  return mergedSchemas ?? {};
-};
-
-/**
- * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge, so each
- * branch is self-contained. Mirrors Redoc's `SchemaModel.initOneOf` behavior.
- * Without this, when an `allOf` override redefines a nested property with
- * `oneOf`, the merged schema ends up with both `properties` and `oneOf` as
- * siblings — and the renderer prints the shared properties twice.
- *
- * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1218
- */
-const foldSiblingsIntoBranches = (schema: any): any => {
-  const branchKey = schema?.oneOf
-    ? "oneOf"
-    : schema?.anyOf
-      ? "anyOf"
-      : undefined;
-  if (!branchKey) return schema;
-
-  const branches = schema[branchKey];
-  if (!Array.isArray(branches) || branches.length === 0) return schema;
-
-  const siblings = { ...schema };
-  delete siblings[branchKey];
-  if (Object.keys(siblings).length === 0) return schema;
-
-  const folded = branches.map((branch: any) =>
-    mergeAllOf({ allOf: [siblings, branch] })
-  );
-
-  const { properties: _, required: _r, type: _t, ...metadata } = schema;
-  return { ...metadata, [branchKey]: folded };
-};
 
 /**
  * Recursively searches for a property in a schema, including nested

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -15,6 +15,7 @@ import Details from "@theme/Details";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import Markdown from "@theme/Markdown";
 import {
+  findPropertyDeep,
   foldSiblingsIntoBranches,
   getDiscriminator,
   isCircularMarker,
@@ -437,27 +438,19 @@ interface DiscriminatorNodeProps {
 
 const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   discriminator,
-  schema: rawSchema,
+  schema,
   schemaType,
 }) => {
-  // Merge top-level allOf only when the discriminator is nested inside allOf
-  // (rawSchema.discriminator is undefined). This matches prod behavior where
-  // SchemaNode merged allOf via `workingSchema = mergeAllOf(schema)` to
-  // promote nested discriminators. When the discriminator is at the raw
-  // top level (rawSchema.discriminator exists), skip the merge to avoid
-  // pulling in unrelated allOf-derived properties.
-  const schema =
-    rawSchema.allOf && !rawSchema.discriminator
-      ? (mergeAllOf(rawSchema) as SchemaObject)
-      : rawSchema;
-
   let discriminatedSchemas: any = {};
   let inferredMapping: any = {};
 
+  // Search for the discriminator property in the schema, including nested
+  // structures. Cached recursive lookup replaces the O(subtree) findProperty
+  // walk that caused #1525's O(N^2) render cost.
+  const discriminatorProperty =
+    findPropertyDeep(schema, discriminator.propertyName) ?? {};
+
   if (schema.allOf) {
-    // Discriminator is at top level and schema still has allOf. Merge just to
-    // extract the discriminated oneOf/anyOf branches, without replacing
-    // `schema` — matches prod's DiscriminatorNode behavior.
     const mergedSchemas = mergeAllOf(schema) as SchemaObject;
     if (mergedSchemas.oneOf || mergedSchemas.anyOf) {
       discriminatedSchemas = mergedSchemas.oneOf || mergedSchemas.anyOf;
@@ -510,12 +503,8 @@ const DiscriminatorNode: React.FC<DiscriminatorNodeProps> = ({
   });
 
   const name = discriminator.propertyName;
-  // Compute discriminatorProperty AFTER the merge loop so it picks up the
-  // definition populated from branches (handles cases where the discriminator
-  // property is defined only inside oneOf/anyOf branches, not at top level).
-  const discriminatorProperty =
-    schema.properties?.[discriminator.propertyName] ?? {};
   const schemaName = getSchemaName(discriminatorProperty);
+  // Default case for discriminator without oneOf/anyOf/allOf
   return (
     <PropertyDiscriminator
       name={name}
@@ -1089,14 +1078,25 @@ const SchemaNode: React.FC<SchemaProps> = ({
     return null;
   }
 
-  // Check top-level first (O(1)), then fall back to cached recursive lookup
-  // for discriminators that allof-merge doesn't promote (e.g. inside oneOf).
-  const discriminator = schema.discriminator ?? getDiscriminator(schema);
-  if (discriminator) {
+  // Resolve discriminator recursively so nested oneOf/anyOf/allOf compositions
+  // can still render discriminator tabs. Cached via getDiscriminator so per-
+  // render cost is O(1) amortized (see #1525).
+  let workingSchema = schema;
+  const resolvedDiscriminator =
+    schema.discriminator ?? getDiscriminator(schema);
+  if (schema.allOf && !schema.discriminator && resolvedDiscriminator) {
+    workingSchema = mergeAllOf(schema) as SchemaObject;
+  }
+  if (!workingSchema.discriminator && resolvedDiscriminator) {
+    workingSchema.discriminator = resolvedDiscriminator;
+  }
+
+  if (workingSchema.discriminator) {
+    const { discriminator } = workingSchema;
     return (
       <DiscriminatorNode
         discriminator={discriminator}
-        schema={schema}
+        schema={workingSchema}
         schemaType={schemaType}
       />
     );

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -73,6 +73,24 @@ describe("normalizeSchema", () => {
       expect(result.anyOf[1].properties.b).toBeDefined();
     });
 
+    it("preserves metadata keys like title and discriminator", () => {
+      const schema = {
+        title: "MySchema",
+        description: "A polymorphic schema",
+        discriminator: { propertyName: "type" },
+        properties: { shared: { type: "string" } },
+        oneOf: [
+          { properties: { a: { type: "number" } } },
+          { properties: { b: { type: "boolean" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.title).toBe("MySchema");
+      expect(result.description).toBe("A polymorphic schema");
+      expect(result.discriminator).toEqual({ propertyName: "type" });
+      expect(result.properties).toBeUndefined();
+    });
+
     it("leaves schema unchanged when no siblings exist", () => {
       const schema = {
         oneOf: [

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import { normalizeSchema, getDiscriminator } from "./normalize";
+import {
+  foldSiblingsIntoBranches,
+  getDiscriminator,
+  normalizeSchema,
+} from "./normalize";
 
 describe("normalizeSchema", () => {
   describe("allOf merging", () => {
@@ -88,6 +92,34 @@ describe("normalizeSchema", () => {
       expect(result.title).toBe("MySchema");
       expect(result.description).toBe("A polymorphic schema");
       expect(result.discriminator).toEqual({ propertyName: "type" });
+      expect(result.properties).toBeUndefined();
+    });
+
+    it("does not leak non-metadata sibling keys into the result", () => {
+      const schema = {
+        type: "object",
+        properties: { shared: { type: "string" } },
+        additionalProperties: { type: "number" },
+        oneOf: [
+          { properties: { a: { type: "number" } } },
+          { properties: { b: { type: "boolean" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.type).toBeUndefined();
+      expect(result.additionalProperties).toBeUndefined();
+      expect(result.properties).toBeUndefined();
+      expect(result.oneOf).toHaveLength(2);
+    });
+
+    it("preserves x-* extension keys as metadata", () => {
+      const schema = {
+        "x-custom": "value",
+        properties: { shared: { type: "string" } },
+        oneOf: [{ properties: { a: { type: "number" } } }],
+      };
+      const result = normalizeSchema(schema);
+      expect(result["x-custom"]).toBe("value");
       expect(result.properties).toBeUndefined();
     });
 
@@ -259,6 +291,55 @@ describe("normalizeSchema", () => {
       expect(normalizeSchema("string")).toBe("string");
       expect(normalizeSchema(42)).toBe(42);
     });
+  });
+});
+
+describe("foldSiblingsIntoBranches", () => {
+  it("returns schema unchanged when no oneOf/anyOf is present", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } } };
+    expect(foldSiblingsIntoBranches(schema)).toBe(schema);
+  });
+
+  it("returns schema unchanged when branches have no siblings", () => {
+    const schema = {
+      oneOf: [{ properties: { a: { type: "string" } } }],
+    };
+    expect(foldSiblingsIntoBranches(schema)).toBe(schema);
+  });
+
+  it("strips non-metadata keys from result", () => {
+    const schema = {
+      type: "object",
+      required: ["shared"],
+      properties: { shared: { type: "string" } },
+      items: { type: "string" },
+      oneOf: [{ properties: { a: { type: "number" } } }],
+    };
+    const result = foldSiblingsIntoBranches(schema);
+    expect(result.type).toBeUndefined();
+    expect(result.required).toBeUndefined();
+    expect(result.properties).toBeUndefined();
+    expect(result.items).toBeUndefined();
+    expect(result.oneOf).toHaveLength(1);
+  });
+
+  it("preserves metadata and x-extension keys", () => {
+    const schema = {
+      title: "Test",
+      description: "desc",
+      discriminator: { propertyName: "type" },
+      deprecated: true,
+      "x-vendor": true,
+      properties: { shared: { type: "string" } },
+      anyOf: [{ properties: { a: { type: "number" } } }],
+    };
+    const result = foldSiblingsIntoBranches(schema);
+    expect(result.title).toBe("Test");
+    expect(result.description).toBe("desc");
+    expect(result.discriminator).toEqual({ propertyName: "type" });
+    expect(result.deprecated).toBe(true);
+    expect(result["x-vendor"]).toBe(true);
+    expect(result.properties).toBeUndefined();
   });
 });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -8,364 +8,68 @@
 import {
   foldSiblingsIntoBranches,
   getDiscriminator,
+  isCircularMarker,
+  mergeAllOf,
   normalizeSchema,
 } from "./normalize";
 
 describe("normalizeSchema", () => {
-  describe("allOf merging", () => {
-    it("merges allOf members into a flat schema", () => {
-      const schema = {
-        allOf: [
-          { type: "object", properties: { a: { type: "string" } } },
-          { type: "object", properties: { b: { type: "number" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.allOf).toBeUndefined();
-      expect(result.properties.a).toEqual({ type: "string" });
-      expect(result.properties.b).toEqual({ type: "number" });
-    });
-
-    it("preserves discriminator from allOf member so getDiscriminator finds it", () => {
-      const schema = {
-        allOf: [
-          {
-            discriminator: { propertyName: "type" },
-            oneOf: [
-              { title: "A", properties: { type: { type: "string" } } },
-              { title: "B", properties: { type: { type: "string" } } },
-            ],
-          },
-          { properties: { shared: { type: "string" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      // allof-merge doesn't promote discriminator to the top level, but
-      // getDiscriminator finds it inside the oneOf branches at render time.
-      expect(getDiscriminator(result)).toEqual({ propertyName: "type" });
-    });
+  it("returns the input as-is (identity-stable pass-through)", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } } };
+    expect(normalizeSchema(schema)).toBe(schema);
   });
 
-  describe("sibling folding", () => {
-    it("folds sibling properties into oneOf branches", () => {
-      const schema = {
-        properties: { shared: { type: "string" } },
-        oneOf: [
-          { properties: { a: { type: "number" } } },
-          { properties: { b: { type: "boolean" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties).toBeUndefined();
-      expect(result.oneOf).toHaveLength(2);
-      expect(result.oneOf[0].properties.shared).toBeDefined();
-      expect(result.oneOf[0].properties.a).toBeDefined();
-    });
+  it("handles null, undefined, and primitives", () => {
+    expect(normalizeSchema(null)).toBeNull();
+    expect(normalizeSchema(undefined)).toBeUndefined();
+    expect(normalizeSchema("string")).toBe("string");
+    expect(normalizeSchema(42)).toBe(42);
+  });
+});
 
-    it("folds sibling properties into anyOf branches", () => {
-      const schema = {
-        properties: { shared: { type: "string" } },
-        anyOf: [
-          { properties: { a: { type: "number" } } },
-          { properties: { b: { type: "boolean" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties).toBeUndefined();
-      expect(result.anyOf).toHaveLength(2);
-      expect(result.anyOf[1].properties.shared).toBeDefined();
-      expect(result.anyOf[1].properties.b).toBeDefined();
-    });
-
-    it("preserves metadata keys like title at the top level", () => {
-      const schema = {
-        title: "MySchema",
-        description: "A polymorphic schema",
-        properties: { shared: { type: "string" } },
-        oneOf: [
-          { properties: { a: { type: "number" } } },
-          { properties: { b: { type: "boolean" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.title).toBe("MySchema");
-      expect(result.description).toBe("A polymorphic schema");
-      // No discriminator → siblings still fold into branches.
-      expect(result.properties).toBeUndefined();
-      expect(result.oneOf[0].properties.shared).toBeDefined();
-    });
-
-    it("preserves top-level properties when a discriminator is present", () => {
-      const schema = {
-        title: "MySchema",
-        discriminator: { propertyName: "type" },
-        properties: { shared: { type: "string" } },
-        oneOf: [
-          { properties: { a: { type: "number" } } },
-          { properties: { b: { type: "boolean" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      // Discriminator schemas keep top-level properties intact so
-      // DiscriminatorNode can locate the discriminator property and render
-      // shared siblings outside the tab content.
-      expect(result.discriminator).toEqual({ propertyName: "type" });
-      expect(result.properties.shared).toBeDefined();
-      expect(result.oneOf[0].properties.shared).toBeUndefined();
-      expect(result.oneOf[0].properties.a).toBeDefined();
-    });
-
-    it("does not leak non-metadata sibling keys into the result", () => {
-      const schema = {
-        type: "object",
-        properties: { shared: { type: "string" } },
-        additionalProperties: { type: "number" },
-        oneOf: [
-          { properties: { a: { type: "number" } } },
-          { properties: { b: { type: "boolean" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.type).toBeUndefined();
-      expect(result.additionalProperties).toBeUndefined();
-      expect(result.properties).toBeUndefined();
-      expect(result.oneOf).toHaveLength(2);
-    });
-
-    it("preserves x-* extension keys as metadata", () => {
-      const schema = {
-        "x-custom": "value",
-        properties: { shared: { type: "string" } },
-        oneOf: [{ properties: { a: { type: "number" } } }],
-      };
-      const result = normalizeSchema(schema);
-      expect(result["x-custom"]).toBe("value");
-      expect(result.properties).toBeUndefined();
-    });
-
-    it("leaves schema unchanged when no siblings exist", () => {
-      const schema = {
-        oneOf: [
-          { properties: { a: { type: "string" } } },
-          { properties: { b: { type: "string" } } },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.oneOf).toHaveLength(2);
-      expect(result.oneOf[0].properties.a).toBeDefined();
-    });
+describe("mergeAllOf", () => {
+  it("merges allOf members into a flat schema", () => {
+    const schema = {
+      allOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { type: "object", properties: { b: { type: "number" } } },
+      ],
+    };
+    const result = mergeAllOf(schema);
+    expect(result.allOf).toBeUndefined();
+    expect(result.properties.a).toEqual({ type: "string" });
+    expect(result.properties.b).toEqual({ type: "number" });
   });
 
-  describe("additionalProperties: false stripping", () => {
-    it("strips conflicting additionalProperties: false from allOf members", () => {
-      const schema = {
-        allOf: [
-          {
-            type: "object",
-            properties: { a: { type: "string" } },
-            additionalProperties: false,
-          },
-          {
-            type: "object",
-            properties: { b: { type: "number" } },
-            additionalProperties: false,
-          },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties.a).toBeDefined();
-      expect(result.properties.b).toBeDefined();
-    });
-  });
-
-  describe("circular reference handling", () => {
-    it("preserves circular string markers in allOf", () => {
-      const schema = {
-        allOf: ["circular(Parent)"],
-        title: "Child",
-      };
-      const result = normalizeSchema(schema);
-      expect(result.allOf).toEqual(["circular(Parent)"]);
-      expect(result.title).toBe("Child");
-    });
-
-    it("preserves circular string markers in items position", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          children: {
-            type: "array",
-            items: "circular(TreeNode)",
-          },
+  it("strips conflicting additionalProperties: false from allOf members", () => {
+    const schema = {
+      allOf: [
+        {
+          type: "object",
+          properties: { a: { type: "string" } },
+          additionalProperties: false,
         },
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties.children.items).toBe("circular(TreeNode)");
-    });
-
-    it("preserves circular string markers in property position", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          parent: "circular(Category)" as any,
-          name: { type: "string" },
+        {
+          type: "object",
+          properties: { b: { type: "number" } },
+          additionalProperties: false,
         },
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties.parent).toBe("circular(Category)");
-      expect(result.properties.name).toEqual({ type: "string" });
-    });
-
-    it("preserves circular string markers in additionalProperties", () => {
-      const schema = {
-        type: "object",
-        properties: { name: { type: "string" } },
-        additionalProperties: "circular(OrgChart)" as any,
-      };
-      const result = normalizeSchema(schema);
-      expect(result.additionalProperties).toBe("circular(OrgChart)");
-    });
+      ],
+    };
+    const result = mergeAllOf(schema);
+    expect(result.properties.a).toBeDefined();
+    expect(result.properties.b).toBeDefined();
   });
 
-  describe("recursive normalization", () => {
-    it("normalizes nested properties", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          nested: {
-            allOf: [
-              { properties: { a: { type: "string" } } },
-              { properties: { b: { type: "number" } } },
-            ],
-          },
-        },
-      };
-      const result = normalizeSchema(schema);
-      expect(result.properties.nested.allOf).toBeUndefined();
-      expect(result.properties.nested.properties.a).toBeDefined();
-      expect(result.properties.nested.properties.b).toBeDefined();
+  it("preserves both properties and oneOf when merging incompatible-shape members", () => {
+    const result = mergeAllOf({
+      allOf: [
+        { type: "object", properties: { id: { type: "string" } } },
+        { oneOf: [{ title: "a" }, { title: "b" }] },
+      ],
     });
-
-    it("normalizes items schema", () => {
-      const schema = {
-        type: "array",
-        items: {
-          allOf: [
-            { properties: { x: { type: "integer" } } },
-            { properties: { y: { type: "integer" } } },
-          ],
-        },
-      };
-      const result = normalizeSchema(schema);
-      expect(result.items.allOf).toBeUndefined();
-      expect(result.items.properties.x).toBeDefined();
-      expect(result.items.properties.y).toBeDefined();
-    });
-
-    it("normalizes additionalProperties schema", () => {
-      const schema = {
-        type: "object",
-        additionalProperties: {
-          allOf: [
-            { properties: { k: { type: "string" } } },
-            { properties: { v: { type: "string" } } },
-          ],
-        },
-      };
-      const result = normalizeSchema(schema);
-      expect(result.additionalProperties.allOf).toBeUndefined();
-      expect(result.additionalProperties.properties.k).toBeDefined();
-    });
-
-    it("normalizes oneOf branch schemas", () => {
-      const schema = {
-        oneOf: [
-          {
-            allOf: [
-              { properties: { a: { type: "string" } } },
-              { properties: { b: { type: "number" } } },
-            ],
-          },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.oneOf[0].allOf).toBeUndefined();
-      expect(result.oneOf[0].properties.a).toBeDefined();
-    });
-  });
-
-  describe("discriminator schemas", () => {
-    it("leaves discriminator schemas alone (no sibling folding)", () => {
-      const schema = {
-        discriminator: { propertyName: "petType" },
-        properties: { name: { type: "string" } },
-        oneOf: [
-          {
-            properties: {
-              petType: { type: "string", enum: ["dog"] },
-              breed: { type: "string" },
-            },
-          },
-          {
-            properties: {
-              petType: { type: "string", enum: ["cat"] },
-              indoor: { type: "boolean" },
-            },
-          },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.discriminator).toEqual({ propertyName: "petType" });
-      // Top-level sibling properties stay at top level so DiscriminatorNode
-      // can render them outside the tabs.
-      expect(result.properties.name).toBeDefined();
-      // Branches retain their own properties without sibling pollution.
-      expect(result.oneOf[0].properties.petType).toBeDefined();
-      expect(result.oneOf[0].properties.name).toBeUndefined();
-    });
-
-    it("keeps discriminator property accessible when defined only in oneOf branches", () => {
-      const schema = {
-        discriminator: { propertyName: "type" },
-        oneOf: [
-          {
-            properties: {
-              type: { type: "string", enum: ["A"] },
-              a: { type: "number" },
-            },
-          },
-          {
-            properties: {
-              type: { type: "string", enum: ["B"] },
-              b: { type: "boolean" },
-            },
-          },
-        ],
-      };
-      const result = normalizeSchema(schema);
-      expect(result.discriminator).toEqual({ propertyName: "type" });
-      expect(result.oneOf[0].properties.type).toBeDefined();
-      expect(result.oneOf[1].properties.type).toBeDefined();
-    });
-  });
-
-  describe("identity and caching", () => {
-    it("short-circuits already-normalized schemas", () => {
-      const schema = {
-        type: "object",
-        properties: { a: { type: "string" } },
-      };
-      const first = normalizeSchema(schema);
-      const second = normalizeSchema(first);
-      expect(second).toBe(first);
-    });
-
-    it("handles null and primitive values", () => {
-      expect(normalizeSchema(null)).toBeNull();
-      expect(normalizeSchema(undefined)).toBeUndefined();
-      expect(normalizeSchema("string")).toBe("string");
-      expect(normalizeSchema(42)).toBe(42);
-    });
+    expect(result.properties.id).toBeDefined();
+    expect(result.oneOf).toHaveLength(2);
   });
 });
 
@@ -382,20 +86,43 @@ describe("foldSiblingsIntoBranches", () => {
     expect(foldSiblingsIntoBranches(schema)).toBe(schema);
   });
 
-  it("strips non-metadata keys from result", () => {
+  it("returns schema unchanged when a discriminator is present", () => {
     const schema = {
-      type: "object",
-      required: ["shared"],
+      discriminator: { propertyName: "type" },
       properties: { shared: { type: "string" } },
-      items: { type: "string" },
       oneOf: [{ properties: { a: { type: "number" } } }],
     };
+    expect(foldSiblingsIntoBranches(schema)).toBe(schema);
+  });
+
+  it("folds sibling properties into oneOf branches", () => {
+    const schema = {
+      properties: { shared: { type: "string" } },
+      oneOf: [
+        { properties: { a: { type: "number" } } },
+        { properties: { b: { type: "boolean" } } },
+      ],
+    };
     const result = foldSiblingsIntoBranches(schema);
-    expect(result.type).toBeUndefined();
-    expect(result.required).toBeUndefined();
     expect(result.properties).toBeUndefined();
-    expect(result.items).toBeUndefined();
-    expect(result.oneOf).toHaveLength(1);
+    expect(result.oneOf).toHaveLength(2);
+    expect(result.oneOf[0].properties.shared).toBeDefined();
+    expect(result.oneOf[0].properties.a).toBeDefined();
+  });
+
+  it("folds sibling properties into anyOf branches", () => {
+    const schema = {
+      properties: { shared: { type: "string" } },
+      anyOf: [
+        { properties: { a: { type: "number" } } },
+        { properties: { b: { type: "boolean" } } },
+      ],
+    };
+    const result = foldSiblingsIntoBranches(schema);
+    expect(result.properties).toBeUndefined();
+    expect(result.anyOf).toHaveLength(2);
+    expect(result.anyOf[1].properties.shared).toBeDefined();
+    expect(result.anyOf[1].properties.b).toBeDefined();
   });
 
   it("preserves metadata and x-extension keys when folding", () => {
@@ -415,13 +142,20 @@ describe("foldSiblingsIntoBranches", () => {
     expect(result.properties).toBeUndefined();
   });
 
-  it("returns schema unchanged when a discriminator is present", () => {
+  it("strips non-metadata keys from result", () => {
     const schema = {
-      discriminator: { propertyName: "type" },
+      type: "object",
+      required: ["shared"],
       properties: { shared: { type: "string" } },
+      items: { type: "string" },
       oneOf: [{ properties: { a: { type: "number" } } }],
     };
-    expect(foldSiblingsIntoBranches(schema)).toBe(schema);
+    const result = foldSiblingsIntoBranches(schema);
+    expect(result.type).toBeUndefined();
+    expect(result.required).toBeUndefined();
+    expect(result.properties).toBeUndefined();
+    expect(result.items).toBeUndefined();
+    expect(result.oneOf).toHaveLength(1);
   });
 });
 
@@ -477,5 +211,28 @@ describe("getDiscriminator", () => {
     const first = getDiscriminator(schema);
     const second = getDiscriminator(schema);
     expect(first).toBe(second);
+  });
+
+  it("handles cycles without infinite recursion", () => {
+    const a: any = { properties: {} };
+    const b: any = { properties: { a } };
+    a.properties.b = b;
+    expect(() => getDiscriminator(a)).not.toThrow();
+    expect(getDiscriminator(a)).toBeUndefined();
+  });
+});
+
+describe("isCircularMarker", () => {
+  it("returns true for circular marker strings", () => {
+    expect(isCircularMarker("circular(Title)")).toBe(true);
+    expect(isCircularMarker("circular()")).toBe(true);
+  });
+
+  it("returns false for other values", () => {
+    expect(isCircularMarker("normal string")).toBe(false);
+    expect(isCircularMarker(null)).toBe(false);
+    expect(isCircularMarker(undefined)).toBe(false);
+    expect(isCircularMarker({})).toBe(false);
+    expect(isCircularMarker(42)).toBe(false);
   });
 });

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -6,6 +6,7 @@
  * ========================================================================== */
 
 import {
+  findPropertyDeep,
   foldSiblingsIntoBranches,
   getDiscriminator,
   isCircularMarker,
@@ -219,6 +220,55 @@ describe("getDiscriminator", () => {
     a.properties.b = b;
     expect(() => getDiscriminator(a)).not.toThrow();
     expect(getDiscriminator(a)).toBeUndefined();
+  });
+});
+
+describe("findPropertyDeep", () => {
+  it("returns property at top level", () => {
+    const schema = { properties: { foo: { type: "string" } } };
+    expect(findPropertyDeep(schema, "foo")).toEqual({ type: "string" });
+  });
+
+  it("finds property in oneOf branches", () => {
+    const schema = {
+      oneOf: [
+        { properties: { a: { type: "string" } } },
+        { properties: { b: { type: "number" } } },
+      ],
+    };
+    expect(findPropertyDeep(schema, "a")).toEqual({ type: "string" });
+    expect(findPropertyDeep(schema, "b")).toEqual({ type: "number" });
+  });
+
+  it("finds property in anyOf branches", () => {
+    const schema = {
+      anyOf: [{ properties: { x: { type: "integer" } } }],
+    };
+    expect(findPropertyDeep(schema, "x")).toEqual({ type: "integer" });
+  });
+
+  it("finds property in allOf branches", () => {
+    const schema = {
+      allOf: [{ properties: { y: { type: "boolean" } } }],
+    };
+    expect(findPropertyDeep(schema, "y")).toEqual({ type: "boolean" });
+  });
+
+  it("returns undefined when property not found", () => {
+    const schema = { properties: { foo: { type: "string" } } };
+    expect(findPropertyDeep(schema, "bar")).toBeUndefined();
+  });
+
+  it("returns undefined for null/primitive input", () => {
+    expect(findPropertyDeep(null, "foo")).toBeUndefined();
+    expect(findPropertyDeep("string", "foo")).toBeUndefined();
+  });
+
+  it("handles cycles without infinite recursion", () => {
+    const a: any = { properties: {} };
+    a.oneOf = [a];
+    expect(() => findPropertyDeep(a, "foo")).not.toThrow();
+    expect(findPropertyDeep(a, "foo")).toBeUndefined();
   });
 });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -1,0 +1,300 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { normalizeSchema, getDiscriminator } from "./normalize";
+
+describe("normalizeSchema", () => {
+  describe("allOf merging", () => {
+    it("merges allOf members into a flat schema", () => {
+      const schema = {
+        allOf: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { type: "object", properties: { b: { type: "number" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.allOf).toBeUndefined();
+      expect(result.properties.a).toEqual({ type: "string" });
+      expect(result.properties.b).toEqual({ type: "number" });
+    });
+
+    it("preserves discriminator from allOf member so getDiscriminator finds it", () => {
+      const schema = {
+        allOf: [
+          {
+            discriminator: { propertyName: "type" },
+            oneOf: [
+              { title: "A", properties: { type: { type: "string" } } },
+              { title: "B", properties: { type: { type: "string" } } },
+            ],
+          },
+          { properties: { shared: { type: "string" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      // allof-merge doesn't promote discriminator to the top level, but
+      // getDiscriminator finds it inside the oneOf branches at render time.
+      expect(getDiscriminator(result)).toEqual({ propertyName: "type" });
+    });
+  });
+
+  describe("sibling folding", () => {
+    it("folds sibling properties into oneOf branches", () => {
+      const schema = {
+        properties: { shared: { type: "string" } },
+        oneOf: [
+          { properties: { a: { type: "number" } } },
+          { properties: { b: { type: "boolean" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties).toBeUndefined();
+      expect(result.oneOf).toHaveLength(2);
+      expect(result.oneOf[0].properties.shared).toBeDefined();
+      expect(result.oneOf[0].properties.a).toBeDefined();
+    });
+
+    it("folds sibling properties into anyOf branches", () => {
+      const schema = {
+        properties: { shared: { type: "string" } },
+        anyOf: [
+          { properties: { a: { type: "number" } } },
+          { properties: { b: { type: "boolean" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties).toBeUndefined();
+      expect(result.anyOf).toHaveLength(2);
+      expect(result.anyOf[1].properties.shared).toBeDefined();
+      expect(result.anyOf[1].properties.b).toBeDefined();
+    });
+
+    it("leaves schema unchanged when no siblings exist", () => {
+      const schema = {
+        oneOf: [
+          { properties: { a: { type: "string" } } },
+          { properties: { b: { type: "string" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.oneOf).toHaveLength(2);
+      expect(result.oneOf[0].properties.a).toBeDefined();
+    });
+  });
+
+  describe("additionalProperties: false stripping", () => {
+    it("strips conflicting additionalProperties: false from allOf members", () => {
+      const schema = {
+        allOf: [
+          {
+            type: "object",
+            properties: { a: { type: "string" } },
+            additionalProperties: false,
+          },
+          {
+            type: "object",
+            properties: { b: { type: "number" } },
+            additionalProperties: false,
+          },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties.a).toBeDefined();
+      expect(result.properties.b).toBeDefined();
+    });
+  });
+
+  describe("circular reference handling", () => {
+    it("preserves circular string markers in allOf", () => {
+      const schema = {
+        allOf: ["circular(Parent)"],
+        title: "Child",
+      };
+      const result = normalizeSchema(schema);
+      expect(result.allOf).toEqual(["circular(Parent)"]);
+      expect(result.title).toBe("Child");
+    });
+
+    it("preserves circular string markers in items position", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          children: {
+            type: "array",
+            items: "circular(TreeNode)",
+          },
+        },
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties.children.items).toBe("circular(TreeNode)");
+    });
+
+    it("preserves circular string markers in property position", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          parent: "circular(Category)" as any,
+          name: { type: "string" },
+        },
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties.parent).toBe("circular(Category)");
+      expect(result.properties.name).toEqual({ type: "string" });
+    });
+
+    it("preserves circular string markers in additionalProperties", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        additionalProperties: "circular(OrgChart)" as any,
+      };
+      const result = normalizeSchema(schema);
+      expect(result.additionalProperties).toBe("circular(OrgChart)");
+    });
+  });
+
+  describe("recursive normalization", () => {
+    it("normalizes nested properties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          nested: {
+            allOf: [
+              { properties: { a: { type: "string" } } },
+              { properties: { b: { type: "number" } } },
+            ],
+          },
+        },
+      };
+      const result = normalizeSchema(schema);
+      expect(result.properties.nested.allOf).toBeUndefined();
+      expect(result.properties.nested.properties.a).toBeDefined();
+      expect(result.properties.nested.properties.b).toBeDefined();
+    });
+
+    it("normalizes items schema", () => {
+      const schema = {
+        type: "array",
+        items: {
+          allOf: [
+            { properties: { x: { type: "integer" } } },
+            { properties: { y: { type: "integer" } } },
+          ],
+        },
+      };
+      const result = normalizeSchema(schema);
+      expect(result.items.allOf).toBeUndefined();
+      expect(result.items.properties.x).toBeDefined();
+      expect(result.items.properties.y).toBeDefined();
+    });
+
+    it("normalizes additionalProperties schema", () => {
+      const schema = {
+        type: "object",
+        additionalProperties: {
+          allOf: [
+            { properties: { k: { type: "string" } } },
+            { properties: { v: { type: "string" } } },
+          ],
+        },
+      };
+      const result = normalizeSchema(schema);
+      expect(result.additionalProperties.allOf).toBeUndefined();
+      expect(result.additionalProperties.properties.k).toBeDefined();
+    });
+
+    it("normalizes oneOf branch schemas", () => {
+      const schema = {
+        oneOf: [
+          {
+            allOf: [
+              { properties: { a: { type: "string" } } },
+              { properties: { b: { type: "number" } } },
+            ],
+          },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.oneOf[0].allOf).toBeUndefined();
+      expect(result.oneOf[0].properties.a).toBeDefined();
+    });
+  });
+
+  describe("identity and caching", () => {
+    it("short-circuits already-normalized schemas", () => {
+      const schema = {
+        type: "object",
+        properties: { a: { type: "string" } },
+      };
+      const first = normalizeSchema(schema);
+      const second = normalizeSchema(first);
+      expect(second).toBe(first);
+    });
+
+    it("handles null and primitive values", () => {
+      expect(normalizeSchema(null)).toBeNull();
+      expect(normalizeSchema(undefined)).toBeUndefined();
+      expect(normalizeSchema("string")).toBe("string");
+      expect(normalizeSchema(42)).toBe(42);
+    });
+  });
+});
+
+describe("getDiscriminator", () => {
+  it("returns direct discriminator", () => {
+    const schema = { discriminator: { propertyName: "type" } };
+    expect(getDiscriminator(schema)).toEqual({ propertyName: "type" });
+  });
+
+  it("finds discriminator in oneOf branches", () => {
+    const schema = {
+      oneOf: [{ discriminator: { propertyName: "kind" } }, { type: "string" }],
+    };
+    expect(getDiscriminator(schema)).toEqual({ propertyName: "kind" });
+  });
+
+  it("finds discriminator in anyOf branches", () => {
+    const schema = {
+      anyOf: [
+        { type: "string" },
+        { discriminator: { propertyName: "variant" } },
+      ],
+    };
+    expect(getDiscriminator(schema)).toEqual({ propertyName: "variant" });
+  });
+
+  it("finds discriminator in allOf branches", () => {
+    const schema = {
+      allOf: [
+        { properties: { id: { type: "string" } } },
+        { discriminator: { propertyName: "type" } },
+      ],
+    };
+    expect(getDiscriminator(schema)).toEqual({ propertyName: "type" });
+  });
+
+  it("returns undefined when no discriminator exists", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    expect(getDiscriminator(schema)).toBeUndefined();
+  });
+
+  it("returns undefined for null/primitive input", () => {
+    expect(getDiscriminator(null)).toBeUndefined();
+    expect(getDiscriminator("string")).toBeUndefined();
+  });
+
+  it("caches results for same object reference", () => {
+    const inner = { discriminator: { propertyName: "type" } };
+    const schema = { oneOf: [inner] };
+    const first = getDiscriminator(schema);
+    const second = getDiscriminator(schema);
+    expect(first).toBe(second);
+  });
+});

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -274,6 +274,57 @@ describe("normalizeSchema", () => {
     });
   });
 
+  describe("discriminator property in branch only", () => {
+    it("promotes discriminator property to top level via sibling folding", () => {
+      const schema = {
+        discriminator: { propertyName: "petType" },
+        properties: { name: { type: "string" } },
+        oneOf: [
+          {
+            properties: {
+              petType: { type: "string", enum: ["dog"] },
+              breed: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              petType: { type: "string", enum: ["cat"] },
+              indoor: { type: "boolean" },
+            },
+          },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.discriminator).toEqual({ propertyName: "petType" });
+      expect(result.oneOf[0].properties.petType).toBeDefined();
+      expect(result.oneOf[0].properties.name).toBeDefined();
+    });
+
+    it("keeps discriminator property accessible when defined only in oneOf branches without siblings", () => {
+      const schema = {
+        discriminator: { propertyName: "type" },
+        oneOf: [
+          {
+            properties: {
+              type: { type: "string", enum: ["A"] },
+              a: { type: "number" },
+            },
+          },
+          {
+            properties: {
+              type: { type: "string", enum: ["B"] },
+              b: { type: "boolean" },
+            },
+          },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      expect(result.discriminator).toEqual({ propertyName: "type" });
+      expect(result.oneOf[0].properties.type).toBeDefined();
+      expect(result.oneOf[1].properties.type).toBeDefined();
+    });
+  });
+
   describe("identity and caching", () => {
     it("short-circuits already-normalized schemas", () => {
       const schema = {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -77,11 +77,10 @@ describe("normalizeSchema", () => {
       expect(result.anyOf[1].properties.b).toBeDefined();
     });
 
-    it("preserves metadata keys like title and discriminator", () => {
+    it("preserves metadata keys like title at the top level", () => {
       const schema = {
         title: "MySchema",
         description: "A polymorphic schema",
-        discriminator: { propertyName: "type" },
         properties: { shared: { type: "string" } },
         oneOf: [
           { properties: { a: { type: "number" } } },
@@ -91,8 +90,29 @@ describe("normalizeSchema", () => {
       const result = normalizeSchema(schema);
       expect(result.title).toBe("MySchema");
       expect(result.description).toBe("A polymorphic schema");
-      expect(result.discriminator).toEqual({ propertyName: "type" });
+      // No discriminator → siblings still fold into branches.
       expect(result.properties).toBeUndefined();
+      expect(result.oneOf[0].properties.shared).toBeDefined();
+    });
+
+    it("preserves top-level properties when a discriminator is present", () => {
+      const schema = {
+        title: "MySchema",
+        discriminator: { propertyName: "type" },
+        properties: { shared: { type: "string" } },
+        oneOf: [
+          { properties: { a: { type: "number" } } },
+          { properties: { b: { type: "boolean" } } },
+        ],
+      };
+      const result = normalizeSchema(schema);
+      // Discriminator schemas keep top-level properties intact so
+      // DiscriminatorNode can locate the discriminator property and render
+      // shared siblings outside the tab content.
+      expect(result.discriminator).toEqual({ propertyName: "type" });
+      expect(result.properties.shared).toBeDefined();
+      expect(result.oneOf[0].properties.shared).toBeUndefined();
+      expect(result.oneOf[0].properties.a).toBeDefined();
     });
 
     it("does not leak non-metadata sibling keys into the result", () => {
@@ -274,8 +294,8 @@ describe("normalizeSchema", () => {
     });
   });
 
-  describe("discriminator property in branch only", () => {
-    it("promotes discriminator property to top level via sibling folding", () => {
+  describe("discriminator schemas", () => {
+    it("leaves discriminator schemas alone (no sibling folding)", () => {
       const schema = {
         discriminator: { propertyName: "petType" },
         properties: { name: { type: "string" } },
@@ -296,11 +316,15 @@ describe("normalizeSchema", () => {
       };
       const result = normalizeSchema(schema);
       expect(result.discriminator).toEqual({ propertyName: "petType" });
+      // Top-level sibling properties stay at top level so DiscriminatorNode
+      // can render them outside the tabs.
+      expect(result.properties.name).toBeDefined();
+      // Branches retain their own properties without sibling pollution.
       expect(result.oneOf[0].properties.petType).toBeDefined();
-      expect(result.oneOf[0].properties.name).toBeDefined();
+      expect(result.oneOf[0].properties.name).toBeUndefined();
     });
 
-    it("keeps discriminator property accessible when defined only in oneOf branches without siblings", () => {
+    it("keeps discriminator property accessible when defined only in oneOf branches", () => {
       const schema = {
         discriminator: { propertyName: "type" },
         oneOf: [
@@ -374,11 +398,10 @@ describe("foldSiblingsIntoBranches", () => {
     expect(result.oneOf).toHaveLength(1);
   });
 
-  it("preserves metadata and x-extension keys", () => {
+  it("preserves metadata and x-extension keys when folding", () => {
     const schema = {
       title: "Test",
       description: "desc",
-      discriminator: { propertyName: "type" },
       deprecated: true,
       "x-vendor": true,
       properties: { shared: { type: "string" } },
@@ -387,10 +410,18 @@ describe("foldSiblingsIntoBranches", () => {
     const result = foldSiblingsIntoBranches(schema);
     expect(result.title).toBe("Test");
     expect(result.description).toBe("desc");
-    expect(result.discriminator).toEqual({ propertyName: "type" });
     expect(result.deprecated).toBe(true);
     expect(result["x-vendor"]).toBe(true);
     expect(result.properties).toBeUndefined();
+  });
+
+  it("returns schema unchanged when a discriminator is present", () => {
+    const schema = {
+      discriminator: { propertyName: "type" },
+      properties: { shared: { type: "string" } },
+      oneOf: [{ properties: { a: { type: "number" } } }],
+    };
+    expect(foldSiblingsIntoBranches(schema)).toBe(schema);
   });
 });
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -55,7 +55,7 @@ function stripConflictingAdditionalProps(node: any): any {
   return result;
 }
 
-function mergeAllOf(allOf: any) {
+export function mergeAllOf(allOf: any) {
   const onMergeError = (msg: string) => console.warn(msg);
   const merged = merge(stripConflictingAdditionalProps(allOf), {
     onMergeError,
@@ -67,7 +67,7 @@ function mergeAllOf(allOf: any) {
  * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge so each
  * branch is self-contained. See issue #1218.
  */
-function foldSiblingsIntoBranches(schema: any): any {
+export function foldSiblingsIntoBranches(schema: any): any {
   const branchKey = schema?.oneOf
     ? "oneOf"
     : schema?.anyOf

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -8,6 +8,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { merge } from "allof-merge";
 
+export function isCircularMarker(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("circular(");
+}
+
 /**
  * Strip `additionalProperties: false` from sibling allOf members so
  * allof-merge doesn't collapse to an unsatisfiable empty schema. See #1119.
@@ -194,15 +198,13 @@ export function normalizeSchema(
   if (Array.isArray(working.allOf) && working.allOf.length > 0) {
     // Skip merge when allOf contains circular-reference string markers
     // (e.g. `allOf: ["circular(Title)"]`) — allof-merge can't handle them.
-    const hasCircularMember = working.allOf.some(
-      (m: any) => typeof m === "string"
-    );
+    const hasCircularMember = working.allOf.some(isCircularMarker);
     if (!hasCircularMember) {
       working = mergeAllOf(working);
     }
   }
 
-  if ((working.oneOf || working.anyOf) && working.properties) {
+  if (working.oneOf || working.anyOf) {
     working = foldSiblingsIntoBranches(working);
   }
 

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -86,7 +86,8 @@ function foldSiblingsIntoBranches(schema: any): any {
     mergeAllOf({ allOf: [siblings, branch] })
   );
 
-  return { [branchKey]: folded };
+  const { properties: _, required: _r, type: _t, ...metadata } = schema;
+  return { ...metadata, [branchKey]: folded };
 }
 
 /**

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -1,0 +1,242 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { merge } from "allof-merge";
+
+/**
+ * Strip `additionalProperties: false` from sibling allOf members so the
+ * strict-AND semantics of `allof-merge` don't collapse the result to an
+ * unsatisfiable empty schema. See issue #1119 for full rationale and
+ * Schema/index.tsx for the historical inline copy.
+ */
+const stripCache = new WeakMap<object, any>();
+
+function stripConflictingAdditionalProps(node: any): any {
+  if (Array.isArray(node)) {
+    const cached = stripCache.get(node);
+    if (cached) return cached;
+    const result = node.map(stripConflictingAdditionalProps);
+    stripCache.set(node, result);
+    return result;
+  }
+  if (!node || typeof node !== "object") return node;
+  const cached = stripCache.get(node);
+  if (cached) return cached;
+
+  let working: any = node;
+  if (Array.isArray(node.allOf) && node.allOf.length > 1) {
+    const hasStrictMember = node.allOf.some(
+      (m: any) => m && m.additionalProperties === false
+    );
+    if (hasStrictMember) {
+      working = {
+        ...node,
+        allOf: node.allOf.map((m: any) => {
+          if (m && m.additionalProperties === false) {
+            const { additionalProperties: _drop, ...rest } = m;
+            return rest;
+          }
+          return m;
+        }),
+      };
+    }
+  }
+
+  const result: any = {};
+  stripCache.set(node, result);
+  for (const [k, v] of Object.entries(working)) {
+    result[k] = stripConflictingAdditionalProps(v);
+  }
+  return result;
+}
+
+function mergeAllOf(allOf: any) {
+  const onMergeError = (msg: string) => console.warn(msg);
+  const merged = merge(stripConflictingAdditionalProps(allOf), {
+    onMergeError,
+  });
+  return merged ?? {};
+}
+
+/**
+ * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge so each
+ * branch is self-contained. See issue #1218.
+ */
+function foldSiblingsIntoBranches(schema: any): any {
+  const branchKey = schema?.oneOf
+    ? "oneOf"
+    : schema?.anyOf
+      ? "anyOf"
+      : undefined;
+  if (!branchKey) return schema;
+
+  const branches = schema[branchKey];
+  if (!Array.isArray(branches) || branches.length === 0) return schema;
+
+  const siblings = { ...schema };
+  delete siblings[branchKey];
+  if (Object.keys(siblings).length === 0) return schema;
+
+  const folded = branches.map((branch: any) =>
+    mergeAllOf({ allOf: [siblings, branch] })
+  );
+
+  return { [branchKey]: folded };
+}
+
+/**
+ * Deeply normalize a schema in one pass so the renderer never has to run
+ * `mergeAllOf` or `foldSiblingsIntoBranches` itself.
+ *
+ * - Eliminates `allOf` (merged into the parent).
+ * - Eliminates oneOf/anyOf + sibling collisions (folded into branches).
+ * - Recurses through every schema-bearing key (properties, items,
+ *   additionalProperties, oneOf, anyOf, not).
+ *
+ * Designed to run once per top-level schema (memoized via `useMemo` at
+ * `RequestSchema` / `ResponseSchema`). The existing inline `if (schema.allOf)`
+ * and `hasProperties && hasOneOfAnyOf` gates in `Schema/index.tsx` become
+ * dead-by-precondition on the normalized output, so the per-render
+ * deep-walk that caused issue #1525 never fires.
+ *
+ * Internally cache-keyed by input identity (WeakMap) so shared-reference
+ * subtrees produced by `$RefParser.dereference({ circular: true })` are
+ * normalized once and shared, and so reference cycles short-circuit safely.
+ * For specs that lose identity through a `JSON.stringify` roundtrip (as
+ * happens in `loadAndResolveSpec.ts`), the cache provides no dedup but is
+ * still negligible cost.
+ *
+ * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
+ */
+// Tracks objects that are already normalized so recursive `SchemaNode`
+// renders (each of which calls `normalizeSchema` on its `schema` prop via
+// `useMemo`) short-circuit instead of re-walking. This is what keeps the
+// per-render cost O(1) on children after a single O(N) top-level pass.
+const normalizedSet = new WeakSet<object>();
+
+/**
+ * Memoized variant of `findDiscriminator` from `Schema/index.tsx`. The
+ * original walks `oneOf`/`anyOf`/`allOf` recursively from every recursive
+ * `SchemaNode` render — for deeply recursive specs like Komga's, this
+ * compounds to O(N²) across the 17K nested renders and contributes to the
+ * browser hang in issue #1525 even after `normalizeSchema` removes the
+ * `mergeAllOf` work.
+ *
+ * The cache is keyed by input identity. Because `normalizeSchema` produces a
+ * tree with stable inner-node identity (each child object is reused in the
+ * parent's `properties`/`items`/etc.), recursive `SchemaNode` renders pass
+ * the same object reference here and get a cached result in O(1).
+ *
+ * `null` cache entries mean "no discriminator found" and short-circuit
+ * negative lookups the same way positives do.
+ */
+const discriminatorCache = new WeakMap<object, any | null>();
+
+export function getDiscriminator(schema: any): any | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  if (discriminatorCache.has(schema)) {
+    const cached = discriminatorCache.get(schema);
+    return cached === null ? undefined : cached;
+  }
+  // Mark in-progress as null so cycles in shared-reference subtrees don't
+  // recurse forever.
+  discriminatorCache.set(schema, null);
+
+  let result: any | undefined;
+  if (schema.discriminator) {
+    result = schema.discriminator;
+  } else if (Array.isArray(schema.oneOf)) {
+    for (const s of schema.oneOf) {
+      const found = getDiscriminator(s);
+      if (found) {
+        result = found;
+        break;
+      }
+    }
+  }
+  if (!result && Array.isArray(schema.anyOf)) {
+    for (const s of schema.anyOf) {
+      const found = getDiscriminator(s);
+      if (found) {
+        result = found;
+        break;
+      }
+    }
+  }
+  if (!result && Array.isArray(schema.allOf)) {
+    for (const s of schema.allOf) {
+      const found = getDiscriminator(s);
+      if (found) {
+        result = found;
+        break;
+      }
+    }
+  }
+
+  discriminatorCache.set(schema, result ?? null);
+  return result;
+}
+
+export function normalizeSchema(
+  schema: any,
+  cache: WeakMap<object, any> = new WeakMap()
+): any {
+  if (Array.isArray(schema)) {
+    const hit = cache.get(schema);
+    if (hit) return hit;
+    const result: any[] = [];
+    cache.set(schema, result);
+    for (const s of schema) result.push(normalizeSchema(s, cache));
+    normalizedSet.add(result);
+    return result;
+  }
+  if (!schema || typeof schema !== "object") return schema;
+  if (normalizedSet.has(schema)) return schema;
+  const hit = cache.get(schema);
+  if (hit) return hit;
+
+  // Allocate the result placeholder first so cycles resolve to the
+  // in-progress object instead of recursing forever.
+  const result: any = {};
+  cache.set(schema, result);
+
+  let working: any = schema;
+
+  if (Array.isArray(working.allOf) && working.allOf.length > 0) {
+    working = mergeAllOf(working);
+  }
+
+  if ((working.oneOf || working.anyOf) && working.properties) {
+    working = foldSiblingsIntoBranches(working);
+  }
+
+  for (const [k, v] of Object.entries(working)) {
+    if (k === "properties" && v && typeof v === "object") {
+      const props: any = {};
+      for (const [pk, pv] of Object.entries(v)) {
+        props[pk] = normalizeSchema(pv, cache);
+      }
+      result[k] = props;
+    } else if (k === "items" || k === "not") {
+      result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
+    } else if (k === "additionalProperties") {
+      // additionalProperties can be true | false | SchemaObject.
+      result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
+    } else if (
+      (k === "oneOf" || k === "anyOf" || k === "allOf") &&
+      Array.isArray(v)
+    ) {
+      result[k] = v.map((s: any) => normalizeSchema(s, cache));
+    } else {
+      result[k] = v;
+    }
+  }
+
+  normalizedSet.add(result);
+  return result;
+}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -113,11 +113,9 @@ function foldSiblingsIntoBranches(schema: any): any {
  *
  * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
  */
-// Tracks objects that are already normalized so recursive `SchemaNode`
-// renders (each of which calls `normalizeSchema` on its `schema` prop via
-// `useMemo`) short-circuit instead of re-walking. This is what keeps the
-// per-render cost O(1) on children after a single O(N) top-level pass.
-const normalizedSet = new WeakSet<object>();
+// Module-level cache shared across all `normalizeSchema` calls so nested
+// `SchemaNode` renders short-circuit in O(1) after the top-level O(N) pass.
+const normalizeCache = new WeakMap<object, any>();
 
 /**
  * Memoized variant of `findDiscriminator` from `Schema/index.tsx`. The
@@ -184,7 +182,7 @@ export function getDiscriminator(schema: any): any | undefined {
 
 export function normalizeSchema(
   schema: any,
-  cache: WeakMap<object, any> = new WeakMap()
+  cache: WeakMap<object, any> = normalizeCache
 ): any {
   if (Array.isArray(schema)) {
     const hit = cache.get(schema);
@@ -192,11 +190,10 @@ export function normalizeSchema(
     const result: any[] = [];
     cache.set(schema, result);
     for (const s of schema) result.push(normalizeSchema(s, cache));
-    normalizedSet.add(result);
+
     return result;
   }
   if (!schema || typeof schema !== "object") return schema;
-  if (normalizedSet.has(schema)) return schema;
   const hit = cache.get(schema);
   if (hit) return hit;
 
@@ -246,6 +243,7 @@ export function normalizeSchema(
     }
   }
 
-  normalizedSet.add(result);
+  // Self-register so re-normalizing the output is an identity no-op.
+  cache.set(result, result);
   return result;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -208,7 +208,16 @@ export function normalizeSchema(
   let working: any = schema;
 
   if (Array.isArray(working.allOf) && working.allOf.length > 0) {
-    working = mergeAllOf(working);
+    // Skip merge when allOf contains circular-reference string markers
+    // produced by loadAndResolveSpec's JSON.stringify roundtrip (e.g.
+    // `allOf: ["circular(Title)"]`). allof-merge doesn't handle string
+    // members and would discard the marker.
+    const hasCircularMember = working.allOf.some(
+      (m: any) => typeof m === "string"
+    );
+    if (!hasCircularMember) {
+      working = mergeAllOf(working);
+    }
   }
 
   if ((working.oneOf || working.anyOf) && working.properties) {

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -15,20 +15,16 @@ export function isCircularMarker(value: unknown): value is string {
 /**
  * Strip `additionalProperties: false` from sibling allOf members so
  * allof-merge doesn't collapse to an unsatisfiable empty schema. See #1119.
+ *
+ * NOT cached: DiscriminatorNode mutates raw subschemas (deletes the
+ * discriminator property from each branch to avoid duplicate rendering).
+ * A WeakMap cache would return the pre-mutation deep clone on subsequent
+ * mergeAllOf calls, causing deleted properties to reappear inside tab
+ * content. Matches prod's per-call behavior.
  */
-const stripCache = new WeakMap<object, any>();
-
 function stripConflictingAdditionalProps(node: any): any {
-  if (Array.isArray(node)) {
-    const cached = stripCache.get(node);
-    if (cached) return cached;
-    const result = node.map(stripConflictingAdditionalProps);
-    stripCache.set(node, result);
-    return result;
-  }
+  if (Array.isArray(node)) return node.map(stripConflictingAdditionalProps);
   if (!node || typeof node !== "object") return node;
-  const cached = stripCache.get(node);
-  if (cached) return cached;
 
   let working: any = node;
   if (Array.isArray(node.allOf) && node.allOf.length > 1) {
@@ -50,8 +46,6 @@ function stripConflictingAdditionalProps(node: any): any {
   }
 
   const result: any = {};
-  // Cache before recursing so shared-identity cycles don't loop forever.
-  stripCache.set(node, result);
   for (const [k, v] of Object.entries(working)) {
     result[k] = stripConflictingAdditionalProps(v);
   }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -9,10 +9,8 @@
 import { merge } from "allof-merge";
 
 /**
- * Strip `additionalProperties: false` from sibling allOf members so the
- * strict-AND semantics of `allof-merge` don't collapse the result to an
- * unsatisfiable empty schema. See issue #1119 for full rationale and
- * Schema/index.tsx for the historical inline copy.
+ * Strip `additionalProperties: false` from sibling allOf members so
+ * allof-merge doesn't collapse to an unsatisfiable empty schema. See #1119.
  */
 const stripCache = new WeakMap<object, any>();
 
@@ -48,6 +46,7 @@ function stripConflictingAdditionalProps(node: any): any {
   }
 
   const result: any = {};
+  // Cache before recursing so shared-identity cycles don't loop forever.
   stripCache.set(node, result);
   for (const [k, v] of Object.entries(working)) {
     result[k] = stripConflictingAdditionalProps(v);
@@ -55,17 +54,33 @@ function stripConflictingAdditionalProps(node: any): any {
   return result;
 }
 
-export function mergeAllOf(allOf: any) {
+export function mergeAllOf(schema: any) {
   const onMergeError = (msg: string) => console.warn(msg);
-  const merged = merge(stripConflictingAdditionalProps(allOf), {
+  const merged = merge(stripConflictingAdditionalProps(schema), {
     onMergeError,
   });
   return merged ?? {};
 }
 
+// Keys that are parent-level metadata and should NOT be folded into branches.
+const METADATA_KEYS = new Set([
+  "title",
+  "description",
+  "discriminator",
+  "deprecated",
+  "externalDocs",
+  "example",
+  "examples",
+  "xml",
+  "nullable",
+  "readOnly",
+  "writeOnly",
+  "default",
+]);
+
 /**
- * Fold sibling fields into each `oneOf`/`anyOf` branch via allOf-merge so each
- * branch is self-contained. See issue #1218.
+ * Fold sibling fields into each oneOf/anyOf branch via allOf-merge so each
+ * branch is self-contained. See #1218.
  */
 export function foldSiblingsIntoBranches(schema: any): any {
   const branchKey = schema?.oneOf
@@ -86,64 +101,31 @@ export function foldSiblingsIntoBranches(schema: any): any {
     mergeAllOf({ allOf: [siblings, branch] })
   );
 
-  const { properties: _, required: _r, type: _t, ...metadata } = schema;
-  return { ...metadata, [branchKey]: folded };
+  const result: any = { [branchKey]: folded };
+  for (const key of Object.keys(schema)) {
+    if (key !== branchKey && (METADATA_KEYS.has(key) || key.startsWith("x-"))) {
+      result[key] = schema[key];
+    }
+  }
+  return result;
 }
 
-/**
- * Deeply normalize a schema in one pass so the renderer never has to run
- * `mergeAllOf` or `foldSiblingsIntoBranches` itself.
- *
- * - Eliminates `allOf` (merged into the parent).
- * - Eliminates oneOf/anyOf + sibling collisions (folded into branches).
- * - Recurses through every schema-bearing key (properties, items,
- *   additionalProperties, oneOf, anyOf, not).
- *
- * Designed to run once per top-level schema (memoized via `useMemo` at
- * `RequestSchema` / `ResponseSchema`). The existing inline `if (schema.allOf)`
- * and `hasProperties && hasOneOfAnyOf` gates in `Schema/index.tsx` become
- * dead-by-precondition on the normalized output, so the per-render
- * deep-walk that caused issue #1525 never fires.
- *
- * Internally cache-keyed by input identity (WeakMap) so shared-reference
- * subtrees produced by `$RefParser.dereference({ circular: true })` are
- * normalized once and shared, and so reference cycles short-circuit safely.
- * For specs that lose identity through a `JSON.stringify` roundtrip (as
- * happens in `loadAndResolveSpec.ts`), the cache provides no dedup but is
- * still negligible cost.
- *
- * See https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525
- */
-// Module-level cache shared across all `normalizeSchema` calls so nested
-// `SchemaNode` renders short-circuit in O(1) after the top-level O(N) pass.
+// WeakMap caches keyed by object identity — shared-reference subtrees from
+// $RefParser.dereference are normalized/looked up once, and cycles short-circuit.
 const normalizeCache = new WeakMap<object, any>();
-
-/**
- * Memoized variant of `findDiscriminator` from `Schema/index.tsx`. The
- * original walks `oneOf`/`anyOf`/`allOf` recursively from every recursive
- * `SchemaNode` render — for deeply recursive specs like Komga's, this
- * compounds to O(N²) across the 17K nested renders and contributes to the
- * browser hang in issue #1525 even after `normalizeSchema` removes the
- * `mergeAllOf` work.
- *
- * The cache is keyed by input identity. Because `normalizeSchema` produces a
- * tree with stable inner-node identity (each child object is reused in the
- * parent's `properties`/`items`/etc.), recursive `SchemaNode` renders pass
- * the same object reference here and get a cached result in O(1).
- *
- * `null` cache entries mean "no discriminator found" and short-circuit
- * negative lookups the same way positives do.
- */
 const discriminatorCache = new WeakMap<object, any | null>();
 
+/**
+ * Cached recursive discriminator lookup. Returns O(1) on repeated calls
+ * with the same object reference (common after normalizeSchema).
+ */
 export function getDiscriminator(schema: any): any | undefined {
   if (!schema || typeof schema !== "object") return undefined;
   if (discriminatorCache.has(schema)) {
     const cached = discriminatorCache.get(schema);
     return cached === null ? undefined : cached;
   }
-  // Mark in-progress as null so cycles in shared-reference subtrees don't
-  // recurse forever.
+  // Sentinel for cycle detection.
   discriminatorCache.set(schema, null);
 
   let result: any | undefined;
@@ -181,6 +163,11 @@ export function getDiscriminator(schema: any): any | undefined {
   return result;
 }
 
+/**
+ * Single O(N) pass that merges allOf, strips conflicting additionalProperties,
+ * and folds siblings into oneOf/anyOf branches. Cached by object identity so
+ * nested SchemaNode renders short-circuit in O(1). See #1525.
+ */
 export function normalizeSchema(
   schema: any,
   cache: WeakMap<object, any> = normalizeCache
@@ -198,8 +185,7 @@ export function normalizeSchema(
   const hit = cache.get(schema);
   if (hit) return hit;
 
-  // Allocate the result placeholder first so cycles resolve to the
-  // in-progress object instead of recursing forever.
+  // Placeholder for cycle detection.
   const result: any = {};
   cache.set(schema, result);
 
@@ -207,9 +193,7 @@ export function normalizeSchema(
 
   if (Array.isArray(working.allOf) && working.allOf.length > 0) {
     // Skip merge when allOf contains circular-reference string markers
-    // produced by loadAndResolveSpec's JSON.stringify roundtrip (e.g.
-    // `allOf: ["circular(Title)"]`). allof-merge doesn't handle string
-    // members and would discard the marker.
+    // (e.g. `allOf: ["circular(Title)"]`) — allof-merge can't handle them.
     const hasCircularMember = working.allOf.some(
       (m: any) => typeof m === "string"
     );
@@ -232,7 +216,6 @@ export function normalizeSchema(
     } else if (k === "items" || k === "not") {
       result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
     } else if (k === "additionalProperties") {
-      // additionalProperties can be true | false | SchemaObject.
       result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
     } else if (
       (k === "oneOf" || k === "anyOf" || k === "allOf") &&

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -86,6 +86,11 @@ const METADATA_KEYS = new Set([
  * Fold sibling fields into each oneOf/anyOf branch via allOf-merge so each
  * branch is self-contained. See #1218.
  *
+ * Skipped when a discriminator is present: DiscriminatorNode already renders
+ * sibling properties at the top level, and folding would duplicate the
+ * discriminator metadata into each branch (causing nested DiscriminatorNode
+ * renders inside tabs — see #1525 follow-up).
+ *
  * Called by normalizeSchema after allOf resolution. Uses mergeAllOf internally
  * to compose `{ allOf: [siblings, branch] }` per branch — the WeakMap caches
  * in stripConflictingAdditionalProps prevent redundant work on shared subtrees.
@@ -101,8 +106,19 @@ export function foldSiblingsIntoBranches(schema: any): any {
   const branches = schema[branchKey];
   if (!Array.isArray(branches) || branches.length === 0) return schema;
 
-  const siblings = { ...schema };
-  delete siblings[branchKey];
+  // Discriminator schemas rely on top-level properties being intact so
+  // DiscriminatorNode can locate the discriminator property and render
+  // shared siblings at the top level. Leave them alone.
+  if (schema.discriminator) return schema;
+
+  // Build siblings from non-metadata keys only. Metadata (title, description,
+  // examples, etc.) belongs at the top level and must not be folded.
+  const siblings: any = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key !== branchKey && !METADATA_KEYS.has(key) && !key.startsWith("x-")) {
+      siblings[key] = value;
+    }
+  }
   if (Object.keys(siblings).length === 0) return schema;
 
   const folded = branches.map((branch: any) =>

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -58,7 +58,7 @@ function stripConflictingAdditionalProps(node: any): any {
   return result;
 }
 
-export function mergeAllOf(schema: any) {
+export function mergeAllOf(schema: any): any {
   const onMergeError = (msg: string) => console.warn(msg);
   const merged = merge(stripConflictingAdditionalProps(schema), {
     onMergeError,
@@ -134,9 +134,8 @@ export function foldSiblingsIntoBranches(schema: any): any {
   return result;
 }
 
-// WeakMap caches keyed by object identity — shared-reference subtrees from
-// $RefParser.dereference are normalized/looked up once, and cycles short-circuit.
-const normalizeCache = new WeakMap<object, any>();
+// WeakMap cache keyed by object identity — shared-reference subtrees from
+// $RefParser.dereference are looked up once, and cycles short-circuit.
 const discriminatorCache = new WeakMap<object, any | null>();
 
 /**
@@ -171,71 +170,21 @@ export function getDiscriminator(schema: any): any | undefined {
 }
 
 /**
- * Single O(N) pass that merges allOf, strips conflicting additionalProperties,
- * and folds siblings into oneOf/anyOf branches. Cached by object identity so
- * nested SchemaNode renders short-circuit in O(1). See #1525.
+ * Identity-stable schema pass-through. Returns the input as-is so SchemaNode
+ * useMemo dependencies stay stable across renders.
+ *
+ * Earlier iterations of this function eagerly merged allOf and folded
+ * siblings into oneOf/anyOf branches, but those operations need to stay
+ * conditional inside SchemaNode and DiscriminatorNode — eager versions
+ * caused cartesian product expansion (allOf with multiple oneOfs) and
+ * double-folding regressions. The render-time helpers below
+ * (mergeAllOf, foldSiblingsIntoBranches) are still cached via the WeakMap
+ * inside stripConflictingAdditionalProps, so per-render cost stays bounded.
+ *
+ * The perf win for #1525 comes from getDiscriminator's WeakMap cache
+ * replacing the O(subtree) findDiscriminator walk, not from eager
+ * normalization here.
  */
 export function normalizeSchema(schema: any): any {
-  return normalizeSchemaImpl(schema, normalizeCache);
-}
-
-function normalizeSchemaImpl(schema: any, cache: WeakMap<object, any>): any {
-  if (Array.isArray(schema)) {
-    const hit = cache.get(schema);
-    if (hit) return hit;
-    const result: any[] = [];
-    cache.set(schema, result);
-    for (const s of schema) result.push(normalizeSchemaImpl(s, cache));
-
-    return result;
-  }
-  if (!schema || typeof schema !== "object") return schema;
-  const hit = cache.get(schema);
-  if (hit) return hit;
-
-  // Placeholder for cycle detection.
-  const result: any = {};
-  cache.set(schema, result);
-
-  let working: any = schema;
-
-  if (Array.isArray(working.allOf) && working.allOf.length > 0) {
-    // Skip merge when allOf contains circular-reference string markers
-    // (e.g. `allOf: ["circular(Title)"]`) — allof-merge can't handle them.
-    const hasCircularMember = working.allOf.some(isCircularMarker);
-    if (!hasCircularMember) {
-      working = mergeAllOf(working);
-    }
-  }
-
-  if (working.oneOf || working.anyOf) {
-    working = foldSiblingsIntoBranches(working);
-  }
-
-  for (const [k, v] of Object.entries(working)) {
-    if (k === "properties" && v && typeof v === "object") {
-      const props: any = {};
-      for (const [pk, pv] of Object.entries(v)) {
-        props[pk] = normalizeSchemaImpl(pv, cache);
-      }
-      result[k] = props;
-    } else if (k === "items" || k === "not") {
-      result[k] =
-        v && typeof v === "object" ? normalizeSchemaImpl(v, cache) : v;
-    } else if (k === "additionalProperties") {
-      result[k] =
-        v && typeof v === "object" ? normalizeSchemaImpl(v, cache) : v;
-    } else if (
-      (k === "oneOf" || k === "anyOf" || k === "allOf") &&
-      Array.isArray(v)
-    ) {
-      result[k] = v.map((s: any) => normalizeSchemaImpl(s, cache));
-    } else {
-      result[k] = v;
-    }
-  }
-
-  // Self-register so re-normalizing the output is an identity no-op.
-  cache.set(result, result);
-  return result;
+  return schema;
 }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -85,6 +85,10 @@ const METADATA_KEYS = new Set([
 /**
  * Fold sibling fields into each oneOf/anyOf branch via allOf-merge so each
  * branch is self-contained. See #1218.
+ *
+ * Called by normalizeSchema after allOf resolution. Uses mergeAllOf internally
+ * to compose `{ allOf: [siblings, branch] }` per branch — the WeakMap caches
+ * in stripConflictingAdditionalProps prevent redundant work on shared subtrees.
  */
 export function foldSiblingsIntoBranches(schema: any): any {
   const branchKey = schema?.oneOf
@@ -123,43 +127,26 @@ const discriminatorCache = new WeakMap<object, any | null>();
  * Cached recursive discriminator lookup. Returns O(1) on repeated calls
  * with the same object reference (common after normalizeSchema).
  */
+const BRANCH_KEYS = ["oneOf", "anyOf", "allOf"] as const;
+
 export function getDiscriminator(schema: any): any | undefined {
   if (!schema || typeof schema !== "object") return undefined;
   if (discriminatorCache.has(schema)) {
     const cached = discriminatorCache.get(schema);
     return cached === null ? undefined : cached;
   }
-  // Sentinel for cycle detection.
   discriminatorCache.set(schema, null);
 
-  let result: any | undefined;
-  if (schema.discriminator) {
-    result = schema.discriminator;
-  } else if (Array.isArray(schema.oneOf)) {
-    for (const s of schema.oneOf) {
-      const found = getDiscriminator(s);
-      if (found) {
-        result = found;
-        break;
+  let result: any | undefined = schema.discriminator;
+  if (!result) {
+    for (const key of BRANCH_KEYS) {
+      const branches = schema[key];
+      if (!Array.isArray(branches)) continue;
+      for (const branch of branches) {
+        result = getDiscriminator(branch);
+        if (result) break;
       }
-    }
-  }
-  if (!result && Array.isArray(schema.anyOf)) {
-    for (const s of schema.anyOf) {
-      const found = getDiscriminator(s);
-      if (found) {
-        result = found;
-        break;
-      }
-    }
-  }
-  if (!result && Array.isArray(schema.allOf)) {
-    for (const s of schema.allOf) {
-      const found = getDiscriminator(s);
-      if (found) {
-        result = found;
-        break;
-      }
+      if (result) break;
     }
   }
 
@@ -172,16 +159,17 @@ export function getDiscriminator(schema: any): any | undefined {
  * and folds siblings into oneOf/anyOf branches. Cached by object identity so
  * nested SchemaNode renders short-circuit in O(1). See #1525.
  */
-export function normalizeSchema(
-  schema: any,
-  cache: WeakMap<object, any> = normalizeCache
-): any {
+export function normalizeSchema(schema: any): any {
+  return normalizeSchemaImpl(schema, normalizeCache);
+}
+
+function normalizeSchemaImpl(schema: any, cache: WeakMap<object, any>): any {
   if (Array.isArray(schema)) {
     const hit = cache.get(schema);
     if (hit) return hit;
     const result: any[] = [];
     cache.set(schema, result);
-    for (const s of schema) result.push(normalizeSchema(s, cache));
+    for (const s of schema) result.push(normalizeSchemaImpl(s, cache));
 
     return result;
   }
@@ -212,18 +200,20 @@ export function normalizeSchema(
     if (k === "properties" && v && typeof v === "object") {
       const props: any = {};
       for (const [pk, pv] of Object.entries(v)) {
-        props[pk] = normalizeSchema(pv, cache);
+        props[pk] = normalizeSchemaImpl(pv, cache);
       }
       result[k] = props;
     } else if (k === "items" || k === "not") {
-      result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
+      result[k] =
+        v && typeof v === "object" ? normalizeSchemaImpl(v, cache) : v;
     } else if (k === "additionalProperties") {
-      result[k] = v && typeof v === "object" ? normalizeSchema(v, cache) : v;
+      result[k] =
+        v && typeof v === "object" ? normalizeSchemaImpl(v, cache) : v;
     } else if (
       (k === "oneOf" || k === "anyOf" || k === "allOf") &&
       Array.isArray(v)
     ) {
-      result[k] = v.map((s: any) => normalizeSchema(s, cache));
+      result[k] = v.map((s: any) => normalizeSchemaImpl(s, cache));
     } else {
       result[k] = v;
     }

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts
@@ -134,9 +134,10 @@ export function foldSiblingsIntoBranches(schema: any): any {
   return result;
 }
 
-// WeakMap cache keyed by object identity — shared-reference subtrees from
+// WeakMap caches keyed by object identity — shared-reference subtrees from
 // $RefParser.dereference are looked up once, and cycles short-circuit.
 const discriminatorCache = new WeakMap<object, any | null>();
+const findPropertyCache = new WeakMap<object, Map<string, any>>();
 
 /**
  * Cached recursive discriminator lookup. Returns O(1) on repeated calls
@@ -166,6 +167,45 @@ export function getDiscriminator(schema: any): any | undefined {
   }
 
   discriminatorCache.set(schema, result ?? null);
+  return result;
+}
+
+/**
+ * Cached recursive property lookup. Searches schema.properties first, then
+ * into oneOf/anyOf/allOf branches. Returns O(1) on repeated calls with the
+ * same (schema, propertyName) pair — replaces the O(subtree) findProperty
+ * walk that caused #1525's O(N^2) render cost.
+ */
+export function findPropertyDeep(
+  schema: any,
+  propertyName: string
+): any | undefined {
+  if (!schema || typeof schema !== "object") return undefined;
+  let cache = findPropertyCache.get(schema);
+  if (cache && cache.has(propertyName)) {
+    const cached = cache.get(propertyName);
+    return cached === null ? undefined : cached;
+  }
+  if (!cache) {
+    cache = new Map();
+    findPropertyCache.set(schema, cache);
+  }
+  cache.set(propertyName, null);
+
+  let result: any | undefined = schema.properties?.[propertyName];
+  if (!result) {
+    for (const key of BRANCH_KEYS) {
+      const branches = schema[key];
+      if (!Array.isArray(branches)) continue;
+      for (const branch of branches) {
+        result = findPropertyDeep(branch, propertyName);
+        if (result) break;
+      }
+      if (result) break;
+    }
+  }
+
+  cache.set(propertyName, result ?? null);
   return result;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1525 — browser hangs on deeply recursive OpenAPI specs (e.g. Komga's ~17K-node search-filter schema) after upgrading to v5.1.0.

**Root cause**: Two O(subtree) recursive walkers added between v4.7.1 and v5.1.0 ran on every `SchemaNode` render, turning O(N) total work into O(N²):

- `findDiscriminator` (#1303) — searched entire subtree per SchemaNode
- `findProperty` (#1303) — searched entire subtree per DiscriminatorNode

A third walker, `stripConflictingAdditionalProps` (#1463), deep-walked every value inside `mergeAllOf`, but its cost was dominated by allof-merge itself.

## Fix

Replace the O(subtree) walkers with **cached** recursive lookups in `packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts`:

- `getDiscriminator(schema)` — WeakMap-cached recursive discriminator lookup with sentinel-based cycle detection. Same result as `findDiscriminator`, amortized O(1).
- `findPropertyDeep(schema, name)` — WeakMap-cached recursive property lookup, keyed by object identity + property name. Same result as `findProperty`, amortized O(1).

`SchemaNode` and `DiscriminatorNode` structure matches `main` exactly — same `workingSchema = mergeAllOf(schema)` promotion for nested discriminators, same mutation-based merge loop — just with the recursive walkers swapped for their cached equivalents. `normalizeSchema()` is intentionally a no-op pass-through so downstream rendering paths (`allOf` handling, sibling folding) stay conditional and match prod behavior.

`stripConflictingAdditionalProps` is deliberately **not** cached: `DiscriminatorNode` mutates raw subschemas (deletes the discriminator property from each variant to prevent duplicate rendering inside tabs), and a cache would return the pre-mutation deep clone on subsequent `mergeAllOf` calls.

## Circular reference rendering

`isCircularMarker()` guard clauses in `AdditionalProperties`, `Items`, and `SchemaEdge` handle `circular(Title)` markers in property, items, `additionalProperties`, and array-item positions. Previously only `allOf` position was handled.

## Test plan

- [x] Perf fixture (`demo/examples/tests/recursiveFilter.yaml`) — reproduces Komga's discriminated recursive `oneOf` with `allOf`/`anyOf`/`not` branches; renders in **~1.6s** with full schema expansion (previously hung indefinitely)
- [x] Circular ref fixtures (`demo/examples/tests/circularRef.yaml`) — 6 endpoints covering self-ref, mutual recursion, `additionalProperties`, `allOf` composition, indirect recursion; all render with correct `circular(Title)` markers
- [x] Original reporter (@gotson) [confirmed the fix works](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1525#issuecomment-4840894330) against their spec
- [x] Unit tests — 29 tests in `normalize.test.ts` covering `mergeAllOf`, `foldSiblingsIntoBranches`, `getDiscriminator`, `findPropertyDeep`, `isCircularMarker`
- [x] Visual regression — 187/195 pages match prod exactly. The 8 remaining diffs are all navigation/index pages showing sidebar-ordering shifts from the two new test fixtures being added — zero schema-rendering regressions

## Files changed

- `packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.ts` — new module: `mergeAllOf`, `foldSiblingsIntoBranches`, `getDiscriminator`, `findPropertyDeep`, `isCircularMarker`, `normalizeSchema` (identity)
- `packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts` — new unit tests
- `packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx` — swap `findDiscriminator`/`findProperty` for `getDiscriminator`/`findPropertyDeep`, add circular marker guards
- `packages/docusaurus-plugin-openapi-docs/src/markdown/createSchema.ts` — WeakMap cache on build-time `stripConflictingAdditionalProps` (safe: no mutation at build time)
- `demo/examples/tests/circularRef.yaml`, `demo/examples/tests/recursiveFilter.yaml` — new regression fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)