### PR TITLE
fix(plugin): rank path matchers by per-segment specificity (#1526)

### DIFF
--- a/demo/examples/tests/pathOrdering.yaml
+++ b/demo/examples/tests/pathOrdering.yaml
@@ -7,7 +7,13 @@ info:
     after parametric paths at the same nesting level. The `/pet/findByTags`
     endpoint must show the full URL in code samples, not just the base server.
 
-    Regression coverage for: https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1519
+    Also validates that a static tail (`/{petIds}/summary`) does not steal a
+    binding from a fully-parametric sibling (`/{petId}/{tagId}`), and vice
+    versa, when both share the same segment count.
+
+    Regression coverage for:
+    - https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1519
+    - https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/issues/1526
 
 servers:
   - url: https://petstore.swagger.io/v2
@@ -89,6 +95,55 @@ paths:
             type: array
             items:
               type: string
+      responses:
+        "200":
+          description: Success
+
+  /pet/{petId}/{tagId}:
+    get:
+      tags:
+        - path-ordering
+      summary: Find pet tag by ID
+      description: |
+        Expected URL in code samples:
+        `https://petstore.swagger.io/v2/pet/{petId}/{tagId}`
+      operationId: getPetTagById
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: tagId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Success
+
+  /pet/{petIds}/summary:
+    get:
+      tags:
+        - path-ordering
+      summary: Get summary for multiple pets
+      description: |
+        Shares segment count with `/pet/{petId}/{tagId}`, but the trailing
+        static `summary` segment must win over the fully-parametric sibling.
+
+        Expected URL in code samples:
+        `https://petstore.swagger.io/v2/pet/{petIds}/summary`
+      operationId: getPetsSummary
+      parameters:
+        - name: petIds
+          in: path
+          required: true
+          schema:
+            type: string
+            example: "1,2,3"
       responses:
         "200":
           description: Success

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts
@@ -383,6 +383,111 @@ describe("openapi", () => {
     });
   });
 
