### PR TITLE
fix(theme): prevent infinite recursion from self-referential discriminators

### DIFF
--- a/cypress/integration/testSchemaSnapshots.spec.ts
+++ b/cypress/integration/testSchemaSnapshots.spec.ts
@@ -29,6 +29,7 @@ describe("Schema Snapshots", () => {
     "https://docusaurus-openapi.tryingpan.dev/tests/multiple-all-of-with-nested-properties",
     "https://docusaurus-openapi.tryingpan.dev/tests/one-of-with-complex-types",
     "https://docusaurus-openapi.tryingpan.dev/tests/one-of-with-nested-one-of",
+    "https://docusaurus-openapi.tryingpan.dev/tests/create-rule",
     "https://docusaurus-openapi.tryingpan.dev/tests/one-of-with-primitive-types",
     "https://docusaurus-openapi.tryingpan.dev/tests/one-of-with-required-properties",
     "https://docusaurus-openapi.tryingpan.dev/tests/one-of-with-shared-properties",

--- a/demo/examples/tests/recursiveDiscriminator.yaml
+++ b/demo/examples/tests/recursiveDiscriminator.yaml
@@ -1,0 +1,93 @@
+openapi: 3.0.3
+info:
+  title: Recursive Discriminator API
+  description: |
+    Reproduces a crash where each `oneOf` branch under `rule_item` declares its
+    *own* `discriminator` on the same property (`technique`) with no mapping.
+    `getDiscriminator` borrows a branch's discriminator by reference for the
+    parent `oneOf`, and DiscriminatorNode then mutates that shared object's
+    `mapping` to the parent's variant set, which includes the branch itself.
+    Rendering the branch then re-enters DiscriminatorNode with a mapping pointing
+    back to itself and recurses until the tab crashes. The fix clones the
+    borrowed discriminator so the inferred mapping stays local to the node.
+  version: 1.0.0
+tags:
+  - name: recursive-discriminator
+    description: Self-owned discriminator variants inside a oneOf
+paths:
+  /rules:
+    post:
+      tags:
+        - recursive-discriminator
+      operationId: createRule
+      summary: Create a rule
+      description: |
+        Accepts a rule container whose `rule_item` is a `oneOf` of variants that
+        each carry their own `discriminator: technique`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RuleContainer"
+      responses:
+        "200":
+          description: The created rule container
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RuleContainer"
+
+components:
+  schemas:
+    RuleItemBase:
+      title: RuleItemBase
+      type: object
+      discriminator:
+        propertyName: technique
+      properties:
+        technique:
+          type: string
+        id:
+          type: string
+      required:
+        - technique
+
+    PatternRule:
+      title: PatternRule
+      allOf:
+        - $ref: "#/components/schemas/RuleItemBase"
+        - type: object
+          properties:
+            pattern:
+              type: string
+      discriminator:
+        propertyName: technique
+      required:
+        - pattern
+
+    DictionaryRule:
+      title: DictionaryRule
+      allOf:
+        - $ref: "#/components/schemas/RuleItemBase"
+        - type: object
+          properties:
+            dictionary:
+              type: string
+      discriminator:
+        propertyName: technique
+      required:
+        - dictionary
+
+    RuleContainer:
+      title: RuleContainer
+      type: object
+      properties:
+        name:
+          type: string
+        rule_item:
+          oneOf:
+            - $ref: "#/components/schemas/PatternRule"
+            - $ref: "#/components/schemas/DictionaryRule"
+      required:
+        - name

--- a/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
+++ b/packages/docusaurus-theme-openapi-docs/src/theme/Schema/index.tsx
@@ -1120,7 +1120,11 @@ const SchemaNode: React.FC<SchemaProps> = ({
     workingSchema = mergeAllOf(schema) as SchemaObject;
   }
   if (!workingSchema.discriminator && resolvedDiscriminator) {
-    workingSchema.discriminator = resolvedDiscriminator;
+    // Clone: getDiscriminator returns a nested branch's discriminator by
+    // reference, and DiscriminatorNode mutates `.mapping` when inferring
+    // variants. Without cloning, a branch that declares its own discriminator
+    // gets a mapping pointing back to itself and recurses forever.
+    workingSchema.discriminator = { ...resolvedDiscriminator };
   }
 
   if (workingSchema.discriminator) {


### PR DESCRIPTION
## Problem

OpenAPI operation pages froze and crashed the browser tab when a schema contained a `oneOf` whose branches each declare their **own** `discriminator` on the same property, with no explicit `mapping`. This surfaced on Palo Alto Networks' DLP **Data Profiles** API docs (`pan.dev/dlp/api/`), where every Data Profiles operation renders a schema shaped like:

```yaml
ExpressionTreeNode:
  properties:
    rule_item:
      oneOf:
        - $ref: '#/components/schemas/DataPatternRuleItem'   # each variant declares
        - $ref: '#/components/schemas/DictionaryRuleItem'    # discriminator: detection_technique
        - ...
```

## Root cause

`getDiscriminator` returns a nested branch's `discriminator` **by reference**. `DiscriminatorNode` then mutates that object's `.mapping` while inferring variants from the parent `oneOf`. Because a branch (e.g. `DataPatternRuleItem`) owns that same discriminator object, its inferred mapping ends up containing **itself** — so rendering the branch re-enters `DiscriminatorNode` with a self-referential mapping and recurses until the stack overflows:

```
SchemaNode(DataPatternRuleItem) → DiscriminatorNode(DataPatternRuleItem) → SchemaNode(DataPatternRuleItem) → …
```

## Fix

Clone the borrowed discriminator before attaching it in `SchemaNode`, so the inferred `.mapping` stays local to the current node instead of poisoning the shared branch schema:

```ts
workingSchema.discriminator = { ...resolvedDiscriminator };
```

## Testing

- Added `demo/examples/tests/recursiveDiscriminator.yaml` reproducing the pattern, plus a `create-rule` entry in the schema-snapshot suite.
- Verified against the real DLP `DataProfiles` spec: the traversal that previously overflowed the stack now completes in a bounded number of node visits.
- `demo` production build succeeds and the previously-crashing pages render the full schema tree (request body, response schema, discriminator tabs) in the browser.
- Existing `normalize` unit tests pass (30/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)