### PR TITLE
Prepare release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 5.2.0 (2026-08-11)
+
+Minor release adding support for OpenAPI 3.2 hierarchical tags. You can now group the sidebar by `tagParent` via `groupPathsBy`, using the new `tags[].parent` field to build nested tag hierarchies. Also includes a theme fix that bundles code snippet language icons locally (no more external icon requests) and a batch of dependency updates.
+
+#### :rocket: New Feature
+
+- feat(plugin): support OpenAPI 3.2 hierarchical tags (`tags[].parent`) ([#1603](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1603))
+
+#### :bug: Bug Fix
+
+- fix(theme): bundle code snippet language icons locally ([#1595](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1595))
+
+#### :robot: Dependencies
+
+- chore(deps): bump the react group across 1 directory with 2 updates ([#1590](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1590))
+- chore(deps): bump postman-collection from 5.3.0 to 5.3.1 ([#1591](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1591))
+- chore(deps): bump fast-uri from 3.1.4 to 3.1.5 ([#1594](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1594))
+- chore(deps): bump github/codeql-action/init from 4.37.2 to 4.37.3 ([#1593](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1593))
+- chore(deps): bump github/codeql-action/analyze from 4.37.2 to 4.37.3 ([#1592](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1592))
+- chore(deps): bump ip-address from 10.2.0 to 10.4.0 ([#1589](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1589))
+- chore(deps): bump nx from 22.6.2 to 22.7.8 ([#1587](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1587))
+- chore(deps): bump postcss from 8.5.13 to 8.5.25 ([#1583](https://github.com/PaloAltoNetworks/docusaurus-openapi-docs/pull/1583))
+
 ## 5.1.3 (2026-07-30)
 
 Patch release with two schema-rendering bug fixes: operation pages no longer freeze the browser when a `oneOf`'s branches each declare their own self-referential `discriminator` (surfaced on specs like PANW DLP Data Profiles), and `additionalProperties` now renders correctly inside discriminator map variants. Also includes a batch of dependency updates.

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.1.3",
+  "version": "5.2.0",
   "npmClient": "yarn"
 }

--- a/packages/create-docusaurus-openapi-docs/package.json
+++ b/packages/create-docusaurus-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-docusaurus-openapi-docs",
   "description": "Create Docusaurus sites with OpenAPI docs.",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/create-docusaurus-openapi-docs/templates/default/package.json
+++ b/packages/create-docusaurus-openapi-docs/templates/default/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-openapi-docs": "5.1.3",
-    "docusaurus-theme-openapi-docs": "5.1.3",
+    "docusaurus-plugin-openapi-docs": "5.2.0",
+    "docusaurus-theme-openapi-docs": "5.2.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/docusaurus-plugin-openapi-docs/package.json
+++ b/packages/docusaurus-plugin-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-plugin-openapi-docs",
   "description": "OpenAPI plugin for Docusaurus.",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "license": "MIT",
   "keywords": [
     "openapi",

--- a/packages/docusaurus-theme-openapi-docs/package.json
+++ b/packages/docusaurus-theme-openapi-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docusaurus-theme-openapi-docs",
   "description": "OpenAPI theme for Docusaurus.",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "license": "MIT",
   "keywords": [
     "openapi",
@@ -38,7 +38,7 @@
     "@types/postman-collection": "^3.5.11",
     "@types/react-modal": "^3.16.3",
     "concurrently": "^10.0.3",
-    "docusaurus-plugin-openapi-docs": "^5.1.3",
+    "docusaurus-plugin-openapi-docs": "^5.2.0",
     "docusaurus-plugin-sass": "^0.2.6",
     "eslint-plugin-prettier": "^5.5.1"
   },


### PR DESCRIPTION
## Release v5.2.0

Minor release adding support for OpenAPI 3.2 hierarchical tags.

### :rocket: New Feature
- Support OpenAPI 3.2 hierarchical tags (`tags[].parent`) — group the sidebar by `tagParent` via `groupPathsBy` (#1603)

### :bug: Bug Fix
- Bundle code snippet language icons locally (no external icon requests) (#1595)

### :robot: Dependencies
- react group bump (#1590), postman-collection (#1591), fast-uri (#1594), codeql-action init/analyze (#1593, #1592), ip-address (#1589), nx (#1587), postcss (#1583)

### Release checklist
- [x] Version bumped to 5.2.0 across all packages + template
- [x] Theme `docusaurus-plugin-openapi-docs` peerDep stays `^5.0.0` (within 5.x train)
- [x] Docs consistent across README, plugin README, demo intro
- [x] CHANGELOG updated

Merging to `main` triggers the release workflow (npm publish + `v5.2.0` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)