### PR TITLE
chore(deps): swap pixelmatch for @blazediff/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
+    "@blazediff/core": "^1.10.0",
     "@eslint-community/eslint-utils": "^4.4.0",
     "@testing-library/cypress": "^10.1.3",
     "@types/jest": "^27.0.2",
@@ -68,7 +69,6 @@
     "lerna": "^9.0.7",
     "lint-staged": "^17.0.4",
     "nodemon": "^3.1.14",
-    "pixelmatch": "^7.1.0",
     "playwright": "^1.40.0",
     "pngjs": "^7.0.0",
     "prettier": "^3.2.5",

--- a/scripts/sitemap-visual-diff.ts
+++ b/scripts/sitemap-visual-diff.ts
@@ -9,8 +9,8 @@
 import fs from "fs";
 import path from "path";
 
+import blazediff from "@blazediff/core";
 import { XMLParser } from "fast-xml-parser";
-import pixelmatch from "pixelmatch";
 import { chromium } from "playwright";
 import { PNG } from "pngjs";
 
@@ -245,7 +245,7 @@ function compareImages(
     prev = cropImage(prev, width, height);
   }
   const diff = new PNG({ width: prod.width, height: prod.height });
-  const numDiff = pixelmatch(
+  const numDiff = blazediff(
     prod.data,
     prev.data,
     diff.data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@blazediff/core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@blazediff/core/-/core-1.10.0.tgz#cad0666655ed0a81517e5cea68b4013fe8e44459"
+  integrity sha512-AOQff0zgR7cGsZL+4E7hVkmujoPUpm0J9xzWGWZj5wCjd3gmxESXAPfKyuzs93VdpQNFhHlBhfOjrcZ+XTERtQ==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -14538,13 +14543,6 @@ pixelmatch@^4.0.2:
   integrity sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==
   dependencies:
     pngjs "^3.0.0"
-
-pixelmatch@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-7.2.0.tgz#59f4e6faca733f763756d175e2579ed71369fd72"
-  integrity sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==
-  dependencies:
-    pngjs "^7.0.0"
 
 pkg-dir@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
**What:** Swaps `pixelmatch` for [`@blazediff/core`](https://blazediff.dev) in `scripts/sitemap-visual-diff.ts`.

**Why:** Same API, same results, faster — [benchmarks](https://github.com/teimurjan/blazediff/blob/main/benchmarks/pixel-by-pixel.md) show 86–91% on identical images, which is most pages on a typical sitemap run.

**How:** Drop-in call-site rename; identical signature, `threshold`/`alpha` carry over untouched.

**Notes:** Diff counts agree with pixelmatch across the fixture set, both use the same YIQ perceptual delta, blazediff just adds two-pass block-level early exit. Already used by Vitest, Shopify, Ant Design, AntV G, Ant Design X, GPT-Vis, Vega, and ApexCharts. Disclosure: I maintain BlazeDiff.

Background on the implementation:
- [Building BlazeDiff: how I made the fastest image diff (up to 60% faster) with block-level optimization](https://dev.to/teimurjan/building-blazediff-how-i-made-the-fastest-image-diff-up-to-60-faster-with-block-level-optimization-ok7)
- [Porting scientific algorithms from MATLAB to JavaScript](https://hackernoon.com/porting-scientific-algorithms-from-matlab-to-javascript)
- [Beating JavaScript performance limits with Rust and N-API](https://hackernoon.com/beating-javascript-performance-limits-with-rust-and-n-api-building-a-faster-image-diff-tool)
