### PR TITLE
Prepare release v5.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 5.1.2 (2026-07-10)
+
+Patch release fixing a regression in nested `anyOf`/`oneOf` schema rendering where branch properties were duplicated across sibling branches.
+
+#### :bug: Bug Fix
+
+- fix(theme): stop duplicating branch properties in nested anyOf/oneOf renders ([#1549](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1549))
+
+#### Committers: 1
+
+- Steven Serrata
+
 ## 5.1.1 (2026-07-08)
 
 Patch release with schema rendering and path-matching fixes: branch descriptions now render for `oneOf`/`anyOf` and discriminator mappings, schema normalization is hoisted out of the render path for better performance, and Postman path matchers are ranked by per-segment specificity to prioritize the most specific match. Also includes a batch of dependency updates.

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.1.1",
+  "version": "5.1.2",
   "npmClient": "yarn"
 }

--- a/packages/create-docusaurus-openapi-docs/package.json
+++ b/packages/create-docusaurus-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-docusaurus-openapi-docs",
   "description": "Create Docusaurus sites with OpenAPI docs.",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/create-docusaurus-openapi-docs/templates/default/package.json
+++ b/packages/create-docusaurus-openapi-docs/templates/default/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-openapi-docs": "5.1.1",
-    "docusaurus-theme-openapi-docs": "5.1.1",
+    "docusaurus-plugin-openapi-docs": "5.1.2",
+    "docusaurus-theme-openapi-docs": "5.1.2",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -38,7 +38,7 @@
     "@types/postman-collection": "^3.5.11",
     "@types/react-modal": "^3.16.3",
     "concurrently": "^10.0.3",
-    "docusaurus-plugin-openapi-docs": "^5.1.1",
+    "docusaurus-plugin-openapi-docs": "^5.1.2",
     "docusaurus-plugin-sass": "^0.2.6",
     "eslint-plugin-prettier": "^5.5.1"
   },


### PR DESCRIPTION
## Summary

Patch release fixing a regression in nested `anyOf`/`oneOf` schema rendering where branch properties were duplicated across sibling branches (#1549).

## Test plan

- [x] `yarn release:version patch` bumped lerna.json, all three package.json files, and the `create-docusaurus-openapi-docs` template
- [x] `docusaurus-theme-openapi-docs` peerDependency on `docusaurus-plugin-openapi-docs` remains `^5.0.0` (within the 5.x train)
- [x] CHANGELOG updated with only the new user-facing item since v5.1.1
- [ ] CI green