### PR TITLE
fix(theme): render branch descriptions for oneOf/anyOf and discriminator mappings

### DIFF
--- a/demo/examples/tests/discriminator.yaml
+++ b/demo/examples/tests/discriminator.yaml
@@ -606,6 +606,10 @@ components:
 
     TypeA:
       type: object
+      description: |
+        **TypeA** — a discriminator variant carrying a single string property `propA`.
+        This description should render in the `TypeA`/`typeA` tab of every
+        discriminator/oneOf path that references this schema (issue #1540).
       properties:
         type:
           type: string
@@ -617,6 +621,10 @@ components:
 
     TypeB:
       type: object
+      description: |
+        **TypeB** — a discriminator variant carrying a numeric property `propB`.
+        Present here to verify branch descriptions render for the second tab as
+        well (issue #1540).
       properties:
         type:
           type: string
@@ -628,6 +636,10 @@ components:
 
     NestedTypeA:
       type: object
+      description: |
+        **NestedTypeA** — variant whose payload nests an object under `nestedA`.
+        Its description should render even when the branch itself contains
+        nested object schemas.
       properties:
         type:
           type: string
@@ -644,6 +656,9 @@ components:
 
     NestedTypeB:
       type: object
+      description: |
+        **NestedTypeB** — companion variant to `NestedTypeA` with a differently
+        shaped nested payload under `nestedB`.
       properties:
         type:
           type: string
@@ -660,6 +675,9 @@ components:
 
     EmptyType:
       type: object
+      description: |
+        **EmptyType** — variant that inherits all fields from the base schema
+        via `allOf` and adds nothing of its own. Description should still render.
       allOf:
         - $ref: "#/components/schemas/BaseEmptySubschema"
 
@@ -743,6 +761,10 @@ components:
 
     NestedVariantA:
       type: object
+      description: |
+        **NestedVariantA** — used inside an `allOf`+`oneOf`+discriminator
+        combination. Verifies that mapping-target descriptions render when the
+        discriminator itself is nested inside `allOf`.
       properties:
         variantType:
           type: string
@@ -759,6 +781,9 @@ components:
 
     NestedVariantB:
       type: object
+      description: |
+        **NestedVariantB** — companion to `NestedVariantA` for the nested
+        discriminator case.
       properties:
         variantType:
           type: string

--- a/demo/examples/tests/discriminator.yaml
+++ b/demo/examples/tests/discriminator.yaml
@@ -606,10 +606,7 @@ components:
 
     TypeA:
       type: object
-      description: |
-        **TypeA** — a discriminator variant carrying a single string property `propA`.
-        This description should render in the `TypeA`/`typeA` tab of every
-        discriminator/oneOf path that references this schema (issue #1540).
+      description: A variant carrying a single string property `propA`.
       properties:
         type:
           type: string
@@ -621,10 +618,7 @@ components:
 
     TypeB:
       type: object
-      description: |
-        **TypeB** — a discriminator variant carrying a numeric property `propB`.
-        Present here to verify branch descriptions render for the second tab as
-        well (issue #1540).
+      description: A variant carrying a numeric property `propB`.
       properties:
         type:
           type: string
@@ -636,10 +630,7 @@ components:
 
     NestedTypeA:
       type: object
-      description: |
-        **NestedTypeA** — variant whose payload nests an object under `nestedA`.
-        Its description should render even when the branch itself contains
-        nested object schemas.
+      description: A variant whose payload nests an object under `nestedA`.
       properties:
         type:
           type: string
@@ -656,9 +647,7 @@ components:
 
     NestedTypeB:
       type: object
-      description: |
-        **NestedTypeB** — companion variant to `NestedTypeA` with a differently
-        shaped nested payload under `nestedB`.
+      description: A variant whose payload nests an object under `nestedB`.
       properties:
         type:
           type: string
@@ -675,9 +664,7 @@ components:
 
     EmptyType:
       type: object
-      description: |
-        **EmptyType** — variant that inherits all fields from the base schema
-        via `allOf` and adds nothing of its own. Description should still render.
+      description: A variant that inherits all fields from the base schema and adds none of its own.
       allOf:
         - $ref: "#/components/schemas/BaseEmptySubschema"
 
@@ -761,10 +748,7 @@ components:
 
     NestedVariantA:
       type: object
-      description: |
-        **NestedVariantA** — used inside an `allOf`+`oneOf`+discriminator
-        combination. Verifies that mapping-target descriptions render when the
-        discriminator itself is nested inside `allOf`.
+      description: A variant selected by a discriminator that is nested inside `allOf`.
       properties:
         variantType:
           type: string
@@ -781,9 +765,7 @@ components:
 
     NestedVariantB:
       type: object
-      description: |
-        **NestedVariantB** — companion to `NestedVariantA` for the nested
-        discriminator case.
+      description: A second variant selected by a discriminator nested inside `allOf`.
       properties:
         variantType:
           type: string

--- a/demo/examples/tests/oneOf.yaml
+++ b/demo/examples/tests/oneOf.yaml
@@ -110,10 +110,18 @@ paths:
                   oneOfProperty:
                     oneOf:
                       - type: object
+                        description: |
+                          **Object branch** — expected to render this description
+                          text at the top of the tab, above its property table
+                          (issue #1540).
                         properties:
                           objectProp:
                             type: string
                       - type: array
+                        description: |
+                          **Array branch** — expected to render this description
+                          text at the top of the tab, above the array items
+                          (issue #1540).
                         items:
                           type: number
 
@@ -253,10 +261,17 @@ paths:
                   oneOfProperty:
                     oneOf:
                       - type: object
+                        description: |
+                          **Branch A** — carries `specificPropA`. Description
+                          should appear in the tab body above the property list
+                          (issue #1540).
                         properties:
                           specificPropA:
                             type: string
                       - type: object
+                        description: |
+                          **Branch B** — carries `specificPropB`. Included so
+                          both tabs exercise branch-description rendering.
                         properties:
                           specificPropB:
                             type: number
@@ -426,6 +441,10 @@ components:
   schemas:
     UploadRequestTemplate:
       type: object
+      description: |
+        **UploadRequestTemplate** — template variant of an upload request.
+        Description should render for this branch under the `oneOf` on
+        `POST /oneof-ref-allof-requestbody` (issue #1540).
       required: [content, notificationChannel, subject, templateName]
       properties:
         notificationChannel:
@@ -438,6 +457,10 @@ components:
         content:
           type: string
     UploadRequest:
+      description: |
+        **UploadRequest** — `allOf`-composed variant that extends
+        `UploadRequestTemplate` with a required `contentType`. Verifies branch
+        descriptions render when the branch is itself `allOf`-composed.
       allOf:
         - $ref: "#/components/schemas/UploadRequestTemplate"
         - type: object

--- a/demo/examples/tests/oneOf.yaml
+++ b/demo/examples/tests/oneOf.yaml
@@ -110,18 +110,12 @@ paths:
                   oneOfProperty:
                     oneOf:
                       - type: object
-                        description: |
-                          **Object branch** — expected to render this description
-                          text at the top of the tab, above its property table
-                          (issue #1540).
+                        description: An object variant containing a single string property.
                         properties:
                           objectProp:
                             type: string
                       - type: array
-                        description: |
-                          **Array branch** — expected to render this description
-                          text at the top of the tab, above the array items
-                          (issue #1540).
+                        description: An array variant whose items are numbers.
                         items:
                           type: number
 
@@ -261,17 +255,12 @@ paths:
                   oneOfProperty:
                     oneOf:
                       - type: object
-                        description: |
-                          **Branch A** — carries `specificPropA`. Description
-                          should appear in the tab body above the property list
-                          (issue #1540).
+                        description: A variant carrying `specificPropA`.
                         properties:
                           specificPropA:
                             type: string
                       - type: object
-                        description: |
-                          **Branch B** — carries `specificPropB`. Included so
-                          both tabs exercise branch-description rendering.
+                        description: A variant carrying `specificPropB`.
                         properties:
                           specificPropB:
                             type: number
@@ -441,10 +430,7 @@ components:
   schemas:
     UploadRequestTemplate:
       type: object
-      description: |
-        **UploadRequestTemplate** — template variant of an upload request.
-        Description should render for this branch under the `oneOf` on
-        `POST /oneof-ref-allof-requestbody` (issue #1540).
+      description: The template variant of an upload request, without a fixed `contentType`.
       required: [content, notificationChannel, subject, templateName]
       properties:
         notificationChannel:
@@ -457,10 +443,7 @@ components:
         content:
           type: string
     UploadRequest:
-      description: |
-        **UploadRequest** — `allOf`-composed variant that extends
-        `UploadRequestTemplate` with a required `contentType`. Verifies branch
-        descriptions render when the branch is itself `allOf`-composed.
+      description: A concrete upload request that extends `UploadRequestTemplate` with a required `contentType`.
       allOf:
         - $ref: "#/components/schemas/UploadRequestTemplate"
         - type: object

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -216,6 +216,11 @@ const AnyOneOf: React.FC<SchemaProps> = ({
               label={label}
               value={`${uniqueId}-${index}-item`}
             >
+              {anyOneSchema.description && (
+                <div style={{ marginLeft: "1rem" }}>
+                  <MarkdownWrapper text={anyOneSchema.description} />
+                </div>
+              )}
               {/* Handle primitive types directly */}
               {(isPrimitive(anyOneSchema) || anyOneSchema.const) && (
                 <SchemaItem
@@ -399,6 +404,13 @@ const PropertyDiscriminator: React.FC<SchemaEdgeProps> = ({
                 label={key}
                 value={`${index}-item-discriminator`}
               >
+                {discriminator.mapping[key]?.description && (
+                  <div style={{ marginLeft: "1rem" }}>
+                    <MarkdownWrapper
+                      text={discriminator.mapping[key].description}
+                    />
+                  </div>
+                )}
                 <SchemaNode
                   schema={discriminator.mapping[key]}
                   schemaType={schemaType}


### PR DESCRIPTION
## Summary
- Restores the `description` render for each `oneOf`/`anyOf` branch and each `discriminator.mapping` target inside the `Schema` theme component.
- Fix is hoisted once at the top of each `TabItem` in `AnyOneOf` so it covers every sub-branch (primitive, empty object, properties, allOf, oneOf, anyOf, items) rather than only the `properties` case.
- Mirrors the existing `MarkdownWrapper` pattern already used by `SchemaNodeDetails` and by `PropertyDiscriminator`'s top-level description.

Fixes #1540.

## Root cause
- `AnyOneOf` never read `anyOneSchema.description`.
- `PropertyDiscriminator` rendered `<SchemaNode schema={discriminator.mapping[key]} />` directly, and `SchemaNode` does not render `schema.description` itself — so mapping-target descriptions were silently dropped.

## Test plan
- [ ] Regenerate a demo page with a `oneOf` + `discriminator.mapping` where each branch has its own `description`; confirm the description text appears in each tab alongside the property list.
- [ ] Regenerate a page with `oneOf` (no discriminator) branches carrying descriptions; confirm they render.
- [ ] Verify no duplicate description rendering for nested `allOf`/`oneOf` branches inside a discriminator mapping.
- [ ] `yarn tsc --noEmit` in `packages/docusaurus-theme-openapi-docs` (passes locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)