### PR TITLE
Handle additionalProperties in map variants

### DIFF
--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -236,6 +236,7 @@ const AnyOneOf: React.FC<SchemaProps> = ({
               {/* Handle empty object as a primitive type */}
               {anyOneSchema.type === "object" &&
                 !anyOneSchema.properties &&
+                !anyOneSchema.additionalProperties &&
                 !anyOneSchema.allOf &&
                 !anyOneSchema.oneOf &&
                 !anyOneSchema.anyOf && (
@@ -265,6 +266,17 @@ const AnyOneOf: React.FC<SchemaProps> = ({
                     schema={anyOneSchema}
                     schemaType={schemaType}
                     schemaPath={childSchemaPath}
+                  />
+                )}
+              {/* Render a map variant's `additionalProperties` */}
+              {(anyOneSchema.type === "object" || !anyOneSchema.type) &&
+                anyOneSchema.additionalProperties &&
+                !anyOneSchema.oneOf &&
+                !anyOneSchema.anyOf &&
+                !anyOneSchema.allOf && (
+                  <AdditionalProperties
+                    schema={anyOneSchema}
+                    schemaType={schemaType}
                   />
                 )}
               {anyOneSchema.allOf && (
@@ -1265,8 +1277,7 @@ const SchemaNode: React.FC<SchemaProps> = ({
 export default SchemaNode;
 
 type PrimitiveSchemaType =
-  | Exclude<NonNullable<SchemaObject["type"]>, "object" | "array">
-  | "null";
+  Exclude<NonNullable<SchemaObject["type"]>, "object" | "array"> | "null";
 
 const PRIMITIVE_TYPES: Record<PrimitiveSchemaType, true> = {
   string: true,


### PR DESCRIPTION
## Description

Handle additionalProperties in variants. It is already handled in objects.

## Motivation and Context

It helps properly render nested additionalProperties

## How Has This Been Tested?

Created a nested scenario with additionalProperties and found it to render nicely.

key snippets of scenario
```
      "Selection": {
        "type": "object",
        "required": [
          "_other"
        ],
        "properties": {
          "_other": {
            "$ref": "#/components/schemas/InclusionDefault"
          }
        },
        "additionalProperties": {
          "$ref": "#/components/schemas/ComponentSelection"
        },
      },
```
```
      "ComponentSelection": {
        "oneOf": [
          {
            "type": "object",
            "description": "Export some of this component's tables.",
            "required": [
              "_other"
            ],
            "properties": {
              "_other": {
                "$ref": "#/components/schemas/InclusionDefault"
              }
            },
            "additionalProperties": {
              "$ref": "#/components/schemas/TableSelection"
            }
          },
          {
            "$ref": "#/components/schemas/ExcludedTag",
            "description": "Exclude this component entirely."
          }
        ],
      },
```


## Screenshots (if appropriate)

Nested property name* rows (in my test workload)

<img width="850" height="1319" alt="image" src="https://github.com/user-attachments/assets/9a01bb41-0c45-4a3a-bd52-545aa224dbad" />

before screenshot for comparison
<img width="950" height="688" alt="image" src="https://github.com/user-attachments/assets/cad40988-abed-4e59-ad17-9cb4a92b882e" />


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.