+  describe("mixed parametric paths at same depth (#1526)", () => {
+    it("binds correct postman requests when a static tail collides with a parametric tail", async () => {
+      const openapiData = {
+        openapi: "3.0.1",
+        info: {
+          title: "Petstore",
+          version: "0.0.1",
+          description: "This is a sample server Petstore server.",
+        },
+        servers: [{ url: "https://petstore.swagger.io/v2" }],
+        paths: {
+          "/pet/{petId}": {
+            get: {
+              summary: "Find pet by ID",
+              operationId: "getPetById",
+              parameters: [
+                {
+                  name: "petId",
+                  in: "path",
+                  required: true,
+                  schema: { type: "integer", format: "int64" },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/pet/{petId}/{tagId}": {
+            get: {
+              summary: "Find pet tag by ID",
+              operationId: "getPetTagById",
+              parameters: [
+                {
+                  name: "petId",
+                  in: "path",
+                  required: true,
+                  schema: { type: "integer", format: "int64" },
+                },
+                {
+                  name: "tagId",
+                  in: "path",
+                  required: true,
+                  schema: { type: "integer", format: "int64" },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+          "/pet/{petIds}/summary": {
+            get: {
+              summary: "Get summary for multiple pets",
+              operationId: "getPetsSummary",
+              parameters: [
+                {
+                  name: "petIds",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string", example: "1,2,3" },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      };
+
+      const options: APIOptions = {
+        specPath: "dummy",
+        outputDir: "build",
+      };
+      const sidebarOptions = {} as SidebarOptions;
+      const [items] = await processOpenapiFile(
+        openapiData as any,
+        options,
+        sidebarOptions
+      );
+
+      const apiItems = items.filter((item) => item.type === "api");
+      expect(apiItems).toHaveLength(3);
+
+      const getPetById = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-pet-by-id"
+      ) as any;
+      expect(getPetById.api.postman).toBeDefined();
+      expect(getPetById.api.postman.url.getPath({ unresolved: true })).toBe(
+        "/pet/:petId"
+      );
+
+      const getPetTagById = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-pet-tag-by-id"
+      ) as any;
+      expect(getPetTagById.api.postman).toBeDefined();
+      expect(getPetTagById.api.postman.url.getPath({ unresolved: true })).toBe(
+        "/pet/:petId/:tagId"
+      );
+
+      const getPetsSummary = apiItems.find(
+        (item) => item.type === "api" && item.id === "get-pets-summary"
+      ) as any;
+      expect(getPetsSummary.api.postman).toBeDefined();
+      expect(getPetsSummary.api.postman.url.getPath({ unresolved: true })).toBe(
+        "/pet/:petIds/summary"
+      );
+    });
+  });
+
   describe("vendor extensions at path level", () => {
     it("does not throw and skips x-* keys and unknown keys on path objects", async () => {
       const openapiData = {

--- a/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.ts
@@ -592,6 +592,16 @@ function pathTemplateToRegex(pathTemplate: string): RegExp {
   return new RegExp(`^${templatePattern}$`);
 }
 
+// Per-segment specificity: 1 for a literal segment, 0 for a `{param}` segment.
+// Anchored path regexes only cross-match when segment counts are equal, so
+// disambiguation ranks literal segments ahead of parameter segments at the
+// same position (e.g. `/pet/{id}/summary` before `/pet/{id}/{tagId}`).
+function pathSpecificity(pathTemplate: string): number[] {
+  return pathTemplate
+    .split("/")
+    .map((segment) => (/^\{[^}]+\}$/.test(segment) ? 0 : 1));
+}
+
 function bindCollectionToApiItems(
   items: ApiMetadata[],
   postmanCollection: sdk.Collection
@@ -602,9 +612,17 @@ function bindCollectionToApiItems(
       apiItem: item,
       method: item.api.method.toLowerCase(),
       pathMatcher: pathTemplateToRegex(item.api.path),
-      hasParams: /\{[^}]+\}/.test(item.api.path),
+      specificity: pathSpecificity(item.api.path),
     }))
-    .sort((a, b) => Number(a.hasParams) - Number(b.hasParams));
+    .sort((a, b) => {
+      const len = Math.max(a.specificity.length, b.specificity.length);
+      for (let i = 0; i < len; i++) {
+        const av = a.specificity[i] ?? -1;
+        const bv = b.specificity[i] ?? -1;
+        if (av !== bv) return bv - av;
+      }
+      return 0;
+    });
 
   postmanCollection.forEachItem((item: any) => {
     const method = item.request.method.toLowerCase();


### PR DESCRIPTION
## Summary

Closes #1526.

- Replace the boolean `hasParams` sort in `bindCollectionToApiItems` with a per-segment specificity ranking (literal segments beat parameter segments at the same position).
- Preserves the #1519 behavior (fully-static paths still come first) and fully disambiguates the same-depth, static-tail-vs-parametric-tail case reported in #1526.
- Add a unit test mirroring the #1526 reproduction (`/pet/{petId}`, `/pet/{petId}/{tagId}`, `/pet/{petIds}/summary`).
- Extend `demo/examples/tests/pathOrdering.yaml` with the two colliding same-depth paths for visual verification.

### Why the #1520 fix was insufficient

The prior sort only distinguished paths with **any** parameters from paths with **none**. Among paths that all have parameters, ordering was source-defined. Given the three #1526 paths, `/pet/:petIds/summary` (from Postman) matches both `^/pet/[^/]+/[^/]+$` and `^/pet/[^/]+/summary$`, and the first one wins the binding — which is why `getPetTagById` rendered the summary URL and `getPetsSummary` rendered no path at all.

Anchored regexes can only cross-match when segment counts are equal, so ranking by per-segment specificity (literal > parameter, compared left-to-right) is sufficient to disambiguate.

## Test plan

- [x] `yarn jest packages/docusaurus-plugin-openapi-docs/src/openapi/openapi.test.ts` — 6/6 pass, including new `#1526` case and existing `#1519` case.
- [ ] Visually verify demo `pathOrdering` pages show the correct URL in code samples for all five operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)