### PR TITLE
fix(theme): stop duplicating branch properties in nested anyOf/oneOf renders

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -251,8 +251,16 @@ const AnyOneOf: React.FC<SchemaProps> = ({
 
               {/* Handle actual object types with properties or nested schemas */}
               {/* Note: In OpenAPI, properties implies type: object even if not explicitly set */}
+              {/* When the branch also has a nested oneOf/anyOf/allOf, skip
+                  Properties here and delegate to SchemaNode below —
+                  foldSiblingsIntoBranches will merge these properties into
+                  each inner variant, so rendering them inline as well would
+                  duplicate them per variant tab. See #1548. */}
               {(anyOneSchema.type === "object" || !anyOneSchema.type) &&
-                anyOneSchema.properties && (
+                anyOneSchema.properties &&
+                !anyOneSchema.oneOf &&
+                !anyOneSchema.anyOf &&
+                !anyOneSchema.allOf && (
                   <Properties
                     schema={anyOneSchema}
                     schemaType={schemaType}

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts
@@ -158,6 +158,78 @@ describe("foldSiblingsIntoBranches", () => {
     expect(result.items).toBeUndefined();
     expect(result.oneOf).toHaveLength(1);
   });
+
+  // Regression for #1548 (property duplication in nested anyOf-of-oneOf):
+  // when the outer schema is `{ properties, anyOf: [{oneOf:[...]}, ...] }`,
+  // fold merges the outer properties into each anyOf branch, giving each
+  // branch its own inner `oneOf` alongside merged properties. The AnyOneOf
+  // render layer then delegates the branch to SchemaNode, which folds again
+  // into each inner variant. If AnyOneOf were to *also* render the branch's
+  // properties directly at that outer level, the same fields would appear
+  // twice per selected inner variant tab — hence the check in Schema/index.tsx
+  // that skips <Properties> when the branch has a nested oneOf/anyOf/allOf.
+  it("folds outer properties into each anyOf branch when branches contain nested oneOf", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        default_value: { type: "string" },
+      },
+      anyOf: [
+        {
+          oneOf: [
+            {
+              title: "aggregate_group",
+              properties: {
+                aggregate_group: { type: "string" },
+              },
+            },
+            {
+              title: "tap",
+              properties: {
+                tap: { type: "object" },
+              },
+            },
+          ],
+        },
+        {
+          oneOf: [
+            {
+              title: "folder",
+              properties: { folder: { type: "string" } },
+            },
+            {
+              title: "snippet",
+              properties: { snippet: { type: "string" } },
+            },
+          ],
+        },
+      ],
+    };
+
+    const outer = foldSiblingsIntoBranches(schema);
+    expect(outer.properties).toBeUndefined();
+    expect(outer.anyOf).toHaveLength(2);
+
+    for (const branch of outer.anyOf) {
+      // Each anyOf branch retains its own inner oneOf and picks up the
+      // merged outer properties as siblings — this is the shape that
+      // AnyOneOf must NOT render <Properties> for directly, because
+      // SchemaNode will fold them into the inner variants below.
+      expect(branch.oneOf).toBeDefined();
+      expect(branch.properties.name).toBeDefined();
+      expect(branch.properties.default_value).toBeDefined();
+
+      const inner = foldSiblingsIntoBranches(branch);
+      expect(inner.properties).toBeUndefined();
+      expect(inner.oneOf).toBeDefined();
+      for (const variant of inner.oneOf) {
+        // Merged outer properties appear exactly once — inside each variant.
+        expect(variant.properties.name).toBeDefined();
+        expect(variant.properties.default_value).toBeDefined();
+      }
+    }
+  });
 });
 
 describe("getDiscriminator", () => {


### PR DESCRIPTION
## Summary

When an outer schema shapes as `{properties, anyOf: [{oneOf: [...]}, ...]}`, `foldSiblingsIntoBranches` merges the outer properties into each anyOf branch, giving each branch its own inner `oneOf` alongside merged properties. `AnyOneOf` then delegates that branch to `SchemaNode`, which folds *again* into each inner variant — but `AnyOneOf` was also rendering `<Properties>` directly for the branch, so the merged fields showed up **twice per selected inner variant tab**.

Gate the direct `<Properties>` render on the branch having no nested `oneOf`/`anyOf`/`allOf`. When a nested composition is present, the delegated `SchemaNode` already folds those properties into every variant, so rendering them inline as well is redundant.

## Repro

Downstream discovered by [pan.dev PR #1342](https://github.com/PaloAltoNetworks/pan.dev/pull/1342) on the `POST /ethernet-interfaces` request schema. The spec shape:

```yaml
type: object
properties:
  name: {...}
  default_value: {...}
  # ...5 more base props
anyOf:
  - oneOf:  # interface-type variants
      - title: aggregate_group
        properties: { aggregate_group: {...} }
      - title: tap
        properties: { tap: {...} }
      - title: layer2
        properties: { layer2: {...} }
      - title: layer3
        properties: { layer3: {...} }
  - oneOf:  # container-scope variants
      - title: folder
        ...
```

Before this fix: `name`, `default_value`, `comment`, `link_speed`, … render once at the outer `object` tab **and** again inside each `aggregate_group` / `tap` / `layer2` / `layer3` variant tab.

After this fix: each field appears exactly once — inside the variant tab where the merge lives, matching pre-5.1.0 behavior.

The existing demo fixture `/tests/any-of-with-nested-one-of-and-properties` (added in `demo/examples/tests/anyOf.yaml`) exercises this exact shape and demonstrates the fix visually on the demo site.

## Test plan

- [x] `yarn jest packages/docusaurus-theme-openapi-docs/src/theme/Schema/normalize.test.ts` — all 30 tests pass, including the new regression test that documents the two-level fold invariant the render layer relies on.
- [x] `yarn build` in the demo — clean.
- [ ] Visual check on the built demo at `/tests/any-of-with-nested-one-of-and-properties`: base properties should render once per variant tab, not twice.

Fixes the duplication observed in [PaloAltoNetworks/pan.dev#1342](https://github.com/PaloAltoNetworks/pan.dev/pull/1342).

🤖 Generated with [Claude Code](https://claude.com/claude-code)