### PR TITLE
fix(markdown): preserve tilde-fenced code blocks

### DIFF
--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.test.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.test.ts
@@ -1,0 +1,26 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+import { clean } from "./utils";
+
+describe("clean", () => {
+  it("escapes curly brackets outside code", () => {
+    expect(
+      clean("Use {value}, `const value = {}`, and ~removed~ {text}.")
+    ).toBe("Use \\{value\\}, `const value = {}`, and ~removed~ \\{text\\}.");
+  });
+
+  it.each([
+    ["backtick", '```json\n{\n  "ok": true\n}\n```'],
+    ["tilde", '~~~json\n{\n  "ok": true\n}\n~~~'],
+  ])("preserves %s fenced code blocks", (_name, codeBlock) => {
+    const input = `Before {value}\n${codeBlock}\nAfter {value}`;
+    const expected = `Before \\{value\\}\n${codeBlock}\nAfter \\{value\\}`;
+
+    expect(clean(input)).toBe(expected);
+  });
+});

--- a/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
+++ b/packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts
@@ -218,24 +218,26 @@ export const greaterThan =
   /(?<!(button|code|details|summary|hr|br|span|strong|small|table|thead|tbody|td|tr|th|h1|h2|h3|h4|h5|h6|title|p|em|b|i|u|strike|bold|a|li|ol|ul|img|svg|div|center|\/|\s|"|'))>/gu;
 export const codeFence = /`{1,3}[\s\S]*?`{1,3}/g;
 export const curlyBrackets = /([{}])/g;
-export const codeBlock = /(^```.*[\s\S]*?```$|`[^`].+?`)/gm;
+export const codeBlock = /(^```.*[\s\S]*?```$|^~~~.*[\s\S]*?~~~$|`[^`].+?`)/gm;
 
 export function clean(value: string | undefined): string {
   if (!value) {
     return "";
   }
 
-  let sections = value.split(codeBlock);
-  for (let sectionIndex in sections) {
-    if (!sections[sectionIndex].startsWith("`")) {
-      sections[sectionIndex] = sections[sectionIndex]
-        .replace(lessThan, "&lt;")
-        .replace(greaterThan, "&gt;")
-        .replace(codeFence, function (match) {
-          return match.replace(/\\>/g, ">");
-        })
-        .replace(curlyBrackets, "\\$1");
-    }
+  const sections = value.split(codeBlock);
+  for (
+    let sectionIndex = 0;
+    sectionIndex < sections.length;
+    sectionIndex += 2
+  ) {
+    sections[sectionIndex] = sections[sectionIndex]
+      .replace(lessThan, "&lt;")
+      .replace(greaterThan, "&gt;")
+      .replace(codeFence, function (match) {
+        return match.replace(/\\>/g, ">");
+      })
+      .replace(curlyBrackets, "\\$1");
   }
   return sections.join("");
 }


### PR DESCRIPTION
## Summary

- recognize triple-tilde fenced code blocks during Markdown cleanup
- sanitize only the non-code segments so prose surrounding either fence style is still escaped
- add regression coverage for prose, inline code, backtick fences, and tilde fences

Fixes #883.

## Verification

- `yarn test --runInBand` (121 tests and 35 snapshots passed)
- `yarn build-packages`
- `yarn eslint packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts packages/docusaurus-plugin-openapi-docs/src/markdown/utils.test.ts`
- `yarn prettier packages/docusaurus-plugin-openapi-docs/src/markdown/utils.ts packages/docusaurus-plugin-openapi-docs/src/markdown/utils.test.ts --check`

## Baseline checks

- `yarn lint` reaches six pre-existing errors in untouched theme files; the edited files pass ESLint directly.
- `yarn format` reports six pre-existing unformatted files outside this change; the edited files pass Prettier directly.

## Assistance disclosure

Implemented with OpenAI Codex (GPT-5) acting as a coding agent. The change and tests were reviewed and verified locally before submission.